### PR TITLE
fix(include): resolve include/import paths from playbook directory, not CWD

### DIFF
--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -481,6 +481,13 @@ impl Executor {
                 for (key, value) in &self.config.extra_vars {
                     runtime.set_global_var(key.clone(), value.clone());
                 }
+                // Set playbook_dir magic variable for include/import path resolution
+                if let Some(playbook_dir) = playbook.get_playbook_dir() {
+                    runtime.set_magic_var(
+                        "playbook_dir".to_string(),
+                        serde_json::json!(playbook_dir.to_string_lossy()),
+                    );
+                }
             }
 
             // Execute each play in sequence

--- a/src/executor/task.rs
+++ b/src/executor/task.rs
@@ -1833,8 +1833,16 @@ impl Task {
             ));
         }
 
-        // Determine base path for path validation
-        let base_path = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        // Determine base path from playbook_dir magic variable (set from playbook path)
+        // Falls back to current directory if playbook_dir is not set
+        let base_path = {
+            let rt = runtime.read().await;
+            rt.get_var("playbook_dir", Some(&ctx.host))
+                .and_then(|v| v.as_str().map(std::path::PathBuf::from))
+                .unwrap_or_else(|| {
+                    std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+                })
+        };
 
         let mut all_vars: IndexMap<String, JsonValue> = IndexMap::new();
         let source: String;
@@ -2030,8 +2038,18 @@ impl Task {
 
         info!("Including tasks from: {}", file);
 
-        // Determine base path from the runtime context or use current directory
-        let base_path = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        // Determine base path from playbook_dir magic variable (set from playbook path)
+        // Falls back to current directory if playbook_dir is not set
+        let base_path = {
+            let rt = runtime.read().await;
+            rt.get_var("playbook_dir", Some(&ctx.host))
+                .and_then(|v| v.as_str().map(std::path::PathBuf::from))
+                .unwrap_or_else(|| {
+                    warn!("playbook_dir not set, falling back to current directory for include path resolution");
+                    std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+                })
+        };
+        debug!("Using base path for include: {}", base_path.display());
         let handler = crate::executor::include_handler::IncludeTasksHandler::new(base_path);
 
         // Build the include spec with any variables passed


### PR DESCRIPTION
## Summary

Closes #57

This PR fixes the issue where `include_tasks`, `import_tasks`, and `include_vars` used the current working directory (CWD) as the base path for resolving relative file paths, instead of using the playbook's directory.

## Changes

**`src/executor/mod.rs`:**
- Set `playbook_dir` magic variable in `run_playbook()` from the playbook's path

**`src/executor/task.rs`:**
- Update `execute_include_tasks()` to read `playbook_dir` from runtime context
- Update `execute_include_vars()` to read `playbook_dir` from runtime context  
- Fall back to current directory if `playbook_dir` is not set (backwards compatibility)

## Why This Matters

Before this fix, running a playbook from a different directory would break relative includes:

```bash
# This would fail because includes resolved from /home/user, not playbook dir
cd /home/user
rustible run /opt/playbooks/site.yml
```

Now, includes correctly resolve from the playbook's directory regardless of where rustible is launched.

## Test Plan

- [x] Build passes with no new warnings
- [x] Existing tests pass (1613 passed, 6 pre-existing failures unrelated to this change)
- [x] Manual test: Created playbook with `include_tasks: tasks/included.yml`, ran from different directory - works correctly
- [x] Path traversal protection remains enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)