### PR TITLE
Add TemplateEngine cache for templates and expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5015,6 +5015,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "libc",
+ "lru",
  "md4",
  "md5",
  "minijinja",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ regex = "1.10"
 glob = "0.3"
 globset = "0.4"
 walkdir = "2.4"
+lru = "0.12"
 shellexpand = "=3.1.0"  # Pin to avoid dirs 6.x which requires Rust 1.88+
 shell-words = "1.1"
 which = "5.0"  # Pin to avoid home 0.5.12 which requires Rust 1.88+

--- a/src/template.rs
+++ b/src/template.rs
@@ -12,13 +12,20 @@
 
 use crate::error::{Error, Result};
 use indexmap::IndexMap;
+use lru::LruCache;
 use minijinja::value::{Value as MiniJinjaValue, ValueKind};
 use minijinja::{Environment, ErrorKind};
 use once_cell::sync::Lazy;
+use parking_lot::{Mutex, RwLock};
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use tracing::trace;
+
+const DEFAULT_TEMPLATE_CACHE_SIZE: usize = 1000;
+const TEMPLATE_CACHE_SIZE_ENV: &str = "RUSTIBLE_TEMPLATE_CACHE_SIZE";
 
 /// Thread-safe template engine using MiniJinja
 ///
@@ -26,13 +33,36 @@ use tracing::trace;
 /// and condition evaluation should go through this engine to ensure consistent
 /// Jinja2 semantics.
 pub struct TemplateEngine {
-    env: Environment<'static>,
+    env: RwLock<Environment<'static>>,
+    template_cache: Option<Mutex<LruCache<String, String>>>,
+    expression_cache:
+        Option<Mutex<LruCache<String, Arc<minijinja::Expression<'static, 'static>>>>>,
+    template_counter: AtomicUsize,
 }
 
 impl TemplateEngine {
     /// Create a new template engine with Ansible-compatible filters and tests
     #[must_use]
     pub fn new() -> Self {
+        Self::with_cache_size(Self::default_cache_size())
+    }
+
+    /// Create a template engine with a specific cache size (0 disables caching).
+    #[must_use]
+    pub fn with_cache_size(cache_size: usize) -> Self {
+        let env = Self::build_environment();
+        let template_cache = Self::build_cache(cache_size);
+        let expression_cache = Self::build_cache(cache_size);
+
+        Self {
+            env: RwLock::new(env),
+            template_cache,
+            expression_cache,
+            template_counter: AtomicUsize::new(0),
+        }
+    }
+
+    fn build_environment() -> Environment<'static> {
         let mut env = Environment::new();
 
         // Configure environment for Ansible compatibility
@@ -44,7 +74,23 @@ impl TemplateEngine {
         // Register custom tests
         Self::register_tests(&mut env);
 
-        Self { env }
+        env
+    }
+
+    fn default_cache_size() -> usize {
+        std::env::var(TEMPLATE_CACHE_SIZE_ENV)
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(DEFAULT_TEMPLATE_CACHE_SIZE)
+    }
+
+    fn build_cache<T>(cache_size: usize) -> Option<Mutex<LruCache<String, T>>> {
+        NonZeroUsize::new(cache_size).map(|capacity| Mutex::new(LruCache::new(capacity)))
+    }
+
+    fn next_template_name(&self) -> String {
+        let id = self.template_counter.fetch_add(1, Ordering::Relaxed);
+        format!("__rustible_template_{}", id)
     }
 
     /// Register Ansible-compatible filters
@@ -136,6 +182,72 @@ impl TemplateEngine {
         env.add_test("skipped", test_skipped);
     }
 
+    fn render_cached<S: serde::Serialize>(&self, template: &str, vars: &S) -> Result<String> {
+        // Fast path: no template syntax
+        if !Self::is_template(template) {
+            return Ok(template.to_string());
+        }
+
+        trace!("Rendering template: {}", template);
+
+        if let Some(cache) = &self.template_cache {
+            let mut cache = cache.lock();
+            if let Some(name) = cache.get(template).cloned() {
+                drop(cache);
+                let env = self.env.read();
+                let tmpl = env.get_template(&name)?;
+                return Ok(tmpl.render(vars)?);
+            }
+
+            let name = self.next_template_name();
+            let template_owned = template.to_string();
+            {
+                let mut env = self.env.write();
+                env.add_template_owned(name.clone(), template_owned.clone())?;
+            }
+
+            if let Some(evicted_name) = cache.put(template_owned, name.clone()) {
+                let mut env = self.env.write();
+                env.remove_template(&evicted_name);
+            }
+            drop(cache);
+
+            let env = self.env.read();
+            let tmpl = env.get_template(&name)?;
+            return Ok(tmpl.render(vars)?);
+        }
+
+        let env = self.env.read();
+        let tmpl = env.template_from_str(template)?;
+        Ok(tmpl.render(vars)?)
+    }
+
+    /// Clear cached templates and expressions.
+    pub fn clear_cache(&self) {
+        if let Some(cache) = &self.template_cache {
+            cache.lock().clear();
+        }
+        if let Some(cache) = &self.expression_cache {
+            cache.lock().clear();
+        }
+
+        let mut env = self.env.write();
+        env.clear_templates();
+    }
+
+    /// Return the number of cached templates and expressions.
+    pub fn cache_stats(&self) -> (usize, usize) {
+        let template_count = self
+            .template_cache
+            .as_ref()
+            .map_or(0, |cache| cache.lock().len());
+        let expression_count = self
+            .expression_cache
+            .as_ref()
+            .map_or(0, |cache| cache.lock().len());
+        (template_count, expression_count)
+    }
+
     /// Render a template string with variables from a HashMap
     ///
     /// # Performance
@@ -144,15 +256,7 @@ impl TemplateEngine {
     /// # Errors
     /// Returns an error if template parsing or rendering fails.
     pub fn render(&self, template: &str, vars: &HashMap<String, JsonValue>) -> Result<String> {
-        // Fast path: no template syntax
-        if !Self::is_template(template) {
-            return Ok(template.to_string());
-        }
-
-        trace!("Rendering template: {}", template);
-        let tmpl = self.env.template_from_str(template)?;
-        let result = tmpl.render(vars)?;
-        Ok(result)
+        self.render_cached(template, vars)
     }
 
     /// Render a template string with variables from an IndexMap
@@ -169,15 +273,7 @@ impl TemplateEngine {
         template: &str,
         vars: &IndexMap<String, JsonValue>,
     ) -> Result<String> {
-        // Fast path: no template syntax
-        if !Self::is_template(template) {
-            return Ok(template.to_string());
-        }
-
-        trace!("Rendering template: {}", template);
-        let tmpl = self.env.template_from_str(template)?;
-        let result = tmpl.render(vars)?;
-        Ok(result)
+        self.render_cached(template, vars)
     }
 
     /// Render a template string with a JSON Value context
@@ -185,15 +281,7 @@ impl TemplateEngine {
     /// This allows rendering directly with a serde_json::Value (e.g. Object) without
     /// converting it to HashMap/IndexMap first.
     pub fn render_with_json(&self, template: &str, context: &JsonValue) -> Result<String> {
-        // Fast path: no template syntax
-        if !Self::is_template(template) {
-            return Ok(template.to_string());
-        }
-
-        trace!("Rendering template: {}", template);
-        let tmpl = self.env.template_from_str(template)?;
-        let result = tmpl.render(context)?;
-        Ok(result)
+        self.render_cached(template, context)
     }
 
     /// Render a JSON value, templating any strings within it
@@ -285,10 +373,36 @@ impl TemplateEngine {
         }
 
         trace!("Evaluating condition: {}", expression);
-        // Compile and evaluate the expression
-        let expr = self.env.compile_expression(expression).map_err(|e| {
-            Error::template_render(expression, format!("Failed to compile expression: {}", e))
-        })?;
+        let expr = if let Some(cache) = &self.expression_cache {
+            let mut cache = cache.lock();
+            if let Some(cached) = cache.get(expression).cloned() {
+                cached
+            } else {
+                let compiled =
+                    EXPRESSION_ENV
+                        .compile_expression_owned(expression.to_string())
+                        .map_err(|e| {
+                            Error::template_render(
+                                expression,
+                                format!("Failed to compile expression: {}", e),
+                            )
+                        })?;
+                let compiled = Arc::new(compiled);
+                cache.put(expression.to_string(), Arc::clone(&compiled));
+                compiled
+            }
+        } else {
+            Arc::new(
+                EXPRESSION_ENV
+                    .compile_expression(expression)
+                    .map_err(|e| {
+                        Error::template_render(
+                            expression,
+                            format!("Failed to compile expression: {}", e),
+                        )
+                    })?,
+            )
+        };
 
         let result = expr.eval(vars).map_err(|e| {
             // Check if it's an undefined variable error - treat as false in non-strict mode
@@ -297,7 +411,10 @@ impl TemplateEngine {
                     "Undefined variable in condition '{}', treating as false",
                     expression
                 );
-                return Error::template_render(expression, format!("Undefined variable: {}", e));
+                return Error::template_render(
+                    expression,
+                    format!("Undefined variable: {}", e),
+                );
             }
             Error::template_render(expression, format!("Failed to evaluate: {}", e))
         })?;
@@ -340,6 +457,9 @@ impl Default for TemplateEngine {
         Self::new()
     }
 }
+
+static EXPRESSION_ENV: Lazy<Environment<'static>> =
+    Lazy::new(TemplateEngine::build_environment);
 
 /// Global shared template engine instance
 pub static TEMPLATE_ENGINE: Lazy<Arc<TemplateEngine>> =
@@ -1181,6 +1301,53 @@ mod tests {
         let result = engine.render_value(&value, &vars).unwrap();
         assert_eq!(result["server"], "localhost");
         assert_eq!(result["port"], 8080);
+    }
+
+    #[test]
+    fn test_template_cache_hits() {
+        let engine = TemplateEngine::with_cache_size(2);
+        let mut vars = HashMap::new();
+        vars.insert("name".to_string(), JsonValue::String("Alice".to_string()));
+
+        let template = "Hello, {{ name }}!";
+        engine.render(template, &vars).unwrap();
+        let (template_count, expression_count) = engine.cache_stats();
+        assert_eq!(template_count, 1);
+        assert_eq!(expression_count, 0);
+
+        engine.render(template, &vars).unwrap();
+        let (template_count, _) = engine.cache_stats();
+        assert_eq!(template_count, 1);
+    }
+
+    #[test]
+    fn test_expression_cache_hits() {
+        let engine = TemplateEngine::with_cache_size(2);
+        let vars = IndexMap::new();
+
+        assert!(engine.evaluate_condition("1", &vars).unwrap());
+        let (_, expression_count) = engine.cache_stats();
+        assert_eq!(expression_count, 1);
+
+        assert!(engine.evaluate_condition("1", &vars).unwrap());
+        let (_, expression_count) = engine.cache_stats();
+        assert_eq!(expression_count, 1);
+    }
+
+    #[test]
+    fn test_clear_cache() {
+        let engine = TemplateEngine::with_cache_size(2);
+        let mut vars = HashMap::new();
+        vars.insert("name".to_string(), JsonValue::String("Alice".to_string()));
+
+        let template = "Hello, {{ name }}!";
+        engine.render(template, &vars).unwrap();
+        engine.evaluate_condition("1", &IndexMap::new()).unwrap();
+        engine.clear_cache();
+
+        let (template_count, expression_count) = engine.cache_stats();
+        assert_eq!(template_count, 0);
+        assert_eq!(expression_count, 0);
     }
 
     #[test]


### PR DESCRIPTION
### **User description**
## Summary
- add LRU caches for compiled templates and expressions in TemplateEngine
- cache compiled templates in the MiniJinja environment with eviction
- make cache size configurable via RUSTIBLE_TEMPLATE_CACHE_SIZE (0 disables)
- add cache stats and clear helpers plus tests

## Testing
- cargo check

Closes #101


___

### **PR Type**
Enhancement


___

### **Description**
- Add LRU caches for compiled templates and expressions

- Make cache size configurable via environment variable

- Provide cache statistics and clear methods

- Refactor template rendering to use unified caching layer


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Template/Expression Input"] --> B["Check Cache"]
  B --> C{Cache Hit?}
  C -->|Yes| D["Return Cached Result"]
  C -->|No| E["Compile & Store"]
  E --> F["Add to LRU Cache"]
  F --> D
  G["RUSTIBLE_TEMPLATE_CACHE_SIZE"] --> H["Configure Cache Size"]
  H --> B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>template.rs</strong><dd><code>Implement template and expression caching system</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/template.rs

<ul><li>Wrap <code>Environment</code> in <code>RwLock</code> for thread-safe access<br> <li> Add <code>LruCache</code> fields for templates and expressions with configurable <br>size<br> <li> Implement <code>render_cached()</code> method with cache lookup and eviction logic<br> <li> Add <code>clear_cache()</code> and <code>cache_stats()</code> public methods<br> <li> Refactor <code>render()</code>, <code>render_with_indexmap()</code>, and <code>render_with_json()</code> to <br>use caching<br> <li> Implement expression caching in <code>evaluate_condition()</code> with <code>Arc</code>-wrapped <br>compiled expressions<br> <li> Create static <code>EXPRESSION_ENV</code> for expression compilation<br> <li> Add three new test cases for cache hits and clearing</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/144/files#diff-94a2be1bc04f2828bc51dc8bfbdc5593caf509f2c6f435755275f71c2d4de379">+201/-34</a></td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add lru crate dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

- Add `lru = "0.12"` dependency for LRU cache implementation


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/144/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds LRU caching to the template engine to avoid re-parsing templates and re-compiling expressions on every use. The implementation includes:

- **Template caching**: Templates are added to the MiniJinja `Environment` with unique names (`__rustible_template_N`) and the LRU cache maps template strings to these names. On eviction, templates are removed from the Environment.
- **Expression caching**: Expressions are compiled once and stored as `Arc<Expression>` in a separate LRU cache to enable concurrent sharing across threads.
- **Configurable cache size**: Via `RUSTIBLE_TEMPLATE_CACHE_SIZE` environment variable (default: 1000), with 0 disabling caching.
- **Cache management**: `clear_cache()` and `cache_stats()` methods for monitoring and manual invalidation.
- **Tests**: Basic cache hit tests verify functionality but don't test eviction edge cases or concurrent access.

**Critical Issues Found:**
1. **Compilation error (line 382)**: `compile_expression_owned` doesn't exist in MiniJinja API - should use `compile_expression`
2. **Type error (line 37-39)**: `Expression<'static, 'static>` has incorrect lifetime count - should be `Expression<'static>`
3. **Potential race condition (line 193-200)**: Dropping cache lock before checking if template exists in Environment could cause issues if template is evicted between cache lookup and Environment access
4. **Deadlock risk (line 204-207)**: Acquiring Environment write lock while holding cache lock could cause deadlock in concurrent scenarios

**Architecture Concerns:**
- Separate `EXPRESSION_ENV` singleton means expressions and templates use different MiniJinja environments, preventing configuration sharing
- Lock ordering between cache and Environment needs careful consideration for thread safety

<h3>Confidence Score: 2/5</h3>


- This PR has compilation errors and potential concurrency issues that need resolution before merging
- Score reflects two critical compilation errors (`compile_expression_owned` method doesn't exist, incorrect Expression lifetime) that will prevent the code from building. Additionally, the cache-Environment synchronization has race condition and deadlock risks in the template rendering path that could manifest under concurrent load. The expression caching path appears safer but uses incorrect API. Tests verify basic functionality but don't cover edge cases or concurrent access patterns.
- src/template.rs requires immediate attention for compilation fixes on lines 37-39 and 382-383, plus concurrency safety improvements in the `render_cached` method (lines 193-217)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/template.rs | Added LRU caches for templates (stored in Environment) and expressions (stored as Arc'd compiled expressions). Cache size is configurable via RUSTIBLE_TEMPLATE_CACHE_SIZE env var. Template cache stores Environment template names, expression cache uses separate EXPRESSION_ENV singleton. Includes cache stats and clear methods with tests. |
| Cargo.toml | Added `lru = "0.12"` dependency for LRU cache implementation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant TemplateEngine
    participant TemplateCache as LRU Cache (Templates)
    participant ExprCache as LRU Cache (Expressions)
    participant Env as MiniJinja Environment
    participant ExprEnv as EXPRESSION_ENV (global)

    Note over Client,ExprEnv: Template Rendering Path
    Client->>TemplateEngine: render(template, vars)
    TemplateEngine->>TemplateEngine: is_template() check
    alt Has cache enabled
        TemplateEngine->>TemplateCache: lock() and get(template)
        alt Cache hit
            TemplateCache-->>TemplateEngine: return template_name
            TemplateEngine->>Env: read() get_template(name)
            Env-->>TemplateEngine: compiled template
            TemplateEngine->>Env: render(vars)
            Env-->>Client: rendered string
        else Cache miss
            TemplateEngine->>TemplateEngine: next_template_name()
            TemplateEngine->>Env: write() add_template_owned(name, template)
            TemplateEngine->>TemplateCache: put(template, name)
            alt Eviction occurred
                TemplateCache-->>TemplateEngine: evicted_name
                TemplateEngine->>Env: write() remove_template(evicted_name)
            end
            TemplateEngine->>Env: read() get_template(name)
            Env-->>TemplateEngine: compiled template
            TemplateEngine->>Env: render(vars)
            Env-->>Client: rendered string
        end
    else No cache
        TemplateEngine->>Env: read() template_from_str(template)
        Env-->>TemplateEngine: compiled template
        TemplateEngine->>Env: render(vars)
        Env-->>Client: rendered string
    end

    Note over Client,ExprEnv: Expression Evaluation Path
    Client->>TemplateEngine: evaluate_condition(expression, vars)
    TemplateEngine->>TemplateEngine: trim and check literals
    alt Has expression cache
        TemplateEngine->>ExprCache: lock() and get(expression)
        alt Cache hit
            ExprCache-->>TemplateEngine: Arc<Expression>
            TemplateEngine->>ExprCache: eval(vars)
            ExprCache-->>Client: boolean result
        else Cache miss
            TemplateEngine->>ExprEnv: compile_expression(expression)
            ExprEnv-->>TemplateEngine: Expression
            TemplateEngine->>TemplateEngine: Arc::new(expr)
            TemplateEngine->>ExprCache: put(expression, Arc<Expression>)
            TemplateEngine->>ExprCache: eval(vars)
            ExprCache-->>Client: boolean result
        end
    else No cache
        TemplateEngine->>ExprEnv: compile_expression(expression)
        ExprEnv-->>TemplateEngine: Arc<Expression>
        TemplateEngine->>ExprEnv: eval(vars)
        ExprEnv-->>Client: boolean result
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->