### PR TITLE
feat(executor): Standardize task result/register payload across modules

### DIFF
--- a/src/executor/task.rs
+++ b/src/executor/task.rs
@@ -148,23 +148,67 @@ impl TaskResult {
     }
 
     /// Convert to RegisteredResult
+    ///
+    /// Extracts data from `self.result` if available, falling back to the
+    /// explicit stdout/stderr parameters. This ensures module output data
+    /// (rc, stdout, stderr, module-specific fields) is preserved for register.
     pub fn to_registered(
         &self,
         stdout: Option<String>,
         stderr: Option<String>,
     ) -> RegisteredResult {
+        // Try to extract fields from self.result if it contains module output data
+        let (rc, result_stdout, result_stderr, data) = if let Some(ref result) = self.result {
+            if let Some(obj) = result.as_object() {
+                let rc = obj.get("rc").and_then(|v| v.as_i64()).map(|v| v as i32);
+                let result_stdout = obj.get("stdout").and_then(|v| v.as_str()).map(String::from);
+                let result_stderr = obj.get("stderr").and_then(|v| v.as_str()).map(String::from);
+
+                // Collect module-specific data (excluding standard fields)
+                let mut data = IndexMap::new();
+                for (key, value) in obj {
+                    // Skip standard RegisteredResult fields
+                    if !matches!(
+                        key.as_str(),
+                        "changed"
+                            | "failed"
+                            | "skipped"
+                            | "rc"
+                            | "stdout"
+                            | "stdout_lines"
+                            | "stderr"
+                            | "stderr_lines"
+                            | "msg"
+                            | "results"
+                    ) {
+                        data.insert(key.clone(), value.clone());
+                    }
+                }
+
+                (rc, result_stdout, result_stderr, data)
+            } else {
+                (None, None, None, IndexMap::new())
+            }
+        } else {
+            (None, None, None, IndexMap::new())
+        };
+
+        // Use result data if available, otherwise fall back to explicit parameters
+        let final_stdout = result_stdout.or(stdout);
+        let final_stderr = result_stderr.or(stderr);
+
         RegisteredResult {
             changed: self.changed,
             failed: self.status == TaskStatus::Failed,
             skipped: self.status == TaskStatus::Skipped,
-            rc: None,
-            stdout: stdout.clone(),
-            stdout_lines: stdout.map(|s| s.lines().map(String::from).collect()),
-            stderr: stderr.clone(),
-            stderr_lines: stderr.map(|s| s.lines().map(String::from).collect()),
+            rc,
+            stdout: final_stdout.clone(),
+            stdout_lines: final_stdout.map(|s| s.lines().map(String::from).collect()),
+            stderr: final_stderr.clone(),
+            stderr_lines: final_stderr.map(|s| s.lines().map(String::from).collect()),
             msg: self.msg.clone(),
             results: None,
-            data: IndexMap::new(),
+            data,
         }
     }
 }
@@ -1015,11 +1059,8 @@ impl Task {
                                     TaskResult::ok()
                                 };
                                 result.msg = Some(msg);
