### PR TITLE
feat: Implement remote facts gathering via Connection

### DIFF
--- a/src/executor/task.rs
+++ b/src/executor/task.rs
@@ -1165,7 +1165,7 @@ impl Task {
     async fn execute_gather_facts(
         &self,
         args: &IndexMap<String, JsonValue>,
-        _ctx: &ExecutionContext,
+        ctx: &ExecutionContext,
     ) -> ExecutorResult<TaskResult> {
         use crate::modules::{Module, ModuleContext};
 
@@ -1179,6 +1179,43 @@ impl Task {
                     .collect::<Vec<_>>()
             });
 
+        // Check if we have a remote connection - if so, gather facts remotely
+        if let Some(ref connection) = ctx.connection {
+            debug!(
+                host = %ctx.host,
+                "Gathering facts remotely via connection"
+            );
+
+            // Gather facts via the connection
+            let facts = crate::modules::facts::gather_facts_via_connection(
+                connection,
+                gather_subset.as_deref(),
+            )
+            .await;
+
+            let mut result = TaskResult::ok();
+            result.msg = Some("Facts gathered successfully (remote)".to_string());
+
+            // Wrap facts in ansible_facts key for compatibility
+            let mut data = std::collections::HashMap::new();
+            let facts_json: serde_json::Map<String, serde_json::Value> =
+                facts.into_iter().collect();
+            data.insert(
+                "ansible_facts".to_string(),
+                serde_json::Value::Object(facts_json),
+            );
+
+            result.result = Some(serde_json::to_value(&data).unwrap_or_default());
+
+            return Ok(result);
+        }
+
+        // No connection or local connection - use local facts gathering
+        debug!(
+            host = %ctx.host,
+            "Gathering facts locally"
+        );
+
         // Convert args to ModuleParams
         let mut params: std::collections::HashMap<String, serde_json::Value> =
             std::collections::HashMap::new();
@@ -1187,9 +1224,9 @@ impl Task {
         }
 
         // Create module context
-        let module_ctx = ModuleContext::default().with_verbosity(_ctx.verbosity);
+        let module_ctx = ModuleContext::default().with_verbosity(ctx.verbosity);
 
-        // Execute the facts module
+        // Execute the facts module locally
         let facts_module = crate::modules::facts::FactsModule;
         match facts_module.execute(&params, &module_ctx) {
             Ok(output) => {

--- a/src/modules/facts.rs
+++ b/src/modules/facts.rs
@@ -2,11 +2,20 @@
 //!
 //! This module gathers facts about the target system including OS, hardware,
 //! network, and other system information.
+//!
+//! ## Remote Facts Gathering
+//!
+//! Facts can be gathered remotely via SSH or other connections using the async
+//! `gather_facts_via_connection` function. This executes commands on the remote
+//! host instead of locally.
 
 use super::{Module, ModuleContext, ModuleOutput, ModuleParams, ModuleResult, ParamExt};
+use crate::connection::Connection;
 use std::collections::HashMap;
 use std::fs;
 use std::process::Command;
+use std::sync::Arc;
+use tracing::debug;
 
 /// Module for gathering system facts
 pub struct FactsModule;
@@ -404,6 +413,477 @@ impl FactsModule {
     }
 }
 
+// ============================================================================
+// Remote Facts Gathering via Connection
+// ============================================================================
+
+/// Gather facts from a remote host via a Connection.
+///
+/// This function executes commands on the remote host using the provided
+/// connection and parses the output to build a facts map.
+///
+/// # Arguments
+///
+/// * `connection` - The connection to use for remote execution
+/// * `gather_subset` - Optional list of fact categories to gather ("all", "os", "hardware", etc.)
+///
+/// # Returns
+///
+/// A map of fact names to their values, similar to local facts gathering.
+pub async fn gather_facts_via_connection(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    gather_subset: Option<&[String]>,
+) -> HashMap<String, serde_json::Value> {
+    let gather_all = gather_subset
+        .map(|s| s.iter().any(|x| x == "all"))
+        .unwrap_or(true);
+
+    let mut all_facts = HashMap::new();
+
+    // Always gather OS facts (or if specifically requested)
+    if gather_all
+        || gather_subset
+            .map(|s| s.iter().any(|x| x == "os" || x == "min"))
+            .unwrap_or(false)
+    {
+        let os_facts = gather_os_facts_remote(connection).await;
+        for (k, v) in os_facts {
+            all_facts.insert(k, v);
+        }
+    }
+
+    // Gather hardware facts
+    if gather_all
+        || gather_subset
+            .map(|s| s.iter().any(|x| x == "hardware"))
+            .unwrap_or(false)
+    {
+        let hw_facts = gather_hardware_facts_remote(connection).await;
+        for (k, v) in hw_facts {
+            all_facts.insert(k, v);
+        }
+    }
+
+    // Gather network facts
+    if gather_all
+        || gather_subset
+            .map(|s| s.iter().any(|x| x == "network"))
+            .unwrap_or(false)
+    {
+        let net_facts = gather_network_facts_remote(connection).await;
+        for (k, v) in net_facts {
+            all_facts.insert(k, v);
+        }
+    }
+
+    // Gather date/time facts
+    if gather_all
+        || gather_subset
+            .map(|s| s.iter().any(|x| x == "date_time"))
+            .unwrap_or(false)
+    {
+        let date_facts = gather_date_facts_remote(connection).await;
+        for (k, v) in date_facts {
+            all_facts.insert(k, v);
+        }
+    }
+
+    // Gather environment facts
+    if gather_all
+        || gather_subset
+            .map(|s| s.iter().any(|x| x == "env"))
+            .unwrap_or(false)
+    {
+        let env_facts = gather_env_facts_remote(connection).await;
+        for (k, v) in env_facts {
+            all_facts.insert(k, v);
+        }
+    }
+
+    all_facts
+}
+
+/// Helper to execute a command and get stdout if successful
+async fn execute_and_get_output(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    command: &str,
+) -> Option<String> {
+    match connection.execute(command, None).await {
+        Ok(result) if result.success => Some(result.stdout.trim().to_string()),
+        Ok(result) => {
+            debug!(
+                "Command '{}' failed with exit code {}: {}",
+                command, result.exit_code, result.stderr
+            );
+            None
+        }
+        Err(e) => {
+            debug!("Command '{}' execution error: {}", command, e);
+            None
+        }
+    }
+}
+
+/// Helper to read a remote file's content
+async fn read_remote_file(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    path: &str,
+) -> Option<String> {
+    // Use cat to read file content via the connection
+    execute_and_get_output(connection, &format!("cat {}", path)).await
+}
+
+/// Gather OS facts from remote host
+async fn gather_os_facts_remote(
+    connection: &Arc<dyn Connection + Send + Sync>,
+) -> HashMap<String, serde_json::Value> {
+    let mut facts = HashMap::new();
+
+    // Get hostname
+    if let Some(hostname) = execute_and_get_output(connection, "hostname -f").await {
+        facts.insert("hostname".to_string(), serde_json::json!(hostname));
+        if let Some(short) = hostname.split('.').next() {
+            facts.insert("hostname_short".to_string(), serde_json::json!(short));
+        }
+    }
+
+    // Get kernel info via uname
+    if let Some(system) = execute_and_get_output(connection, "uname -s").await {
+        facts.insert("system".to_string(), serde_json::json!(system));
+    }
+
+    if let Some(kernel) = execute_and_get_output(connection, "uname -r").await {
+        facts.insert("kernel".to_string(), serde_json::json!(kernel));
+    }
+
+    if let Some(arch) = execute_and_get_output(connection, "uname -m").await {
+        facts.insert("architecture".to_string(), serde_json::json!(&arch));
+
+        // Map to common architecture names
+        let machine = match arch.as_str() {
+            "x86_64" | "amd64" => "x86_64",
+            "aarch64" | "arm64" => "aarch64",
+            "armv7l" => "armv7l",
+            "i686" | "i386" => "i386",
+            _ => &arch,
+        };
+        facts.insert("machine".to_string(), serde_json::json!(machine));
+    }
+
+    // Get OS release info
+    if let Some(content) = read_remote_file(connection, "/etc/os-release").await {
+        for line in content.lines() {
+            if let Some((key, value)) = line.split_once('=') {
+                let value = value.trim_matches('"');
+                match key {
+                    "ID" => {
+                        facts.insert("distribution".to_string(), serde_json::json!(value));
+                    }
+                    "VERSION_ID" => {
+                        facts.insert("distribution_version".to_string(), serde_json::json!(value));
+                    }
+                    "ID_LIKE" => {
+                        facts.insert("os_family".to_string(), serde_json::json!(value));
+                    }
+                    "PRETTY_NAME" => {
+                        facts.insert(
+                            "distribution_pretty_name".to_string(),
+                            serde_json::json!(value),
+                        );
+                    }
+                    "VERSION_CODENAME" => {
+                        facts.insert(
+                            "distribution_codename".to_string(),
+                            serde_json::json!(value),
+                        );
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    // Determine OS family if not set
+    if !facts.contains_key("os_family") {
+        if let Some(serde_json::Value::String(distro)) = facts.get("distribution") {
+            let family = match distro.to_lowercase().as_str() {
+                "ubuntu" | "debian" | "linuxmint" | "pop" | "elementary" => "debian",
+                "fedora" | "centos" | "rhel" | "rocky" | "alma" | "oracle" => "redhat",
+                "arch" | "manjaro" | "endeavouros" => "arch",
+                "opensuse" | "sles" => "suse",
+                "alpine" => "alpine",
+                "gentoo" => "gentoo",
+                _ => "unknown",
+            };
+            facts.insert("os_family".to_string(), serde_json::json!(family));
+        }
+    }
+
+    // Get current user
+    if let Some(user) = execute_and_get_output(connection, "whoami").await {
+        facts.insert("user_id".to_string(), serde_json::json!(user));
+    }
+
+    // Get user's UID
+    if let Some(uid_str) = execute_and_get_output(connection, "id -u").await {
+        if let Ok(uid) = uid_str.parse::<u32>() {
+            facts.insert("user_uid".to_string(), serde_json::json!(uid));
+        }
+    }
+
+    // Get user's GID
+    if let Some(gid_str) = execute_and_get_output(connection, "id -g").await {
+        if let Ok(gid) = gid_str.parse::<u32>() {
+            facts.insert("user_gid".to_string(), serde_json::json!(gid));
+        }
+    }
+
+    facts
+}
+
+/// Gather hardware facts from remote host
+async fn gather_hardware_facts_remote(
+    connection: &Arc<dyn Connection + Send + Sync>,
+) -> HashMap<String, serde_json::Value> {
+    let mut facts = HashMap::new();
+
+    // Get CPU info
+    if let Some(content) = read_remote_file(connection, "/proc/cpuinfo").await {
+        let mut processor_count = 0;
+        let mut model_name = String::new();
+        let mut cpu_cores = 0;
+
+        for line in content.lines() {
+            if line.starts_with("processor") {
+                processor_count += 1;
+            } else if line.starts_with("model name") {
+                if let Some((_, value)) = line.split_once(':') {
+                    model_name = value.trim().to_string();
+                }
+            } else if line.starts_with("cpu cores") {
+                if let Some((_, value)) = line.split_once(':') {
+                    cpu_cores = value.trim().parse().unwrap_or(0);
+                }
+            }
+        }
+
+        facts.insert(
+            "processor_count".to_string(),
+            serde_json::json!(processor_count),
+        );
+        if !model_name.is_empty() {
+            facts.insert("processor".to_string(), serde_json::json!(model_name));
+        }
+        if cpu_cores > 0 {
+            facts.insert("processor_cores".to_string(), serde_json::json!(cpu_cores));
+        }
+    }
+
+    // Get memory info
+    if let Some(content) = read_remote_file(connection, "/proc/meminfo").await {
+        for line in content.lines() {
+            if line.starts_with("MemTotal:") {
+                if let Some(kb_str) = line.split_whitespace().nth(1) {
+                    if let Ok(kb) = kb_str.parse::<u64>() {
+                        facts.insert("memtotal_mb".to_string(), serde_json::json!(kb / 1024));
+                    }
+                }
+            } else if line.starts_with("MemFree:") {
+                if let Some(kb_str) = line.split_whitespace().nth(1) {
+                    if let Ok(kb) = kb_str.parse::<u64>() {
+                        facts.insert("memfree_mb".to_string(), serde_json::json!(kb / 1024));
+                    }
+                }
+            } else if line.starts_with("SwapTotal:") {
+                if let Some(kb_str) = line.split_whitespace().nth(1) {
+                    if let Ok(kb) = kb_str.parse::<u64>() {
+                        facts.insert("swaptotal_mb".to_string(), serde_json::json!(kb / 1024));
+                    }
+                }
+            }
+        }
+    }
+
+    // Get disk info - root filesystem
+    if let Some(stdout) = execute_and_get_output(connection, "df -B1 /").await {
+        if let Some(line) = stdout.lines().nth(1) {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 4 {
+                if let Ok(total) = parts[1].parse::<u64>() {
+                    facts.insert("disk_total_bytes".to_string(), serde_json::json!(total));
+                }
+                if let Ok(used) = parts[2].parse::<u64>() {
+                    facts.insert("disk_used_bytes".to_string(), serde_json::json!(used));
+                }
+                if let Ok(avail) = parts[3].parse::<u64>() {
+                    facts.insert("disk_available_bytes".to_string(), serde_json::json!(avail));
+                }
+            }
+        }
+    }
+
+    facts
+}
+
+/// Gather network facts from remote host
+async fn gather_network_facts_remote(
+    connection: &Arc<dyn Connection + Send + Sync>,
+) -> HashMap<String, serde_json::Value> {
+    let mut facts = HashMap::new();
+    let mut interfaces: Vec<serde_json::Value> = Vec::new();
+
+    // Get network interfaces by listing /sys/class/net
+    if let Some(iface_list) =
+        execute_and_get_output(connection, "ls -1 /sys/class/net 2>/dev/null").await
+    {
+        for iface_name in iface_list.lines() {
+            let iface_name = iface_name.trim();
+
+            // Skip loopback
+            if iface_name == "lo" || iface_name.is_empty() {
+                continue;
+            }
+
+            let mut iface_info = serde_json::Map::new();
+            iface_info.insert(
+                "device".to_string(),
+                serde_json::json!(iface_name.to_string()),
+            );
+
+            // Get MAC address
+            if let Some(mac) = read_remote_file(
+                connection,
+                &format!("/sys/class/net/{}/address", iface_name),
+            )
+            .await
+            {
+                let mac = mac.trim();
+                if mac != "00:00:00:00:00:00" {
+                    iface_info.insert("macaddress".to_string(), serde_json::json!(mac));
+                }
+            }
+
+            // Get MTU
+            if let Some(mtu_str) =
+                read_remote_file(connection, &format!("/sys/class/net/{}/mtu", iface_name)).await
+            {
+                if let Ok(mtu) = mtu_str.trim().parse::<u32>() {
+                    iface_info.insert("mtu".to_string(), serde_json::json!(mtu));
+                }
+            }
+
+            // Get operstate
+            if let Some(state) = read_remote_file(
+                connection,
+                &format!("/sys/class/net/{}/operstate", iface_name),
+            )
+            .await
+            {
+                iface_info.insert(
+                    "active".to_string(),
+                    serde_json::json!(state.trim() == "up"),
+                );
+            }
+
+            interfaces.push(serde_json::Value::Object(iface_info));
+        }
+    }
+
+    facts.insert("interfaces".to_string(), serde_json::json!(interfaces));
+
+    // Get default IPv4 address
+    if let Some(stdout) = execute_and_get_output(connection, "ip route get 1.1.1.1 2>/dev/null").await
+    {
+        if let Some(ip) = stdout.split("src ").nth(1) {
+            if let Some(ip) = ip.split_whitespace().next() {
+                facts.insert("default_ipv4".to_string(), serde_json::json!(ip));
+            }
+        }
+    }
+
+    // Get FQDN
+    if let Some(fqdn) = execute_and_get_output(connection, "hostname -f").await {
+        facts.insert("fqdn".to_string(), serde_json::json!(fqdn));
+    }
+
+    facts
+}
+
+/// Gather date/time facts from remote host
+async fn gather_date_facts_remote(
+    connection: &Arc<dyn Connection + Send + Sync>,
+) -> HashMap<String, serde_json::Value> {
+    let mut facts = HashMap::new();
+
+    // Get current date/time info
+    if let Some(datetime) =
+        execute_and_get_output(connection, "date '+%Y-%m-%d %H:%M:%S %Z'").await
+    {
+        facts.insert("date_time".to_string(), serde_json::json!(datetime));
+    }
+
+    // Get epoch
+    if let Some(epoch_str) = execute_and_get_output(connection, "date +%s").await {
+        if let Ok(epoch) = epoch_str.parse::<u64>() {
+            facts.insert("epoch".to_string(), serde_json::json!(epoch));
+        }
+    }
+
+    // Get timezone
+    if let Some(tz) = read_remote_file(connection, "/etc/timezone").await {
+        facts.insert("timezone".to_string(), serde_json::json!(tz.trim()));
+    } else if let Some(link) = execute_and_get_output(connection, "readlink /etc/localtime").await {
+        // Extract timezone from symlink path
+        if let Some(tz) = link.strip_prefix("/usr/share/zoneinfo/") {
+            facts.insert("timezone".to_string(), serde_json::json!(tz));
+        }
+    }
+
+    // Get uptime
+    if let Some(content) = read_remote_file(connection, "/proc/uptime").await {
+        if let Some(seconds_str) = content.split_whitespace().next() {
+            if let Ok(seconds) = seconds_str.parse::<f64>() {
+                facts.insert(
+                    "uptime_seconds".to_string(),
+                    serde_json::json!(seconds as u64),
+                );
+            }
+        }
+    }
+
+    facts
+}
+
+/// Gather environment facts from remote host
+async fn gather_env_facts_remote(
+    connection: &Arc<dyn Connection + Send + Sync>,
+) -> HashMap<String, serde_json::Value> {
+    let mut facts = HashMap::new();
+    let mut env_vars = serde_json::Map::new();
+
+    // Get important environment variables using printenv
+    let env_cmd = "printenv PATH HOME USER SHELL LANG LC_ALL TERM PWD 2>/dev/null || echo ''";
+    if let Some(env_output) = execute_and_get_output(connection, env_cmd).await {
+        for line in env_output.lines() {
+            if let Some((key, value)) = line.split_once('=') {
+                env_vars.insert(key.to_string(), serde_json::json!(value));
+            }
+        }
+    }
+
+    facts.insert("env".to_string(), serde_json::Value::Object(env_vars));
+
+    // Get Python version if available
+    if let Some(version_output) = execute_and_get_output(connection, "python3 --version 2>&1").await
+    {
+        if let Some(ver) = version_output.strip_prefix("Python ") {
+            facts.insert("python_version".to_string(), serde_json::json!(ver.trim()));
+        }
+    }
+
+    facts
+}
+
 impl Module for FactsModule {
     fn name(&self) -> &'static str {
         "gather_facts"
@@ -538,5 +1018,138 @@ mod tests {
 
         assert!(!result.changed);
         assert!(result.data.contains_key("ansible_facts"));
+    }
+
+    // ========================================================================
+    // Remote Facts Gathering Tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_gather_facts_via_connection_all() {
+        use crate::connection::local::LocalConnection;
+
+        let conn: Arc<dyn Connection + Send + Sync> = Arc::new(LocalConnection::new());
+        let facts = gather_facts_via_connection(&conn, None).await;
+
+        // Should have OS facts
+        assert!(
+            facts.contains_key("system") || facts.contains_key("hostname"),
+            "Expected OS facts"
+        );
+
+        // Should have hardware facts if /proc exists
+        if std::path::Path::new("/proc/cpuinfo").exists() {
+            assert!(
+                facts.contains_key("processor_count"),
+                "Expected processor_count fact"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_gather_facts_via_connection_os_subset() {
+        use crate::connection::local::LocalConnection;
+
+        let conn: Arc<dyn Connection + Send + Sync> = Arc::new(LocalConnection::new());
+        let subset = vec!["os".to_string()];
+        let facts = gather_facts_via_connection(&conn, Some(&subset)).await;
+
+        // Should have OS facts
+        assert!(
+            facts.contains_key("system") || facts.contains_key("hostname"),
+            "Expected OS facts with 'os' subset"
+        );
+
+        // Should NOT have hardware-specific facts when only 'os' is requested
+        // Note: processor_count is a hardware fact, not an OS fact
+    }
+
+    #[tokio::test]
+    async fn test_gather_facts_via_connection_hardware_subset() {
+        use crate::connection::local::LocalConnection;
+
+        let conn: Arc<dyn Connection + Send + Sync> = Arc::new(LocalConnection::new());
+        let subset = vec!["hardware".to_string()];
+        let facts = gather_facts_via_connection(&conn, Some(&subset)).await;
+
+        // Should have hardware facts if /proc exists
+        if std::path::Path::new("/proc/cpuinfo").exists() {
+            assert!(
+                facts.contains_key("processor_count"),
+                "Expected hardware facts with 'hardware' subset"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_gather_os_facts_remote() {
+        use crate::connection::local::LocalConnection;
+
+        let conn: Arc<dyn Connection + Send + Sync> = Arc::new(LocalConnection::new());
+        let facts = gather_os_facts_remote(&conn).await;
+
+        // Should get hostname
+        assert!(
+            facts.contains_key("hostname") || facts.contains_key("system"),
+            "Expected hostname or system fact"
+        );
+
+        // Should get user info
+        assert!(facts.contains_key("user_id"), "Expected user_id fact");
+    }
+
+    #[tokio::test]
+    async fn test_gather_hardware_facts_remote() {
+        use crate::connection::local::LocalConnection;
+
+        let conn: Arc<dyn Connection + Send + Sync> = Arc::new(LocalConnection::new());
+        let facts = gather_hardware_facts_remote(&conn).await;
+
+        // Should have processor info on Linux
+        if std::path::Path::new("/proc/cpuinfo").exists() {
+            assert!(
+                facts.contains_key("processor_count"),
+                "Expected processor_count"
+            );
+        }
+
+        // Should have memory info on Linux
+        if std::path::Path::new("/proc/meminfo").exists() {
+            assert!(facts.contains_key("memtotal_mb"), "Expected memtotal_mb");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_gather_network_facts_remote() {
+        use crate::connection::local::LocalConnection;
+
+        let conn: Arc<dyn Connection + Send + Sync> = Arc::new(LocalConnection::new());
+        let facts = gather_network_facts_remote(&conn).await;
+
+        // Should have interfaces list
+        assert!(facts.contains_key("interfaces"), "Expected interfaces fact");
+    }
+
+    #[tokio::test]
+    async fn test_gather_date_facts_remote() {
+        use crate::connection::local::LocalConnection;
+
+        let conn: Arc<dyn Connection + Send + Sync> = Arc::new(LocalConnection::new());
+        let facts = gather_date_facts_remote(&conn).await;
+
+        // Should have date/time info
+        assert!(facts.contains_key("date_time"), "Expected date_time fact");
+        assert!(facts.contains_key("epoch"), "Expected epoch fact");
+    }
+
+    #[tokio::test]
+    async fn test_gather_env_facts_remote() {
+        use crate::connection::local::LocalConnection;
+
+        let conn: Arc<dyn Connection + Send + Sync> = Arc::new(LocalConnection::new());
+        let facts = gather_env_facts_remote(&conn).await;
+
+        // Should have env fact
+        assert!(facts.contains_key("env"), "Expected env fact");
     }
 }


### PR DESCRIPTION
## Summary

- Implements remote facts gathering to fix issue where facts were gathered locally even for remote hosts
- Adds `gather_facts_via_connection()` async function that executes commands via Connection instead of locally
- Adds remote gathering functions for OS, hardware, network, date/time, and environment facts
- Updates `execute_gather_facts()` to use the connection from ExecutionContext when available
- Adds comprehensive tests for remote facts gathering using LocalConnection

## Details

Previously, `gather_facts` always ran commands locally using `std::process::Command`, even when targeting remote hosts. This meant facts like hostname, kernel version, and memory would reflect the control node rather than the target host.

Now, when `ExecutionContext.connection` is present (indicating a remote host), facts are gathered by executing commands via the connection's `execute()` method. For local hosts or when no connection is available, the existing local gathering is used as fallback.

### New Remote Gathering Functions

- `gather_os_facts_remote()` - hostname, kernel, architecture, distribution, user info
- `gather_hardware_facts_remote()` - CPU info, memory, disk space
- `gather_network_facts_remote()` - interfaces, MAC addresses, default IP
- `gather_date_facts_remote()` - date/time, timezone, uptime
- `gather_env_facts_remote()` - environment variables, Python version

## Test plan

- [x] Added 8 new async tests for remote facts gathering
- [x] All 25 facts-related tests pass
- [x] Build succeeds with no errors

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)