### PR TITLE
Make connection pooling async-aware

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -110,11 +110,11 @@ pub mod winrm;
 pub mod kubernetes;
 
 use async_trait::async_trait;
-use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use thiserror::Error;
+use tokio::sync::RwLock;
 
 // Re-export config types at module level for convenience
 pub use crate::config::SshConfig;
@@ -597,7 +597,7 @@ pub struct ConnectionFactory {
     /// Global configuration
     config: Arc<ConnectionConfig>,
     /// Connection pool
-    pool: Arc<RwLock<ConnectionPool>>,
+    pool: AsyncConnectionPool,
 }
 
 impl ConnectionFactory {
@@ -605,7 +605,7 @@ impl ConnectionFactory {
     pub fn new(config: ConnectionConfig) -> Self {
         Self {
             config: Arc::new(config),
-            pool: Arc::new(RwLock::new(ConnectionPool::new(10))), // Default pool size of 10
+            pool: AsyncConnectionPool::new(10), // Default pool size of 10
         }
     }
 
@@ -613,7 +613,7 @@ impl ConnectionFactory {
     pub fn with_pool_size(config: ConnectionConfig, pool_size: usize) -> Self {
         Self {
             config: Arc::new(config),
-            pool: Arc::new(RwLock::new(ConnectionPool::new(pool_size))),
+            pool: AsyncConnectionPool::new(pool_size),
         }
     }
 
@@ -626,19 +626,23 @@ impl ConnectionFactory {
         let pool_key = conn_type.pool_key();
 
         // Try to get from pool first - release lock before await
-        let pooled_conn = { self.pool.write().get(&pool_key) };
+        let pooled_conn = self.pool.get(&pool_key).await;
 
         if let Some(conn) = pooled_conn {
             if conn.is_alive().await {
                 return Ok(conn);
             }
+            self.pool.remove(&pool_key).await;
         }
 
         // Create new connection
         let conn = self.create_connection(&conn_type).await?;
 
         // Add to pool
-        self.pool.write().put(pool_key, conn.clone());
+        let pooled = self.pool.put(pool_key, conn.clone()).await;
+        if !pooled {
+            tracing::debug!("Connection pool full, returning unpooled connection");
+        }
 
         Ok(conn)
     }
@@ -759,10 +763,7 @@ impl ConnectionFactory {
 
     /// Close all connections in the pool
     pub async fn close_all(&self) -> ConnectionResult<()> {
-        let connections: Vec<_> = {
-            let mut pool = self.pool.write();
-            pool.drain()
-        };
+        let connections = self.pool.drain().await;
 
         for conn in connections {
             let _ = conn.close().await;
@@ -772,8 +773,8 @@ impl ConnectionFactory {
     }
 
     /// Get pool statistics
-    pub fn pool_stats(&self) -> PoolStats {
-        self.pool.read().stats()
+    pub async fn pool_stats(&self) -> PoolStats {
+        self.pool.stats().await
     }
 }
 
@@ -942,6 +943,10 @@ impl ConnectionPool {
         // Clean up expired connections first
         self.cleanup_expired();
 
+        if self.connections.contains_key(&key) {
+            let _ = self.remove(&key);
+        }
+
         let host_key = Self::extract_host_key(&key);
 
         // Check per-host limit
@@ -1031,6 +1036,65 @@ impl ConnectionPool {
     /// Get detailed per-host statistics
     pub fn host_stats(&self) -> HashMap<String, usize> {
         self.host_counts.clone()
+    }
+}
+
+/// Async-aware wrapper around the connection pool.
+#[derive(Clone)]
+pub struct AsyncConnectionPool {
+    inner: Arc<RwLock<ConnectionPool>>,
+}
+
+impl AsyncConnectionPool {
+    /// Create a new async connection pool with default configuration.
+    pub fn new(max_connections: usize) -> Self {
+        Self::with_config(ConnectionPoolConfig {
+            max_total_connections: max_connections,
+            ..Default::default()
+        })
+    }
+
+    /// Create a new async connection pool with custom configuration.
+    pub fn with_config(config: ConnectionPoolConfig) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(ConnectionPool::with_config(config))),
+        }
+    }
+
+    /// Get a connection from the pool.
+    pub async fn get(&self, key: &str) -> Option<Arc<dyn Connection + Send + Sync>> {
+        let mut pool = self.inner.write().await;
+        pool.get(key)
+    }
+
+    /// Put a connection into the pool.
+    pub async fn put(&self, key: String, conn: Arc<dyn Connection + Send + Sync>) -> bool {
+        let mut pool = self.inner.write().await;
+        pool.put(key, conn)
+    }
+
+    /// Remove a connection from the pool.
+    pub async fn remove(&self, key: &str) -> Option<Arc<dyn Connection + Send + Sync>> {
+        let mut pool = self.inner.write().await;
+        pool.remove(key)
+    }
+
+    /// Drain all connections from the pool.
+    pub async fn drain(&self) -> Vec<Arc<dyn Connection + Send + Sync>> {
+        let mut pool = self.inner.write().await;
+        pool.drain()
+    }
+
+    /// Get pool statistics.
+    pub async fn stats(&self) -> PoolStats {
+        let pool = self.inner.read().await;
+        pool.stats()
+    }
+
+    /// Get per-host connection counts.
+    pub async fn host_stats(&self) -> HashMap<String, usize> {
+        let pool = self.inner.read().await;
+        pool.host_stats()
     }
 }
 
@@ -1329,5 +1393,21 @@ mod tests {
         assert_eq!(stats.host_count, 0);
         assert_eq!(stats.idle_timeout_secs, 60);
         assert_eq!(stats.max_lifetime_secs, 300);
+    }
+
+    #[tokio::test]
+    async fn test_async_connection_pool_put_get() {
+        let pool = AsyncConnectionPool::new(5);
+        let conn: Arc<dyn Connection + Send + Sync> =
+            Arc::new(local::LocalConnection::new());
+
+        assert!(pool.put("local".to_string(), conn).await);
+
+        let pooled = pool.get("local").await;
+        assert!(pooled.is_some());
+        assert!(pooled.unwrap().is_alive().await);
+
+        let stats = pool.stats().await;
+        assert_eq!(stats.active_connections, 1);
     }
 }


### PR DESCRIPTION
### **User description**
## Summary
- add AsyncConnectionPool wrapper using tokio::sync::RwLock for async-friendly access
- refactor ConnectionFactory to use async pool operations and remove dead entries before recreating connections
- make pool_stats async and add an async pool test
- fix ConnectionPool::put to replace existing entries without leaking host counts

## Testing
- cargo check

Closes #102


___

### **PR Type**
Enhancement


___

### **Description**
- Replace parking_lot::RwLock with tokio::sync::RwLock for async compatibility

- Introduce AsyncConnectionPool wrapper for async-aware pool operations

- Make pool_stats() async and update all pool access patterns

- Fix ConnectionPool::put to handle duplicate entries without leaking host counts

- Add comprehensive async pool test coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["parking_lot RwLock"] -->|"Replace with"| B["tokio::sync::RwLock"]
  C["ConnectionFactory"] -->|"Uses"| D["AsyncConnectionPool"]
  D -->|"Wraps"| B
  E["Pool Operations"] -->|"Made async"| F["get/put/drain/stats"]
  G["ConnectionPool::put"] -->|"Enhanced"| H["Handle duplicates safely"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Async-aware connection pool with tokio RwLock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/connection/mod.rs

<ul><li>Replaced <code>parking_lot::RwLock</code> with <code>tokio::sync::RwLock</code> for async <br>compatibility<br> <li> Created new <code>AsyncConnectionPool</code> struct wrapping <code>ConnectionPool</code> with <br>async methods<br> <li> Updated <code>ConnectionFactory</code> to use <code>AsyncConnectionPool</code> instead of manual <br>lock management<br> <li> Made <code>pool_stats()</code> async and updated all pool access patterns to use <br><code>.await</code><br> <li> Enhanced <code>ConnectionPool::put()</code> to remove existing entries before <br>adding duplicates<br> <li> Added <code>test_async_connection_pool_put_get()</code> test for async pool <br>operations</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/146/files#diff-24113098c9f8de91a5c31bf07307e12595768d986967971aea33fcbaf6065abb">+92/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Replaced `parking_lot::RwLock` with `tokio::sync::RwLock` for async-aware connection pooling. Created `AsyncConnectionPool` wrapper that delegates to the underlying `ConnectionPool` through async lock operations. Fixed bug where `ConnectionPool::put` could leak host counts when replacing existing entries by removing old entries before insertion.

**Key changes:**
- Wrapped synchronous `ConnectionPool` with `tokio::sync::RwLock` in new `AsyncConnectionPool` type
- All pool operations (`get`, `put`, `remove`, `drain`, `stats`) now use `.await` for async lock acquisition
- Added check in `ConnectionPool::put` to remove existing keys before replacement, preventing host count leaks
- Made `pool_stats()` method async in `ConnectionFactory`
- Added async test `test_async_connection_pool_put_get` to verify basic functionality

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor considerations around testing and performance
- The refactoring is straightforward and fixes a bug in connection replacement. However, the implementation still holds locks during async operations (`is_alive().await`), which doesn't fully address the contention issues mentioned in the related issue. The approach is minimally invasive and maintains backward compatibility
- No files require special attention - changes are localized and well-tested

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/connection/mod.rs | Replaced `parking_lot::RwLock` with `tokio::sync::RwLock` wrapper, added async methods, and fixed connection replacement logic in pool |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant ConnectionFactory
    participant AsyncConnectionPool
    participant RwLock
    participant ConnectionPool
    participant Connection

    Client->>ConnectionFactory: get_connection(host)
    ConnectionFactory->>ConnectionFactory: resolve_connection_type(host)
    ConnectionFactory->>ConnectionFactory: conn_type.pool_key()
    
    ConnectionFactory->>AsyncConnectionPool: get(pool_key)
    AsyncConnectionPool->>RwLock: write().await
    RwLock->>ConnectionPool: get(key)
    ConnectionPool->>ConnectionPool: cleanup_expired()
    ConnectionPool-->>AsyncConnectionPool: Option<Connection>
    AsyncConnectionPool-->>ConnectionFactory: Option<Connection>
    
    alt Connection exists
        ConnectionFactory->>Connection: is_alive().await
        alt Connection alive
            Connection-->>Client: Return connection
        else Connection dead
            ConnectionFactory->>AsyncConnectionPool: remove(pool_key)
            AsyncConnectionPool->>RwLock: write().await
            RwLock->>ConnectionPool: remove(key)
            ConnectionPool->>ConnectionPool: update host_counts
            ConnectionFactory->>ConnectionFactory: create_connection()
            ConnectionFactory->>AsyncConnectionPool: put(pool_key, conn)
            AsyncConnectionPool->>RwLock: write().await
            RwLock->>ConnectionPool: put(key, conn)
            ConnectionPool->>ConnectionPool: check if key exists & remove
            ConnectionPool->>ConnectionPool: check limits
            ConnectionPool->>ConnectionPool: update host_counts
            ConnectionFactory-->>Client: Return new connection
        end
    else No connection in pool
        ConnectionFactory->>ConnectionFactory: create_connection()
        ConnectionFactory->>AsyncConnectionPool: put(pool_key, conn)
        AsyncConnectionPool->>RwLock: write().await
        RwLock->>ConnectionPool: put(key, conn)
        ConnectionPool->>ConnectionPool: check if key exists & remove
        ConnectionPool->>ConnectionPool: check limits
        ConnectionPool->>ConnectionPool: update host_counts
        ConnectionFactory-->>Client: Return new connection
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->