### PR TITLE
fix: Use playbook directory as base path for includes (not CWD)

### DIFF
--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -119,7 +119,7 @@ impl RunArgs {
 
         // Get inventory path and load inventory
         let inventory_path = ctx.inventory().cloned();
-        let runtime = if let Some(inv_path) = &inventory_path {
+        let mut runtime = if let Some(inv_path) = &inventory_path {
             if inv_path.exists() {
                 match Inventory::load(inv_path) {
                     Ok(inventory) => {
@@ -143,6 +143,12 @@ impl RunArgs {
             runtime.add_host("localhost".to_string(), Some("all"));
             runtime
         };
+
+        // Set playbook directory for resolving relative includes
+        if let Some(playbook_dir) = self.playbook.parent() {
+            runtime.set_playbook_dir(playbook_dir);
+            ctx.output.debug(&format!("Playbook directory: {}", playbook_dir.display()));
+        }
 
         // Validate limit pattern if specified
         if let Some(ref limit) = ctx.limit {

--- a/src/executor/runtime.rs
+++ b/src/executor/runtime.rs
@@ -481,6 +481,28 @@ impl RuntimeContext {
             .insert("inventory_dir".to_string(), JsonValue::Null);
     }
 
+    /// Set the playbook directory
+    ///
+    /// This should be called when loading a playbook to set the base path
+    /// for resolving relative includes and imports.
+    pub fn set_playbook_dir(&mut self, path: &std::path::Path) {
+        let path_str = path.to_string_lossy().to_string();
+        trace!("Setting playbook_dir: {}", path_str);
+        self.magic_vars
+            .insert("playbook_dir".to_string(), JsonValue::String(path_str));
+    }
+
+    /// Get the playbook directory
+    ///
+    /// Returns the directory containing the playbook, used as base path
+    /// for resolving relative includes and imports.
+    pub fn get_playbook_dir(&self) -> Option<std::path::PathBuf> {
+        self.magic_vars
+            .get("playbook_dir")
+            .and_then(|v| v.as_str())
+            .map(std::path::PathBuf::from)
+    }
+
     /// Set a global variable
     pub fn set_global_var(&mut self, name: String, value: JsonValue) {
         trace!("Setting global var: {} = {:?}", name, value);
@@ -1626,6 +1648,33 @@ mod tests {
         assert_eq!(
             ctx.get_var_with_full_precedence("test_var", Some("server1")),
             Some(serde_json::json!("role_param"))
+        );
+    }
+
+    #[test]
+    fn test_playbook_dir() {
+        use std::path::Path;
+
+        let mut ctx = RuntimeContext::new();
+
+        // Initially playbook_dir should be None (stored as Null in magic_vars)
+        assert!(ctx.get_playbook_dir().is_none());
+
+        // Set playbook directory
+        let playbook_path = Path::new("/home/user/playbooks/site");
+        ctx.set_playbook_dir(playbook_path);
+
+        // Should now return the path
+        assert_eq!(
+            ctx.get_playbook_dir(),
+            Some(std::path::PathBuf::from("/home/user/playbooks/site"))
+        );
+
+        // Should also be available as a variable
+        let merged = ctx.get_merged_vars("localhost");
+        assert_eq!(
+            merged.get("playbook_dir"),
+            Some(&serde_json::json!("/home/user/playbooks/site"))
         );
     }
 }

--- a/src/executor/task.rs
+++ b/src/executor/task.rs
@@ -1833,8 +1833,12 @@ impl Task {
             ));
         }
 
-        // Determine base path for path validation
-        let base_path = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        // Determine base path from playbook directory, falling back to current directory
+        let base_path = {
+            let rt = runtime.read().await;
+            rt.get_playbook_dir()
+                .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")))
+        };
 
         let mut all_vars: IndexMap<String, JsonValue> = IndexMap::new();
         let source: String;
@@ -2030,8 +2034,12 @@ impl Task {
 
         info!("Including tasks from: {}", file);
 
-        // Determine base path from the runtime context or use current directory
-        let base_path = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        // Determine base path from the playbook directory, falling back to current directory
+        let base_path = {
+            let rt = runtime.read().await;
+            rt.get_playbook_dir()
+                .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")))
+        };
         let handler = crate::executor::include_handler::IncludeTasksHandler::new(base_path);
 
         // Build the include spec with any variables passed


### PR DESCRIPTION
## Summary

This PR fixes Issue #57 where `include_tasks` and `include_vars` used the current working directory (CWD) as the base path for resolving relative includes, instead of the playbook directory.

### Problem

When running a playbook from a different directory, relative includes would fail because they were resolved relative to CWD instead of the playbook location:

```bash
# This would fail if includes/tasks.yml existed in /playbooks/ but not in /tmp/
cd /tmp
rustible run /playbooks/site.yml  # include_tasks: includes/tasks.yml would look in /tmp/includes/
```

### Solution

- Added `set_playbook_dir()` and `get_playbook_dir()` methods to `RuntimeContext`
- CLI now sets `playbook_dir` when loading a playbook
- `include_tasks` and `include_vars` now use `playbook_dir` as base path
- Falls back to CWD if `playbook_dir` is not set (backwards compatible)

### Changes

- **`src/executor/runtime.rs`**: Added `set_playbook_dir()`, `get_playbook_dir()`, and test
- **`src/cli/commands/run.rs`**: Set `playbook_dir` when loading playbook
- **`src/executor/task.rs`**: Updated `execute_include_tasks()` and `execute_include_vars()` to use `playbook_dir`

## Test plan

- [x] New `test_playbook_dir` test passes
- [x] All existing runtime and include tests pass
- [x] Build succeeds
- [ ] Manual testing with playbooks from different directories

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)