### PR TITLE
Avoid IndexMap conversions in template engine

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -175,12 +175,8 @@ impl TemplateEngine {
         }
 
         trace!("Rendering template: {}", template);
-        // Convert IndexMap to a context that MiniJinja can use
-        let context: HashMap<String, JsonValue> =
-            vars.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-
         let tmpl = self.env.template_from_str(template)?;
-        let result = tmpl.render(&context)?;
+        let result = tmpl.render(vars)?;
         Ok(result)
     }
 
@@ -289,17 +285,12 @@ impl TemplateEngine {
         }
 
         trace!("Evaluating condition: {}", expression);
-
-        // Convert vars to HashMap for MiniJinja
-        let context: HashMap<String, JsonValue> =
-            vars.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-
         // Compile and evaluate the expression
         let expr = self.env.compile_expression(expression).map_err(|e| {
             Error::template_render(expression, format!("Failed to compile expression: {}", e))
         })?;
 
-        let result = expr.eval(&context).map_err(|e| {
+        let result = expr.eval(vars).map_err(|e| {
             // Check if it's an undefined variable error - treat as false in non-strict mode
             if matches!(e.kind(), ErrorKind::UndefinedError) {
                 trace!(


### PR DESCRIPTION
### **User description**
## Summary
- render templates and evaluate conditions directly from IndexMap contexts
- remove per-render HashMap allocations/clones

## Testing
- cargo check

Closes #103


___

### **PR Type**
Enhancement


___

### **Description**
- Remove unnecessary IndexMap to HashMap conversions in template rendering

- Pass IndexMap directly to MiniJinja for render and eval operations

- Eliminate per-render allocations and clones of context data


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["IndexMap context"] -->|"Previously: clone to HashMap"| B["MiniJinja render/eval"]
  A -->|"Now: pass directly"| C["MiniJinja render/eval"]
  B -->|"Allocations & clones"| D["Performance overhead"]
  C -->|"Zero-copy"| E["Improved performance"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>template.rs</strong><dd><code>Remove IndexMap to HashMap conversions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/template.rs

<ul><li>Removed HashMap conversion in <code>render()</code> method, passing IndexMap <br>directly to <code>tmpl.render()</code><br> <li> Removed HashMap conversion in <code>evaluate_condition()</code> method, passing <br>IndexMap directly to <code>expr.eval()</code><br> <li> Eliminated per-render allocations and clones of context variables<br> <li> Simplified code by removing intermediate context variable assignments</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/143/files#diff-94a2be1bc04f2828bc51dc8bfbdc5593caf509f2c6f435755275f71c2d4de379">+2/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Eliminates per-render IndexMap→HashMap conversions in template engine by passing IndexMap directly to MiniJinja. The changes remove two expensive conversion operations:

- **`render_with_indexmap`**: Removed 4 lines that cloned all keys and values into a new HashMap before rendering
- **`evaluate_condition`**: Removed 3 lines that performed the same conversion before expression evaluation

**Performance Impact:**
- Eliminates heap allocations for HashMap on every template render
- Removes O(n) key/value cloning where n = number of variables
- Works because IndexMap implements `Serialize` (enabled via `serde` feature in Cargo.toml line 86)

**Note:** PR description describes a complex `VariableStore` implementation with PHF maps from Issue #103, but actual changes are a simpler optimization that passes IndexMap directly to MiniJinja's render/eval methods.

<h3>Confidence Score: 5/5</h3>


- Safe to merge - clean performance optimization with no functional changes
- Simple, well-tested optimization that eliminates unnecessary allocations. MiniJinja accepts any `Serialize` type, and IndexMap implements `Serialize` via the `serde` feature. No logic changes, only removes conversion overhead. Author tested with `cargo check`.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/template.rs | Removes HashMap conversions in render_with_indexmap and evaluate_condition methods - passes IndexMap directly to MiniJinja |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Executor
    participant TemplateEngine
    participant MiniJinja
    participant IndexMap

    Note over Executor,IndexMap: Before: IndexMap → HashMap conversion

    Executor->>TemplateEngine: render_with_indexmap(template, vars: &IndexMap)
    TemplateEngine->>TemplateEngine: is_template() check (fast path)
    alt No template syntax
        TemplateEngine-->>Executor: Return unchanged string
    else Has template syntax
        Note over TemplateEngine: OLD: Convert IndexMap → HashMap<br/>(clone all keys & values)
        TemplateEngine->>MiniJinja: template_from_str(template)
        MiniJinja-->>TemplateEngine: Compiled template
        Note over TemplateEngine,MiniJinja: OLD: render(HashMap)
        TemplateEngine->>MiniJinja: render(converted_hashmap)
        MiniJinja->>MiniJinja: Serialize & render
        MiniJinja-->>TemplateEngine: Rendered string
        TemplateEngine-->>Executor: Result<String>
    end

    Note over Executor,IndexMap: After: Direct IndexMap usage (this PR)

    Executor->>TemplateEngine: render_with_indexmap(template, vars: &IndexMap)
    TemplateEngine->>TemplateEngine: is_template() check (fast path)
    alt No template syntax
        TemplateEngine-->>Executor: Return unchanged string
    else Has template syntax
        TemplateEngine->>MiniJinja: template_from_str(template)
        MiniJinja-->>TemplateEngine: Compiled template
        Note over TemplateEngine,IndexMap: NEW: Pass IndexMap directly<br/>(no conversion, no clones)
        TemplateEngine->>MiniJinja: render(vars: &IndexMap)
        MiniJinja->>IndexMap: Serialize via serde trait
        IndexMap-->>MiniJinja: Serialized context
        MiniJinja->>MiniJinja: Render template
        MiniJinja-->>TemplateEngine: Rendered string
        TemplateEngine-->>Executor: Result<String>
    end

    Note over Executor,IndexMap: Performance: Eliminates per-render allocations & clones
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->