### PR TITLE
refactor(connection): extract shared SSH helpers

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -56,6 +56,9 @@ pub mod docker;
 /// Local execution connection implementation.
 pub mod local;
 
+/// Shared SSH connection utilities.
+pub(crate) mod ssh_common;
+
 /// Pure Rust SSH implementation using russh.
 #[cfg(feature = "russh")]
 pub mod russh;

--- a/src/connection/russh.rs
+++ b/src/connection/russh.rs
@@ -44,9 +44,8 @@ const WARMUP_TIMEOUT: Duration = Duration::from_secs(10);
 /// Minimum time between keepalive pings
 const MIN_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
 
-use super::config::{
-    default_identity_files, expand_path, ConnectionConfig, HostConfig, RetryConfig,
-};
+use super::config::{ConnectionConfig, HostConfig};
+use super::ssh_common;
 use super::{
     CommandResult, Connection, ConnectionError, ConnectionResult, ExecuteOptions, FileStat,
     RusshError, TransferOptions,
@@ -859,13 +858,15 @@ impl RusshConnection {
         host_config: Option<HostConfig>,
         global_config: &ConnectionConfig,
     ) -> ConnectionResult<Self> {
-        let host_config = host_config.unwrap_or_else(|| global_config.get_host_merged(host));
-        let retry_config = host_config.retry_config();
-
-        let actual_host = host_config.hostname.as_deref().unwrap_or(host);
-        let actual_port = host_config.port.unwrap_or(port);
-        let actual_user = host_config.user.as_deref().unwrap_or(user);
-        let timeout = host_config.timeout_duration();
+        let ssh_common::ResolvedConnectionParams {
+            host_config,
+            retry_config,
+            host: actual_host,
+            port: actual_port,
+            user: actual_user,
+            timeout,
+            identifier,
+        } = ssh_common::resolve_connection_params(host, port, user, host_config, global_config);
 
         debug!(
             host = %actual_host,
@@ -874,17 +875,20 @@ impl RusshConnection {
             "Connecting via SSH (russh)"
         );
 
-        let identifier = format!("{}@{}:{}", actual_user, actual_host, actual_port);
-
         // Connect with retry logic
-        let handle = Self::connect_with_retry(
-            actual_host,
-            actual_port,
-            actual_user,
-            &host_config,
-            global_config,
-            timeout,
+        let handle = ssh_common::connect_with_retry_async(
             &retry_config,
+            "SSH connection",
+            || {
+                Self::do_connect(
+                    &actual_host,
+                    actual_port,
+                    &actual_user,
+                    &host_config,
+                    global_config,
+                    timeout,
+                )
+            },
         )
         .await?;
 
@@ -912,39 +916,6 @@ impl RusshConnection {
         );
 
         Ok(conn)
-    }
-
-    /// Connect with retry logic
-    async fn connect_with_retry(
-        host: &str,
-        port: u16,
-        user: &str,
-        host_config: &HostConfig,
-        global_config: &ConnectionConfig,
-        timeout: Duration,
-        retry_config: &RetryConfig,
-    ) -> ConnectionResult<Handle<ClientHandler>> {
-        let mut last_error = None;
-
-        for attempt in 0..=retry_config.max_retries {
-            if attempt > 0 {
-                let delay = retry_config.delay_for_attempt(attempt - 1);
-                debug!(attempt = %attempt, delay = ?delay, "Retrying SSH connection");
-                tokio::time::sleep(delay).await;
-            }
-
-            match Self::do_connect(host, port, user, host_config, global_config, timeout).await {
-                Ok(handle) => return Ok(handle),
-                Err(e) => {
-                    warn!(attempt = %attempt, error = %e, "SSH connection attempt failed");
-                    last_error = Some(e);
-                }
-            }
-        }
-
-        Err(last_error.unwrap_or_else(|| {
-            ConnectionError::ConnectionFailed("Unknown connection error".to_string())
-        }))
     }
 
     /// Perform the actual connection
@@ -1012,10 +983,7 @@ impl RusshConnection {
         let accept_unknown = !host_config.strict_host_key_checking.unwrap_or(false);
 
         // Use configured known_hosts file if provided
-        let known_hosts_path = host_config
-            .user_known_hosts_file
-            .as_ref()
-            .map(PathBuf::from);
+        let known_hosts_path = ssh_common::user_known_hosts_path(host_config);
 
         let handler = ClientHandler::new(host, port, accept_unknown, known_hosts_path);
 
@@ -1048,32 +1016,7 @@ impl RusshConnection {
         }
 
         // Try key-based authentication
-        // 1. Try specific identity file if configured
-        if let Some(identity_file) = &host_config.identity_file {
-            let key_path = expand_path(identity_file);
-            if Self::try_key_auth(session, user, &key_path, host_config.password.as_deref())
-                .await
-                .is_ok()
-            {
-                debug!(key = %key_path.display(), "Authenticated using key");
-                return Ok(());
-            }
-        }
-
-        // 2. Try default identity files from global config
-        for identity_file in &global_config.defaults.identity_files {
-            let key_path = expand_path(identity_file);
-            if Self::try_key_auth(session, user, &key_path, host_config.password.as_deref())
-                .await
-                .is_ok()
-            {
-                debug!(key = %key_path.display(), "Authenticated using key");
-                return Ok(());
-            }
-        }
-
-        // 3. Try default identity files from ~/.ssh/
-        for key_path in default_identity_files() {
+        for key_path in ssh_common::identity_file_candidates(host_config, global_config) {
             if Self::try_key_auth(session, user, &key_path, host_config.password.as_deref())
                 .await
                 .is_ok()

--- a/src/connection/ssh.rs
+++ b/src/connection/ssh.rs
@@ -13,11 +13,10 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::task;
-use tracing::{debug, trace, warn};
+use tracing::{debug, trace};
 
-use super::config::{
-    default_identity_files, expand_path, ConnectionConfig, HostConfig, RetryConfig,
-};
+use super::config::{ConnectionConfig, HostConfig};
+use super::ssh_common;
 use super::{
     CommandResult, Connection, ConnectionError, ConnectionResult, ExecuteOptions, FileStat,
     TransferOptions,
@@ -44,13 +43,15 @@ impl SshConnection {
         host_config: Option<HostConfig>,
         global_config: &ConnectionConfig,
     ) -> ConnectionResult<Self> {
-        let host_config = host_config.unwrap_or_else(|| global_config.get_host_merged(host));
-        let retry_config = host_config.retry_config();
-
-        let actual_host = host_config.hostname.as_deref().unwrap_or(host);
-        let actual_port = host_config.port.unwrap_or(port);
-        let actual_user = host_config.user.as_deref().unwrap_or(user);
-        let timeout = host_config.timeout_duration();
+        let ssh_common::ResolvedConnectionParams {
+            host_config,
+            retry_config,
+            host: actual_host,
+            port: actual_port,
+            user: actual_user,
+            timeout,
+            identifier,
+        } = ssh_common::resolve_connection_params(host, port, user, host_config, global_config);
 
         debug!(
             host = %actual_host,
@@ -59,12 +60,10 @@ impl SshConnection {
             "Connecting via SSH"
         );
 
-        let identifier = format!("{}@{}:{}", actual_user, actual_host, actual_port);
-
         // Clone values for the blocking task
-        let host_owned = actual_host.to_string();
+        let host_owned = actual_host.clone();
         let port_owned = actual_port;
-        let user_owned = actual_user.to_string();
+        let user_owned = actual_user.clone();
         let config_owned = host_config.clone();
         let global_config_owned = global_config.clone();
         let timeout_owned = timeout;
@@ -72,15 +71,16 @@ impl SshConnection {
 
         // Run connection in a blocking task since ssh2 is synchronous
         let session = task::spawn_blocking(move || {
-            Self::connect_with_retry(
-                &host_owned,
-                port_owned,
-                &user_owned,
-                &config_owned,
-                &global_config_owned,
-                timeout_owned,
-                &retry_config_owned,
-            )
+            ssh_common::connect_with_retry_blocking(&retry_config_owned, "SSH connection", || {
+                Self::do_connect(
+                    &host_owned,
+                    port_owned,
+                    &user_owned,
+                    &config_owned,
+                    &global_config_owned,
+                    timeout_owned,
+                )
+            })
         })
         .await
         .map_err(|e| ConnectionError::ConnectionFailed(format!("Task join error: {}", e)))??;
@@ -91,39 +91,6 @@ impl SshConnection {
             host_config,
             connected: Arc::new(Mutex::new(true)),
         })
-    }
-
-    /// Connect with retry logic
-    fn connect_with_retry(
-        host: &str,
-        port: u16,
-        user: &str,
-        host_config: &HostConfig,
-        global_config: &ConnectionConfig,
-        timeout: Duration,
-        retry_config: &RetryConfig,
-    ) -> ConnectionResult<Session> {
-        let mut last_error = None;
-
-        for attempt in 0..=retry_config.max_retries {
-            if attempt > 0 {
-                let delay = retry_config.delay_for_attempt(attempt - 1);
-                debug!(attempt = %attempt, delay = ?delay, "Retrying SSH connection");
-                std::thread::sleep(delay);
-            }
-
-            match Self::do_connect(host, port, user, host_config, global_config, timeout) {
-                Ok(session) => return Ok(session),
-                Err(e) => {
-                    warn!(attempt = %attempt, error = %e, "SSH connection attempt failed");
-                    last_error = Some(e);
-                }
-            }
-        }
-
-        Err(last_error.unwrap_or_else(|| {
-            ConnectionError::ConnectionFailed("Unknown connection error".to_string())
-        }))
     }
 
     /// Perform the actual connection
@@ -201,30 +168,7 @@ impl SshConnection {
 
         // Try key-based authentication
         if methods.contains("publickey") {
-            // Try specific identity file if configured
-            if let Some(identity_file) = &host_config.identity_file {
-                let key_path = expand_path(identity_file);
-                if Self::try_key_auth(session, user, &key_path, host_config.password.as_deref())
-                    .is_ok()
-                {
-                    debug!(key = %key_path.display(), "Authenticated using key");
-                    return Ok(());
-                }
-            }
-
-            // Try default identity files from global config
-            for identity_file in &global_config.defaults.identity_files {
-                let key_path = expand_path(identity_file);
-                if Self::try_key_auth(session, user, &key_path, host_config.password.as_deref())
-                    .is_ok()
-                {
-                    debug!(key = %key_path.display(), "Authenticated using key");
-                    return Ok(());
-                }
-            }
-
-            // Try default identity files
-            for key_path in default_identity_files() {
+            for key_path in ssh_common::identity_file_candidates(host_config, global_config) {
                 if Self::try_key_auth(session, user, &key_path, host_config.password.as_deref())
                     .is_ok()
                 {

--- a/src/connection/ssh_common.rs
+++ b/src/connection/ssh_common.rs
@@ -1,0 +1,212 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use tracing::{debug, warn};
+
+use super::config::{default_identity_files, expand_path, ConnectionConfig, HostConfig, RetryConfig};
+use super::{ConnectionError, ConnectionResult};
+
+#[derive(Debug, Clone)]
+pub struct ResolvedConnectionParams {
+    pub host_config: HostConfig,
+    pub retry_config: RetryConfig,
+    pub host: String,
+    pub port: u16,
+    pub user: String,
+    pub timeout: Duration,
+    pub identifier: String,
+}
+
+pub fn resolve_connection_params(
+    host: &str,
+    port: u16,
+    user: &str,
+    host_config: Option<HostConfig>,
+    global_config: &ConnectionConfig,
+) -> ResolvedConnectionParams {
+    let host_config = host_config.unwrap_or_else(|| global_config.get_host_merged(host));
+    let retry_config = host_config.retry_config();
+
+    let actual_host = host_config.hostname.as_deref().unwrap_or(host).to_string();
+    let actual_port = host_config.port.unwrap_or(port);
+    let actual_user = host_config.user.as_deref().unwrap_or(user).to_string();
+    let timeout = host_config.timeout_duration();
+
+    let identifier = format!("{}@{}:{}", actual_user, actual_host, actual_port);
+
+    ResolvedConnectionParams {
+        host_config,
+        retry_config,
+        host: actual_host,
+        port: actual_port,
+        user: actual_user,
+        timeout,
+        identifier,
+    }
+}
+
+pub fn identity_file_candidates(
+    host_config: &HostConfig,
+    global_config: &ConnectionConfig,
+) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    let mut seen = HashSet::new();
+
+    let mut push_unique = |path: PathBuf| {
+        if seen.insert(path.clone()) {
+            candidates.push(path);
+        }
+    };
+
+    if let Some(identity_file) = &host_config.identity_file {
+        push_unique(expand_path(identity_file));
+    }
+
+    for identity_file in &global_config.defaults.identity_files {
+        push_unique(expand_path(identity_file));
+    }
+
+    for key_path in default_identity_files() {
+        push_unique(key_path);
+    }
+
+    candidates
+}
+
+pub fn user_known_hosts_path(host_config: &HostConfig) -> Option<PathBuf> {
+    host_config
+        .user_known_hosts_file
+        .as_ref()
+        .map(PathBuf::from)
+}
+
+pub async fn connect_with_retry_async<T, F, Fut>(
+    retry_config: &RetryConfig,
+    operation: &str,
+    mut attempt: F,
+) -> ConnectionResult<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = ConnectionResult<T>>,
+{
+    let mut last_error = None;
+
+    for attempt_idx in 0..=retry_config.max_retries {
+        if attempt_idx > 0 {
+            let delay = retry_config.delay_for_attempt(attempt_idx - 1);
+            debug!(
+                attempt = %attempt_idx,
+                delay = ?delay,
+                operation = %operation,
+                "Retrying connection"
+            );
+            tokio::time::sleep(delay).await;
+        }
+
+        match attempt().await {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                warn!(
+                    attempt = %attempt_idx,
+                    error = %e,
+                    operation = %operation,
+                    "Connection attempt failed"
+                );
+                last_error = Some(e);
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        ConnectionError::ConnectionFailed("Unknown connection error".to_string())
+    }))
+}
+
+pub fn connect_with_retry_blocking<T, F>(
+    retry_config: &RetryConfig,
+    operation: &str,
+    mut attempt: F,
+) -> ConnectionResult<T>
+where
+    F: FnMut() -> ConnectionResult<T>,
+{
+    let mut last_error = None;
+
+    for attempt_idx in 0..=retry_config.max_retries {
+        if attempt_idx > 0 {
+            let delay = retry_config.delay_for_attempt(attempt_idx - 1);
+            debug!(
+                attempt = %attempt_idx,
+                delay = ?delay,
+                operation = %operation,
+                "Retrying connection"
+            );
+            std::thread::sleep(delay);
+        }
+
+        match attempt() {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                warn!(
+                    attempt = %attempt_idx,
+                    error = %e,
+                    operation = %operation,
+                    "Connection attempt failed"
+                );
+                last_error = Some(e);
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        ConnectionError::ConnectionFailed("Unknown connection error".to_string())
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_identity_file_candidates_order_and_dedupe() {
+        let mut host_config = HostConfig::default();
+        host_config.identity_file = Some("/tmp/test_key".to_string());
+
+        let mut config = ConnectionConfig::default();
+        config.defaults.identity_files = vec![
+            "/tmp/test_key".to_string(),
+            "/tmp/other_key".to_string(),
+        ];
+
+        let candidates = identity_file_candidates(&host_config, &config);
+        assert!(candidates.len() >= 2);
+
+        let expected_first = expand_path("/tmp/test_key");
+        let expected_second = expand_path("/tmp/other_key");
+
+        assert_eq!(candidates[0], expected_first);
+        assert_eq!(candidates[1], expected_second);
+
+        let count = candidates.iter().filter(|p| **p == expected_first).count();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_resolve_connection_params_overrides() {
+        let mut host_config = HostConfig::default();
+        host_config.hostname = Some("example.com".to_string());
+        host_config.port = Some(2222);
+        host_config.user = Some("admin".to_string());
+        host_config.connect_timeout = Some(30);
+
+        let config = ConnectionConfig::default();
+        let resolved = resolve_connection_params("host", 22, "root", Some(host_config), &config);
+
+        assert_eq!(resolved.host, "example.com");
+        assert_eq!(resolved.port, 2222);
+        assert_eq!(resolved.user, "admin");
+        assert_eq!(resolved.timeout, Duration::from_secs(30));
+        assert_eq!(resolved.identifier, "admin@example.com:2222");
+    }
+}


### PR DESCRIPTION
### **User description**
## Summary
- add  helpers for shared SSH connection setup, identity file selection, and retry logic
- update russh and ssh2 backends to use shared helpers and remove duplicate retry/auth loops
- add small unit tests for the shared helpers

## Testing
- cargo check

Closes #108


___

### **PR Type**
Enhancement


___

### **Description**
- Extract shared SSH connection helpers into dedicated module

- Consolidate retry logic for async and blocking SSH connections

- Unify identity file selection across russh and ssh2 backends

- Remove duplicate connection setup code from both implementations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SSH Connection Logic<br/>russh + ssh2"] -->|"Extract Common Patterns"| B["ssh_common Module"]
  B -->|"resolve_connection_params"| C["Connection Parameters"]
  B -->|"connect_with_retry_async/blocking"| D["Retry Logic"]
  B -->|"identity_file_candidates"| E["Key Selection"]
  B -->|"user_known_hosts_path"| F["Known Hosts"]
  C --> G["russh Backend"]
  D --> G
  E --> G
  F --> G
  C --> H["ssh2 Backend"]
  D --> H
  E --> H
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add ssh_common module declaration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/connection/mod.rs

<ul><li>Add public module declaration for new <code>ssh_common</code> module<br> <li> Expose shared SSH utilities to connection implementations</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/141/files#diff-24113098c9f8de91a5c31bf07307e12595768d986967971aea33fcbaf6065abb">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ssh_common.rs</strong><dd><code>Create shared SSH connection utilities module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/connection/ssh_common.rs

<ul><li>Create new module with <code>ResolvedConnectionParams</code> struct for unified <br>connection parameters<br> <li> Implement <code>resolve_connection_params()</code> to consolidate <br>host/port/user/timeout resolution<br> <li> Implement <code>identity_file_candidates()</code> with deduplication for key file <br>selection<br> <li> Implement <code>user_known_hosts_path()</code> helper for known_hosts file handling<br> <li> Implement <code>connect_with_retry_async()</code> for async retry logic with <br>configurable delays<br> <li> Implement <code>connect_with_retry_blocking()</code> for blocking retry logic<br> <li> Add unit tests for identity file deduplication and connection <br>parameter resolution</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/141/files#diff-5faf479d8c8a4fd210a889dd7fab58ee31f646e8f677343b5fe4975ec1673daf">+212/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>russh.rs</strong><dd><code>Refactor russh backend to use shared helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/connection/russh.rs

<ul><li>Replace manual connection parameter resolution with <br><code>ssh_common::resolve_connection_params()</code><br> <li> Replace custom <code>connect_with_retry()</code> method with <br><code>ssh_common::connect_with_retry_async()</code><br> <li> Replace identity file selection logic with <br><code>ssh_common::identity_file_candidates()</code><br> <li> Replace known_hosts path handling with <br><code>ssh_common::user_known_hosts_path()</code><br> <li> Remove 45 lines of duplicate retry and authentication logic<br> <li> Update imports to use shared helpers instead of config functions</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/141/files#diff-5a5f319af308046fcf17857bbdf4fc7331cb4b0a2d84936163456e4060c80fdf">+25/-82</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ssh.rs</strong><dd><code>Refactor ssh2 backend to use shared helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/connection/ssh.rs

<ul><li>Replace manual connection parameter resolution with <br><code>ssh_common::resolve_connection_params()</code><br> <li> Replace custom <code>connect_with_retry()</code> method with <br><code>ssh_common::connect_with_retry_blocking()</code><br> <li> Replace identity file selection logic with <br><code>ssh_common::identity_file_candidates()</code><br> <li> Remove 45 lines of duplicate retry and authentication logic<br> <li> Update imports to use shared helpers instead of config functions<br> <li> Simplify variable cloning by using <code>clone()</code> on already-owned strings</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/141/files#diff-394a78a5f852fb99a485898ae16f198d7ad85e21e07a21851367e1d4cb919394">+25/-81</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Extracted common SSH connection logic into new `ssh_common.rs` module, removing ~120 lines of duplicate code from `russh.rs` and `ssh.rs`. The refactor introduces shared helpers for connection parameter resolution, identity file selection with deduplication, and both async/blocking retry logic with exponential backoff.

**Key improvements:**
- `resolve_connection_params()` consolidates host/port/user override logic
- `identity_file_candidates()` deduplicates key paths and maintains priority order (host-specific → global → defaults)
- `connect_with_retry_async()` and `connect_with_retry_blocking()` extract retry loops with consistent logging
- `user_known_hosts_path()` centralizes known_hosts file resolution
- Both backends now use identical connection/auth flows, reducing maintenance burden
- Unit tests added for param resolution and identity file ordering/deduplication

<h3>Confidence Score: 5/5</h3>


- Safe to merge - well-structured refactoring with proper test coverage
- Clean extraction of duplicate code into shared helpers with no behavioral changes, solid unit tests verify deduplication and param resolution logic, both SSH backends successfully use the new helpers, and the refactoring directly addresses issue #108
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/connection/ssh_common.rs | New shared SSH utility module extracts common connection logic (param resolution, identity file selection, retry helpers) with clean deduplication and unit tests |
| src/connection/russh.rs | Refactored to use shared helpers - removed duplicate retry/auth logic (~60 lines), now uses `ssh_common::resolve_connection_params`, `connect_with_retry_async`, and `identity_file_candidates` |
| src/connection/ssh.rs | Refactored to use shared helpers - removed duplicate retry/auth logic (~60 lines), now uses `ssh_common::resolve_connection_params`, `connect_with_retry_blocking`, and `identity_file_candidates` |
| src/connection/mod.rs | Added `pub(crate) mod ssh_common` module declaration to expose shared SSH utilities within the connection module |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant RusshConnection
    participant SshConnection
    participant ssh_common
    participant Config
    
    Note over Client,Config: Connection Establishment Flow

    Client->>RusshConnection: connect(host, port, user, config)
    RusshConnection->>ssh_common: resolve_connection_params()
    ssh_common->>Config: get_host_merged(), retry_config()
    Config-->>ssh_common: ResolvedConnectionParams
    ssh_common-->>RusshConnection: params (host, port, user, timeout, etc.)
    
    RusshConnection->>ssh_common: connect_with_retry_async(retry_config, closure)
    loop max_retries times
        ssh_common->>RusshConnection: do_connect()
        RusshConnection->>RusshConnection: create russh client, TCP handshake
        alt success
            ssh_common-->>RusshConnection: Ok(handle)
        else failure
            Note over ssh_common: sleep(exponential backoff)
            ssh_common->>RusshConnection: retry
        end
    end
    
    RusshConnection->>RusshConnection: authenticate()
    RusshConnection->>ssh_common: identity_file_candidates()
    ssh_common->>Config: host identity, global identities, defaults
    Config-->>ssh_common: [key_paths]
    ssh_common-->>RusshConnection: deduplicated key paths
    
    loop for each key_path
        RusshConnection->>RusshConnection: try_key_auth(key_path)
        alt authenticated
            RusshConnection-->>Client: Ok(RusshConnection)
        end
    end
    
    Note over Client,Config: SSH2 Backend (Blocking)
    
    Client->>SshConnection: connect(host, port, user, config)
    SshConnection->>ssh_common: resolve_connection_params()
    ssh_common-->>SshConnection: params
    
    SshConnection->>SshConnection: spawn_blocking()
    SshConnection->>ssh_common: connect_with_retry_blocking(retry_config, closure)
    loop max_retries times
        ssh_common->>SshConnection: do_connect()
        SshConnection->>SshConnection: TCP connect, SSH handshake
        alt success
            ssh_common-->>SshConnection: Ok(session)
        else failure
            Note over ssh_common: sleep(exponential backoff)
            ssh_common->>SshConnection: retry
        end
    end
    
    SshConnection->>SshConnection: authenticate()
    SshConnection->>ssh_common: identity_file_candidates()
    ssh_common-->>SshConnection: deduplicated key paths
    
    loop for each key_path
        SshConnection->>SshConnection: try_key_auth(key_path)
        alt authenticated
            SshConnection-->>Client: Ok(SshConnection)
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->