### PR TITLE
feat: Wire real connections into executor and module context

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -610,8 +610,10 @@ impl ConnectionFactory {
         let conn_type = self.resolve_connection_type(host)?;
         let pool_key = conn_type.pool_key();
 
-        // Try to get from pool first
-        if let Some(conn) = self.pool.write().get(&pool_key) {
+        // Try to get from pool first - release lock before await
+        let pooled_conn = { self.pool.write().get(&pool_key) };
+
+        if let Some(conn) = pooled_conn {
             if conn.is_alive().await {
                 return Ok(conn);
             }

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -117,6 +117,7 @@ use thiserror::Error;
 use tokio::sync::{Mutex, RwLock, Semaphore};
 use tracing::{debug, error, info, instrument, warn};
 
+use crate::connection::ConnectionFactory;
 use crate::executor::parallelization::ParallelizationManager;
 use crate::executor::playbook::{Play, Playbook};
 use crate::executor::runtime::{ExecutionContext, RuntimeContext};
@@ -381,6 +382,8 @@ pub struct Executor {
     semaphore: Arc<Semaphore>,
     parallelization_manager: Arc<ParallelizationManager>,
     recovery_manager: Option<Arc<RecoveryManager>>,
+    /// Connection factory for remote execution
+    connection_factory: Option<Arc<ConnectionFactory>>,
 }
 
 impl Executor {
@@ -395,6 +398,7 @@ impl Executor {
             semaphore: Arc::new(Semaphore::new(forks)),
             parallelization_manager: Arc::new(ParallelizationManager::new()),
             recovery_manager: None,
+            connection_factory: None,
         }
     }
 
@@ -409,6 +413,7 @@ impl Executor {
             semaphore: Arc::new(Semaphore::new(forks)),
             parallelization_manager: Arc::new(ParallelizationManager::new()),
             recovery_manager: None,
+            connection_factory: None,
         }
     }
 
@@ -416,6 +421,30 @@ impl Executor {
     pub fn with_recovery_manager(mut self, recovery_manager: Arc<RecoveryManager>) -> Self {
         self.recovery_manager = Some(recovery_manager);
         self
+    }
+
+    /// Set the connection factory for remote execution
+    pub fn with_connection_factory(mut self, factory: ConnectionFactory) -> Self {
+        self.connection_factory = Some(Arc::new(factory));
+        self
+    }
+
+    /// Get a connection for a host from the connection factory
+    async fn get_connection_for_host(
+        &self,
+        host: &str,
+    ) -> Option<Arc<dyn crate::connection::Connection + Send + Sync>> {
+        if let Some(factory) = &self.connection_factory {
+            match factory.get_connection(host).await {
+                Ok(conn) => Some(conn),
+                Err(e) => {
+                    warn!("Failed to get connection for host {}: {}", host, e);
+                    None
+                }
+            }
+        } else {
+            None
+        }
     }
 
     /// Run a complete playbook
@@ -869,15 +898,23 @@ impl Executor {
                 unreachable: false,
             };
 
+            // Get connection for host once before running tasks
+            let host_connection = self.get_connection_for_host(&host).await;
+
             for task in tasks {
                 if host_result.failed || host_result.unreachable {
                     break;
                 }
 
-                let ctx = ExecutionContext::new(host.clone())
+                let mut ctx = ExecutionContext::new(host.clone())
                     .with_check_mode(self.config.check_mode)
                     .with_diff_mode(self.config.diff_mode)
                     .with_verbosity(self.config.verbosity);
+
+                // Set connection if available
+                if let Some(ref conn) = host_connection {
+                    ctx = ctx.with_connection(conn.clone());
+                }
 
                 let task_result = task
                     .execute(
@@ -968,6 +1005,7 @@ impl Executor {
                 let notified = Arc::clone(&self.notified_handlers);
                 let parallelization_local = Arc::clone(&self.parallelization_manager);
                 let recovery_manager = self.recovery_manager.clone();
+                let connection_factory = self.connection_factory.clone();
                 let tx_id = tx_id.clone();
 
                 tokio::spawn(async move {
@@ -980,15 +1018,33 @@ impl Executor {
                         unreachable: false,
                     };
 
+                    // Get connection for host
+                    let host_connection = if let Some(ref factory) = connection_factory {
+                        match factory.get_connection(&host).await {
+                            Ok(conn) => Some(conn),
+                            Err(e) => {
+                                warn!("Failed to get connection for host {}: {}", host, e);
+                                None
+                            }
+                        }
+                    } else {
+                        None
+                    };
+
                     for task in tasks.iter() {
                         if host_result.failed || host_result.unreachable {
                             break;
                         }
 
-                        let ctx = ExecutionContext::new(host.clone())
+                        let mut ctx = ExecutionContext::new(host.clone())
                             .with_check_mode(check_mode)
                             .with_diff_mode(diff_mode)
                             .with_verbosity(verbosity);
+
+                        // Set connection if available
+                        if let Some(ref conn) = host_connection {
+                            ctx = ctx.with_connection(conn.clone());
+                        }
 
                         let task_result = task
                             .execute(&ctx, &runtime, &handlers, &notified, &parallelization_local)
@@ -1200,10 +1256,18 @@ impl Executor {
             let host = &hosts[0];
             let _permit = self.semaphore.acquire().await.unwrap();
 
-            let ctx = ExecutionContext::new(host.clone())
+            // Get connection for host
+            let host_connection = self.get_connection_for_host(host).await;
+
+            let mut ctx = ExecutionContext::new(host.clone())
                 .with_check_mode(self.config.check_mode)
                 .with_diff_mode(self.config.diff_mode)
                 .with_verbosity(self.config.verbosity);
+
+            // Set connection if available
+            if let Some(conn) = host_connection {
+                ctx = ctx.with_connection(conn);
+            }
 
             let result = task
                 .execute(
@@ -1287,14 +1351,33 @@ impl Executor {
                 let handlers = Arc::clone(&self.handlers);
                 let notified = Arc::clone(&self.notified_handlers);
                 let parallelization = Arc::clone(&self.parallelization_manager);
+                let connection_factory = self.connection_factory.clone();
 
                 tokio::spawn(async move {
                     let _permit = semaphore.acquire().await.unwrap();
 
-                    let ctx = ExecutionContext::new(host.clone())
+                    // Get connection for host
+                    let host_connection = if let Some(ref factory) = connection_factory {
+                        match factory.get_connection(&host).await {
+                            Ok(conn) => Some(conn),
+                            Err(e) => {
+                                warn!("Failed to get connection for host {}: {}", host, e);
+                                None
+                            }
+                        }
+                    } else {
+                        None
+                    };
+
+                    let mut ctx = ExecutionContext::new(host.clone())
                         .with_check_mode(check_mode)
                         .with_diff_mode(diff_mode)
                         .with_verbosity(verbosity);
+
+                    // Set connection if available
+                    if let Some(conn) = host_connection {
+                        ctx = ctx.with_connection(conn);
+                    }
 
                     let result = task
                         .execute(&ctx, &runtime, &handlers, &notified, &parallelization)

--- a/src/executor/runtime.rs
+++ b/src/executor/runtime.rs
@@ -212,7 +212,7 @@ pub struct ExecutionContext {
     /// Verbosity level (0-4)
     pub verbosity: u8,
     /// Optional connection for remote execution
-    pub connection: Option<Arc<dyn Connection>>,
+    pub connection: Option<Arc<dyn Connection + Send + Sync>>,
     /// Python interpreter path on remote host
     pub python_interpreter: String,
 }
@@ -261,7 +261,7 @@ impl ExecutionContext {
     }
 
     /// Set the connection for remote execution
-    pub fn with_connection(mut self, conn: Arc<dyn Connection>) -> Self {
+    pub fn with_connection(mut self, conn: Arc<dyn Connection + Send + Sync>) -> Self {
         self.connection = Some(conn);
         self
     }

--- a/src/executor/task.rs
+++ b/src/executor/task.rs
@@ -1306,7 +1306,7 @@ impl Task {
                     r#become: false,
                     become_method: None,
                     become_user: None,
-                    connection: None,
+                    connection: ctx.connection.clone(),
                 };
 
                 let registry = crate::modules::ModuleRegistry::with_builtins();
@@ -1347,7 +1347,7 @@ impl Task {
             r#become: false,
             become_method: None,
             become_user: None,
-            connection: None, // Local execution for integration tests
+            connection: ctx.connection.clone(),
         };
 
         // Get the copy module from registry and execute
@@ -1393,7 +1393,7 @@ impl Task {
             r#become: false,
             become_method: None,
             become_user: None,
-            connection: None, // Local execution for integration tests
+            connection: ctx.connection.clone(),
         };
 
         // Get the file module from registry and execute
@@ -1446,7 +1446,7 @@ impl Task {
             r#become: false,
             become_method: None,
             become_user: None,
-            connection: None, // Local execution for integration tests
+            connection: ctx.connection.clone(),
         };
 
         // Get the template module from registry and execute


### PR DESCRIPTION
## Summary

- Adds ConnectionFactory support to the Executor for remote execution
- Wires real SSH connections into ExecutionContext and ModuleContext
- Enables native modules and Python fallback to use actual remote connections

## Changes

1. **Executor struct**:
   - Added `connection_factory: Option<Arc<ConnectionFactory>>` field
   - Added `with_connection_factory()` builder method
   - Added `get_connection_for_host()` helper for connection retrieval

2. **ExecutionContext creation** (4 locations in mod.rs):
   - Now gets connection from factory before task execution
   - Uses `.with_connection(conn)` to set connection on context

3. **ModuleContext creation** (4 locations in task.rs):
   - Changed `connection: None` to `connection: ctx.connection.clone()`
   - Propagates connection from ExecutionContext to modules

4. **Type alignment**:
   - Updated `ExecutionContext.connection` to `Arc<dyn Connection + Send + Sync>`
   - Updated `with_connection()` signature to match

5. **ConnectionFactory fix**:
   - Fixed RwLock guard held across await point (Send issue)

## Test plan

- [x] All 135 executor tests pass
- [x] Code compiles without errors
- [x] Formatting verified

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)