-                                if !output.data.is_empty() {
-                                    result.result = Some(
-                                        serde_json::to_value(&output.data).unwrap_or_default(),
-                                    );
-                                }
+                                // Store full module output for register access
+                                result.result = Some(output.to_result_json());
                                 Ok(result)
                             }
                             Err(e) => Err(ExecutorError::RuntimeError(format!(
@@ -1234,10 +1275,8 @@ impl Task {
                 let mut result = TaskResult::ok();
                 result.msg = Some(output.msg.clone());
 
-                // Include ansible_facts in the result so they can be stored
-                if !output.data.is_empty() {
-                    result.result = Some(serde_json::to_value(&output.data).unwrap_or_default());
-                }
+                // Store full module output for register access (includes ansible_facts)
+                result.result = Some(output.to_result_json());
 
                 Ok(result)
             }
@@ -1367,11 +1406,9 @@ impl Task {
                         } else {
                             TaskResult::ok()
                         };
-                        result.msg = Some(output.msg);
-                        if !output.data.is_empty() {
-                            result.result =
-                                Some(serde_json::to_value(&output.data).unwrap_or_default());
-                        }
+                        result.msg = Some(output.msg.clone());
+                        // Store full module output for register access
+                        result.result = Some(output.to_result_json());
                         Ok(result)
                     }
                     Err(e) => Ok(TaskResult::failed(format!(
@@ -1408,10 +1445,9 @@ impl Task {
                 } else {
                     TaskResult::ok()
                 };
-                result.msg = Some(output.msg);
-                if !output.data.is_empty() {
-                    result.result = Some(serde_json::to_value(&output.data).unwrap_or_default());
-                }
+                result.msg = Some(output.msg.clone());
+                // Store full module output for register access
+                result.result = Some(output.to_result_json());
                 Ok(result)
             }
             Err(e) => Ok(TaskResult::failed(format!("copy module failed: {}", e))),
@@ -1454,10 +1490,9 @@ impl Task {
                 } else {
                     TaskResult::ok()
                 };
-                result.msg = Some(output.msg);
-                if !output.data.is_empty() {
-                    result.result = Some(serde_json::to_value(&output.data).unwrap_or_default());
-                }
+                result.msg = Some(output.msg.clone());
+                // Store full module output for register access
+                result.result = Some(output.to_result_json());
                 Ok(result)
             }
             Err(e) => Ok(TaskResult::failed(format!("file module failed: {}", e))),
@@ -1507,10 +1542,9 @@ impl Task {
                 } else {
                     TaskResult::ok()
                 };
-                result.msg = Some(output.msg);
-                if !output.data.is_empty() {
-                    result.result = Some(serde_json::to_value(&output.data).unwrap_or_default());
-                }
+                result.msg = Some(output.msg.clone());
+                // Store full module output for register access
+                result.result = Some(output.to_result_json());
                 Ok(result)
             }
             Err(e) => Ok(TaskResult::failed(format!("template module failed: {}", e))),
@@ -2691,5 +2725,152 @@ mod tests {
         assert!(is_truthy(&JsonValue::String("hello".to_string())));
         assert!(!is_truthy(&JsonValue::Array(vec![])));
         assert!(is_truthy(&JsonValue::Array(vec![JsonValue::Null])));
+    }
+
+    #[test]
+    fn test_to_registered_extracts_rc_stdout_stderr_from_result() {
+        // Simulate a command module result stored in TaskResult.result
+        let mut result = TaskResult::changed();
+        result.result = Some(serde_json::json!({
+            "rc": 0,
+            "stdout": "Hello, World!",
+            "stderr": "warning: deprecated",
+            "changed": true,
+            "custom_field": "custom_value"
+        }));
+
+        let registered = result.to_registered(None, None);
+
+        // Verify standard fields are extracted
+        assert_eq!(registered.rc, Some(0));
+        assert_eq!(registered.stdout, Some("Hello, World!".to_string()));
+        assert_eq!(registered.stderr, Some("warning: deprecated".to_string()));
+        assert_eq!(
+            registered.stdout_lines,
+            Some(vec!["Hello, World!".to_string()])
+        );
+        assert_eq!(
+            registered.stderr_lines,
+            Some(vec!["warning: deprecated".to_string()])
+        );
+        assert!(registered.changed);
+
+        // Verify custom data is preserved
+        assert_eq!(
+            registered.data.get("custom_field"),
+            Some(&JsonValue::String("custom_value".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_to_registered_multiline_stdout() {
+        let mut result = TaskResult::ok();
+        result.result = Some(serde_json::json!({
+            "stdout": "line1\nline2\nline3",
+            "rc": 0
+        }));
+
+        let registered = result.to_registered(None, None);
+
+        assert_eq!(
+            registered.stdout_lines,
+            Some(vec![
+                "line1".to_string(),
+                "line2".to_string(),
+                "line3".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn test_to_registered_fallback_to_explicit_params() {
+        // When self.result is None, use explicit stdout/stderr params
+        let result = TaskResult::ok();
+
+        let registered = result.to_registered(
+            Some("explicit stdout".to_string()),
+            Some("explicit stderr".to_string()),
+        );
+
+        assert_eq!(registered.stdout, Some("explicit stdout".to_string()));
+        assert_eq!(registered.stderr, Some("explicit stderr".to_string()));
+        assert_eq!(registered.rc, None); // No result, no rc
+    }
+
+    #[test]
+    fn test_to_registered_result_takes_precedence() {
+        // When self.result has stdout/stderr, it takes precedence
+        let mut result = TaskResult::ok();
+        result.result = Some(serde_json::json!({
+            "stdout": "from result",
+            "stderr": "from result error"
+        }));
+
+        let registered = result.to_registered(
+            Some("explicit stdout".to_string()),
+            Some("explicit stderr".to_string()),
+        );
+
+        // Result data takes precedence over explicit params
+        assert_eq!(registered.stdout, Some("from result".to_string()));
+        assert_eq!(registered.stderr, Some("from result error".to_string()));
+    }
+
+    #[test]
+    fn test_to_registered_failed_status() {
+        let result = TaskResult::failed("Command failed");
+
+        let registered = result.to_registered(None, None);
+
+        assert!(registered.failed);
+        assert!(!registered.changed);
+        assert_eq!(registered.msg, Some("Command failed".to_string()));
+    }
+
+    #[test]
+    fn test_to_registered_skipped_status() {
+        let result = TaskResult::skipped("Skipped in check mode");
+
+        let registered = result.to_registered(None, None);
+
+        assert!(registered.skipped);
+        assert!(!registered.failed);
+        assert!(!registered.changed);
+    }
+
+    #[test]
+    fn test_to_registered_excludes_standard_fields_from_data() {
+        // Standard RegisteredResult fields should not be duplicated in data
+        let mut result = TaskResult::changed();
+        result.result = Some(serde_json::json!({
+            "changed": true,
+            "failed": false,
+            "skipped": false,
+            "rc": 0,
+            "stdout": "output",
+            "stdout_lines": ["output"],
+            "stderr": "",
+            "stderr_lines": [],
+            "msg": "Success",
+            "results": null,
+            "custom_data": "should_be_in_data"
+        }));
+
+        let registered = result.to_registered(None, None);
+
+        // Standard fields should not be in data
+        assert!(!registered.data.contains_key("changed"));
+        assert!(!registered.data.contains_key("failed"));
+        assert!(!registered.data.contains_key("skipped"));
+        assert!(!registered.data.contains_key("rc"));
+        assert!(!registered.data.contains_key("stdout"));
+        assert!(!registered.data.contains_key("stdout_lines"));
+        assert!(!registered.data.contains_key("stderr"));
+        assert!(!registered.data.contains_key("stderr_lines"));
+        assert!(!registered.data.contains_key("msg"));
+        assert!(!registered.data.contains_key("results"));
+
+        // Custom field should be in data
+        assert!(registered.data.contains_key("custom_data"));
     }
 }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -491,6 +491,42 @@ impl ModuleOutput {
         self.rc = rc;
         self
     }
+
+    /// Convert to a JSON value suitable for storing in TaskResult.result
+    ///
+    /// This creates a canonical representation that includes all fields
+    /// necessary for proper `register` variable access.
+    pub fn to_result_json(&self) -> serde_json::Value {
+        let mut result = serde_json::json!({
+            "changed": self.changed,
+            "failed": self.status == ModuleStatus::Failed,
+            "skipped": self.status == ModuleStatus::Skipped,
+            "msg": self.msg,
+        });
+
+        if let Some(rc) = self.rc {
+            result["rc"] = serde_json::json!(rc);
+        }
+        if let Some(ref stdout) = self.stdout {
+            result["stdout"] = serde_json::json!(stdout);
+            result["stdout_lines"] = serde_json::json!(
+                stdout.lines().map(String::from).collect::<Vec<_>>()
+            );
+        }
+        if let Some(ref stderr) = self.stderr {
+            result["stderr"] = serde_json::json!(stderr);
+            result["stderr_lines"] = serde_json::json!(
+                stderr.lines().map(String::from).collect::<Vec<_>>()
+            );
+        }
+
+        // Add module-specific data
+        for (key, value) in &self.data {
+            result[key] = value.clone();
+        }
+
+        result
+    }
 }
 
 /// Parameters passed to a module
@@ -1087,5 +1123,83 @@ mod tests {
         assert!(validate_package_name("pkg\"name").is_err()); // double quote
         assert!(validate_package_name("pkg>file").is_err()); // redirect
         assert!(validate_package_name("pkg<file").is_err()); // redirect
+    }
+
+    #[test]
+    fn test_module_output_to_result_json_basic() {
+        let output = ModuleOutput::changed("Task completed");
+
+        let json = output.to_result_json();
+
+        assert_eq!(json["changed"], true);
+        assert_eq!(json["failed"], false);
+        assert_eq!(json["skipped"], false);
+        assert_eq!(json["msg"], "Task completed");
+    }
+
+    #[test]
+    fn test_module_output_to_result_json_with_command_output() {
+        let mut output = ModuleOutput::ok("Command executed");
+        output.rc = Some(0);
+        output.stdout = Some("Hello, World!".to_string());
+        output.stderr = Some("warning message".to_string());
+
+        let json = output.to_result_json();
+
+        assert_eq!(json["rc"], 0);
+        assert_eq!(json["stdout"], "Hello, World!");
+        assert_eq!(json["stderr"], "warning message");
+        assert_eq!(json["stdout_lines"], serde_json::json!(["Hello, World!"]));
+        assert_eq!(json["stderr_lines"], serde_json::json!(["warning message"]));
+    }
+
+    #[test]
+    fn test_module_output_to_result_json_multiline() {
+        let mut output = ModuleOutput::ok("Command executed");
+        output.stdout = Some("line1\nline2\nline3".to_string());
+
+        let json = output.to_result_json();
+
+        assert_eq!(
+            json["stdout_lines"],
+            serde_json::json!(["line1", "line2", "line3"])
+        );
+    }
+
+    #[test]
+    fn test_module_output_to_result_json_with_custom_data() {
+        let output = ModuleOutput::changed("File created")
+            .with_data("path", serde_json::json!("/tmp/file.txt"))
+            .with_data("size", serde_json::json!(1024))
+            .with_data("owner", serde_json::json!("root"));
+
+        let json = output.to_result_json();
+
+        assert_eq!(json["path"], "/tmp/file.txt");
+        assert_eq!(json["size"], 1024);
+        assert_eq!(json["owner"], "root");
+    }
+
+    #[test]
+    fn test_module_output_to_result_json_failed() {
+        let output = ModuleOutput::failed("Command not found");
+
+        let json = output.to_result_json();
+
+        assert_eq!(json["changed"], false);
+        assert_eq!(json["failed"], true);
+        assert_eq!(json["skipped"], false);
+        assert_eq!(json["msg"], "Command not found");
+    }
+
+    #[test]
+    fn test_module_output_to_result_json_skipped() {
+        let output = ModuleOutput::skipped("Skipped in check mode");
+
+        let json = output.to_result_json();
+
+        assert_eq!(json["changed"], false);
+        assert_eq!(json["failed"], false);
+        assert_eq!(json["skipped"], true);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #60

This PR ensures that `register` variables contain a predictable set of fields (`changed`, `failed`, `skipped`, `rc`, `stdout`, `stdout_lines`, `stderr`, `stderr_lines`, `msg`, plus module-specific data) regardless of whether the task was executed via a native module or Python fallback.

### Changes

- Add `ModuleOutput::to_result_json()` method that creates a canonical JSON representation of module output including all standard fields
- Update `TaskResult::to_registered()` to extract rc, stdout, stderr, and module-specific data from `self.result` when available (previously always returned `rc: None` and empty data)
- Update all native module execution paths (command, copy, file, template, gather_facts, Python fallback) to use `to_result_json()` instead of only storing `output.data`
- Add comprehensive tests for register behavior

### The Problem

Previously, `TaskResult::to_registered()` ignored the `self.result` field which contained the actual module output data. This meant:
- `rc` was always `None`
- `stdout` and `stderr` were only available if passed as explicit parameters
- Module-specific data (like file paths, checksums) was lost
- Registered variables had inconsistent fields depending on the execution path

### The Solution

Now all module execution paths store the full `ModuleOutput` as JSON in `TaskResult.result`, and `to_registered()` properly extracts:
- `rc`, `stdout`, `stderr`, `stdout_lines`, `stderr_lines` from the result
- Module-specific data in the `data` field (e.g., `path`, `owner`, `checksum`)

## Test plan

- [x] All new unit tests pass for `to_registered()` behavior
- [x] All new unit tests pass for `to_result_json()` behavior
- [x] Library tests pass (`cargo test --lib`)
- [x] Build succeeds with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)