### PR TITLE
Close remaining Ansible compat edge cases

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -284,10 +284,10 @@ A comprehensive roadmap for Rustible development, outlining current features, pl
 | Task | Priority | Description |
 |------|----------|-------------|
 | Fix remaining tests | Critical | Achieve 100% test pass rate |
-| Ansible boolean compat | High | Fix remaining boolean edge cases |
-| Block parsing | High | Fix block parsing edge cases |
-| Python/FQCN edge cases | High | Fix FQCN resolution issues |
-| CLI edge cases | Medium | Fix CLI handling issues |
+| Ansible boolean compat | High | Done: handle y/n/t/f and string boolean variants consistently |
+| Block parsing | High | Done: treat null block/rescue/always as empty lists |
+| Python/FQCN edge cases | High | Done: normalize ansible.builtin/ansible.legacy module names |
+| CLI edge cases | Medium | Done: support comma-separated tags and richer extra-vars parsing |
 
 ### Execution Plan Preview
 

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -193,13 +193,58 @@ impl CommandContext {
         let mut vars = HashMap::new();
 
         for var in &self.extra_vars {
-            if let Some(file_path) = var.strip_prefix('@') {
+            let trimmed = var.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            if let Some(file_path) = trimmed.strip_prefix('@') {
                 // Load from file
                 let content = std::fs::read_to_string(file_path)?;
                 let file_vars: HashMap<String, serde_yaml::Value> = serde_yaml::from_str(&content)?;
                 vars.extend(file_vars);
-            } else if let Some((key, value)) = var.split_once('=') {
-                // Parse key=value
+                continue;
+            }
+
+            if !trimmed.contains('=') {
+                let value: serde_yaml::Value = serde_yaml::from_str(trimmed)?;
+                if let serde_yaml::Value::Mapping(mapping) = value {
+                    for (key, value) in mapping {
+                        let key = key.as_str().ok_or_else(|| {
+                            anyhow::anyhow!("Extra vars mapping keys must be strings")
+                        })?;
+                        vars.insert(key.to_string(), value);
+                    }
+                } else {
+                    anyhow::bail!("Extra vars must be key=value or a YAML/JSON mapping");
+                }
+                continue;
+            }
+
+            let mut tokens: Vec<String> = Vec::new();
+            if trimmed.chars().any(char::is_whitespace) {
+                let split_tokens = shell_words::split(trimmed).map_err(|e| {
+                    anyhow::anyhow!("Failed to parse extra vars string '{}': {}", trimmed, e)
+                })?;
+                if split_tokens.len() > 1 && split_tokens.iter().all(|token| token.contains('=')) {
+                    tokens = split_tokens;
+                }
+            }
+
+            if tokens.is_empty() {
+                let (key, value) = trimmed
+                    .split_once('=')
+                    .ok_or_else(|| anyhow::anyhow!("Invalid extra vars entry: {}", trimmed))?;
+                let parsed_value: serde_yaml::Value = serde_yaml::from_str(value)
+                    .unwrap_or_else(|_| serde_yaml::Value::String(value.to_string()));
+                vars.insert(key.to_string(), parsed_value);
+                continue;
+            }
+
+            for token in tokens {
+                let (key, value) = token
+                    .split_once('=')
+                    .ok_or_else(|| anyhow::anyhow!("Invalid extra vars entry: {}", token))?;
                 let parsed_value: serde_yaml::Value = serde_yaml::from_str(value)
                     .unwrap_or_else(|_| serde_yaml::Value::String(value.to_string()));
                 vars.insert(key.to_string(), parsed_value);
@@ -216,4 +261,44 @@ impl CommandContext {
 pub trait Runnable {
     /// Execute the command
     async fn run(&self, ctx: &mut CommandContext) -> Result<i32>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::Cli;
+    use clap::Parser;
+
+    #[test]
+    fn test_parse_extra_vars_json_mapping() {
+        let cli =
+            Cli::try_parse_from(["rustible", "-e", "{\"a\": 1, \"b\": 2}", "run", "play.yml"])
+                .unwrap();
+        let ctx = CommandContext::new(&cli, Config::default());
+        let vars = ctx.parse_extra_vars().unwrap();
+
+        assert_eq!(vars.get("a").and_then(|v| v.as_i64()), Some(1));
+        assert_eq!(vars.get("b").and_then(|v| v.as_i64()), Some(2));
+    }
+
+    #[test]
+    fn test_parse_extra_vars_multiple_pairs() {
+        let cli = Cli::try_parse_from(["rustible", "-e", "a=1 b=2", "run", "play.yml"]).unwrap();
+        let ctx = CommandContext::new(&cli, Config::default());
+        let vars = ctx.parse_extra_vars().unwrap();
+
+        assert_eq!(vars.get("a").and_then(|v| v.as_i64()), Some(1));
+        assert_eq!(vars.get("b").and_then(|v| v.as_i64()), Some(2));
+    }
+
+    #[test]
+    fn test_parse_extra_vars_value_with_spaces() {
+        let cli =
+            Cli::try_parse_from(["rustible", "-e", "message=hello world", "run", "play.yml"])
+                .unwrap();
+        let ctx = CommandContext::new(&cli, Config::default());
+        let vars = ctx.parse_extra_vars().unwrap();
+
+        assert_eq!(vars.get("message").and_then(|v| v.as_str()), Some("hello world"));
+    }
 }

--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -1259,8 +1259,11 @@ impl RunArgs {
 
     /// Check if a task should run based on tags
     fn should_run_task(&self, task: &serde_yaml::Value) -> bool {
+        let tags = Self::normalize_tags(&self.tags);
+        let skip_tags = Self::normalize_tags(&self.skip_tags);
+
         // If no tags specified, run everything
-        if self.tags.is_empty() && self.skip_tags.is_empty() {
+        if tags.is_empty() && skip_tags.is_empty() {
             return true;
         }
 
@@ -1280,15 +1283,15 @@ impl RunArgs {
             .unwrap_or_default();
 
         // Check skip_tags first
-        for skip_tag in &self.skip_tags {
+        for skip_tag in &skip_tags {
             if task_tags.contains(skip_tag) {
                 return false;
             }
         }
 
         // Check tags
-        if !self.tags.is_empty() {
-            for tag in &self.tags {
+        if !tags.is_empty() {
+            for tag in &tags {
                 if task_tags.contains(tag) || tag == "all" {
                     return true;
                 }
@@ -1297,6 +1300,15 @@ impl RunArgs {
         }
 
         true
+    }
+
+    fn normalize_tags(tags: &[String]) -> Vec<String> {
+        tags.iter()
+            .flat_map(|tag| tag.split(','))
+            .map(|tag| tag.trim())
+            .filter(|tag| !tag.is_empty())
+            .map(|tag| tag.to_string())
+            .collect()
     }
 
     /// Detect which module a task is using
@@ -1678,6 +1690,28 @@ mod tests {
         ])
         .unwrap();
         assert_eq!(args.tags, vec!["install", "configure"]);
+    }
+
+    #[test]
+    fn test_normalize_tags_with_commas() {
+        let args = RunArgs::try_parse_from([
+            "run",
+            "playbook.yml",
+            "--tags",
+            "install, configure",
+            "--skip-tags",
+            "slow, noisy",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            RunArgs::normalize_tags(&args.tags),
+            vec!["install", "configure"]
+        );
+        assert_eq!(
+            RunArgs::normalize_tags(&args.skip_tags),
+            vec!["slow", "noisy"]
+        );
     }
 
     #[test]

--- a/src/executor/playbook.rs
+++ b/src/executor/playbook.rs
@@ -22,8 +22,8 @@ where
     match &value {
         JsonValue::Bool(b) => Ok(*b),
         JsonValue::String(s) => match s.to_lowercase().as_str() {
-            "yes" | "true" | "on" | "1" => Ok(true),
-            "no" | "false" | "off" | "0" | "" => Ok(false),
+            "yes" | "true" | "on" | "1" | "y" | "t" => Ok(true),
+            "no" | "false" | "off" | "0" | "" | "n" | "f" => Ok(false),
             _ => Err(D::Error::custom(format!("invalid boolean string: {}", s))),
         },
         JsonValue::Number(n) => {
@@ -56,8 +56,8 @@ where
         Some(JsonValue::Null) => Ok(None),
         Some(JsonValue::Bool(b)) => Ok(Some(b)),
         Some(JsonValue::String(s)) => match s.to_lowercase().as_str() {
-            "yes" | "true" | "on" | "1" => Ok(Some(true)),
-            "no" | "false" | "off" | "0" | "" => Ok(Some(false)),
+            "yes" | "true" | "on" | "1" | "y" | "t" => Ok(Some(true)),
+            "no" | "false" | "off" | "0" | "" | "n" | "f" => Ok(Some(false)),
             _ => Err(D::Error::custom(format!("invalid boolean string: {}", s))),
         },
         Some(JsonValue::Number(n)) => {
@@ -1222,6 +1222,16 @@ fn parse_task_definition(
     Ok(tasks)
 }
 
+fn normalize_builtin_module_name(name: &str) -> &str {
+    if let Some(stripped) = name.strip_prefix("ansible.builtin.") {
+        stripped.rsplit('.').next().unwrap_or(stripped)
+    } else if let Some(stripped) = name.strip_prefix("ansible.legacy.") {
+        stripped.rsplit('.').next().unwrap_or(stripped)
+    } else {
+        name
+    }
+}
+
 /// Find the module name and args in a task definition
 fn find_module_in_definition(
     def: &TaskDefinition,
@@ -1287,7 +1297,7 @@ fn find_module_in_definition(
                     full_args.insert("_raw_params".to_string(), JsonValue::String(s.clone()));
                 }
 
-                return Ok((key.clone(), full_args));
+                return Ok((normalize_builtin_module_name(key).to_string(), full_args));
             }
         }
     }
@@ -1310,7 +1320,7 @@ fn find_module_in_definition(
                 }
             };
 
-            return Ok((key.clone(), args));
+            return Ok((normalize_builtin_module_name(key).to_string(), args));
         }
     }
 
@@ -1361,6 +1371,8 @@ fn parse_handler_definition(def: HandlerDefinition) -> ExecutorResult<Handler> {
 
         (module_name, module_args)
     };
+
+    let module_name = normalize_builtin_module_name(&module_name).to_string();
 
     Ok(Handler {
         name: def.name,
@@ -1420,6 +1432,28 @@ mod tests {
 
         let task = &play.tasks[0];
         assert_eq!(task.name, "Debug message");
+        assert_eq!(task.module, "debug");
+    }
+
+    #[test]
+    fn test_parse_flexible_booleans_and_fqcn() {
+        let yaml = r#"
+- name: Test Play
+  hosts: all
+  gather_facts: n
+  become: t
+  tasks:
+    - name: Debug message
+      ansible.builtin.debug:
+        msg: "Hello World"
+"#;
+
+        let playbook = Playbook::parse(yaml, None).unwrap();
+        let play = &playbook.plays[0];
+        assert!(!play.gather_facts);
+        assert!(play.r#become);
+
+        let task = &play.tasks[0];
         assert_eq!(task.module, "debug");
     }
 

--- a/src/executor/task.rs
+++ b/src/executor/task.rs
@@ -2828,7 +2828,22 @@ fn is_truthy(value: &JsonValue) -> bool {
         JsonValue::Null => false,
         JsonValue::Bool(b) => *b,
         JsonValue::Number(n) => n.as_f64().map(|f| f != 0.0).unwrap_or(false),
-        JsonValue::String(s) => !s.is_empty() && s != "false" && s != "False" && s != "no",
+        JsonValue::String(s) => {
+            let value = s.trim();
+            if value.is_empty() {
+                return false;
+            }
+            if value.eq_ignore_ascii_case("false")
+                || value.eq_ignore_ascii_case("no")
+                || value.eq_ignore_ascii_case("off")
+                || value.eq_ignore_ascii_case("n")
+                || value.eq_ignore_ascii_case("f")
+                || value == "0"
+            {
+                return false;
+            }
+            true
+        }
         JsonValue::Array(arr) => !arr.is_empty(),
         JsonValue::Object(obj) => !obj.is_empty(),
     }
@@ -2958,6 +2973,12 @@ mod tests {
         assert!(!is_truthy(&JsonValue::Bool(false)));
         assert!(is_truthy(&JsonValue::Bool(true)));
         assert!(!is_truthy(&JsonValue::String("".to_string())));
+        assert!(!is_truthy(&JsonValue::String("0".to_string())));
+        assert!(!is_truthy(&JsonValue::String("false".to_string())));
+        assert!(!is_truthy(&JsonValue::String("no".to_string())));
+        assert!(!is_truthy(&JsonValue::String("off".to_string())));
+        assert!(!is_truthy(&JsonValue::String("n".to_string())));
+        assert!(!is_truthy(&JsonValue::String("f".to_string())));
         assert!(is_truthy(&JsonValue::String("hello".to_string())));
         assert!(!is_truthy(&JsonValue::Array(vec![])));
         assert!(is_truthy(&JsonValue::Array(vec![JsonValue::Null])));

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -1324,8 +1324,8 @@ fn parse_ini_value(value: &str) -> serde_yaml::Value {
 
     // Handle booleans
     match value.to_lowercase().as_str() {
-        "true" | "yes" | "on" => return serde_yaml::Value::Bool(true),
-        "false" | "no" | "off" => return serde_yaml::Value::Bool(false),
+        "true" | "yes" | "on" | "y" | "t" => return serde_yaml::Value::Bool(true),
+        "false" | "no" | "off" | "n" | "f" => return serde_yaml::Value::Bool(false),
         _ => {}
     }
 

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1588,9 +1588,20 @@ impl ModuleRegistry {
         self.categories.insert(name, category);
     }
 
+    fn normalize_module_name<'a>(name: &'a str) -> &'a str {
+        if let Some(stripped) = name.strip_prefix("ansible.builtin.") {
+            stripped.rsplit('.').next().unwrap_or(stripped)
+        } else if let Some(stripped) = name.strip_prefix("ansible.legacy.") {
+            stripped.rsplit('.').next().unwrap_or(stripped)
+        } else {
+            name
+        }
+    }
+
     /// Get the category of a module
     pub fn get_category(&self, name: &str) -> Option<ModuleCategory> {
-        self.categories.get(name).copied()
+        let normalized = Self::normalize_module_name(name);
+        self.categories.get(normalized).copied()
     }
 
     /// Get all modules in a specific category
@@ -1618,12 +1629,14 @@ impl ModuleRegistry {
 
     /// Get a module by name
     pub fn get(&self, name: &str) -> Option<Arc<dyn Module>> {
-        self.modules.get(name).cloned()
+        let normalized = Self::normalize_module_name(name);
+        self.modules.get(normalized).cloned()
     }
 
     /// Check if a module exists
     pub fn contains(&self, name: &str) -> bool {
-        self.modules.contains_key(name)
+        let normalized = Self::normalize_module_name(name);
+        self.modules.contains_key(normalized)
     }
 
     /// Get all module names
@@ -1708,6 +1721,15 @@ mod tests {
 
         let module = registry.get("test").unwrap();
         assert_eq!(module.name(), "test");
+    }
+
+    #[test]
+    fn test_module_registry_builtin_fqcn() {
+        let mut registry = ModuleRegistry::new();
+        registry.register(Arc::new(TestModule));
+
+        assert!(registry.get("ansible.builtin.test").is_some());
+        assert!(registry.get("ansible.legacy.test").is_some());
     }
 
     #[test]

--- a/src/parser/playbook.rs
+++ b/src/parser/playbook.rs
@@ -17,8 +17,8 @@ where
     match &value {
         serde_yaml::Value::Bool(b) => Ok(*b),
         serde_yaml::Value::String(s) => match s.to_lowercase().as_str() {
-            "yes" | "true" | "on" | "1" => Ok(true),
-            "no" | "false" | "off" | "0" | "" => Ok(false),
+            "yes" | "true" | "on" | "1" | "y" | "t" => Ok(true),
+            "no" | "false" | "off" | "0" | "" | "n" | "f" => Ok(false),
             _ => Err(D::Error::custom(format!("invalid boolean string: {}", s))),
         },
         serde_yaml::Value::Number(n) => {
@@ -52,8 +52,8 @@ where
         Some(serde_yaml::Value::Null) => Ok(None),
         Some(serde_yaml::Value::Bool(b)) => Ok(Some(b)),
         Some(serde_yaml::Value::String(s)) => match s.to_lowercase().as_str() {
-            "yes" | "true" | "on" | "1" => Ok(Some(true)),
-            "no" | "false" | "off" | "0" | "" => Ok(Some(false)),
+            "yes" | "true" | "on" | "1" | "y" | "t" => Ok(Some(true)),
+            "no" | "false" | "off" | "0" | "" | "n" | "f" => Ok(Some(false)),
             _ => Err(D::Error::custom(format!("invalid boolean string: {}", s))),
         },
         Some(serde_yaml::Value::Number(n)) => {
@@ -97,6 +97,15 @@ where
         }
         other => Ok(vec![format!("{:?}", other)]),
     }
+}
+
+/// Deserialize a YAML sequence, treating `null`/`~` as an empty list.
+fn deserialize_seq_or_null<'de, D, T>(deserializer: D) -> std::result::Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Ok(Option::<Vec<T>>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 /// A complete playbook containing multiple plays
@@ -571,15 +580,15 @@ pub struct Task {
     pub args: Option<IndexMap<String, serde_yaml::Value>>,
 
     /// Block of tasks (for block/rescue/always)
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_seq_or_null")]
     pub block: Vec<Task>,
 
     /// Rescue tasks (run on block failure)
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_seq_or_null")]
     pub rescue: Vec<Task>,
 
     /// Always tasks (always run after block)
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_seq_or_null")]
     pub always: Vec<Task>,
 
     /// Connection type
@@ -1179,6 +1188,34 @@ mod tests {
         assert_eq!(task.name, "Install nginx");
         assert_eq!(task.r#become, Some(true));
         assert!(task.notify.contains(&"restart nginx".to_string()));
+    }
+
+    #[test]
+    fn test_task_boolean_variants() {
+        let yaml = r#"
+name: Boolean task
+ignore_errors: y
+ignore_unreachable: f
+"#;
+
+        let task: Task = serde_yaml::from_str(yaml).unwrap();
+        assert!(task.ignore_errors);
+        assert!(!task.ignore_unreachable);
+    }
+
+    #[test]
+    fn test_task_block_null_defaults() {
+        let yaml = r#"
+name: Block task
+block:
+rescue:
+always:
+"#;
+
+        let task: Task = serde_yaml::from_str(yaml).unwrap();
+        assert!(task.block.is_empty());
+        assert!(task.rescue.is_empty());
+        assert!(task.always.is_empty());
     }
 
     #[test]

--- a/src/playbook.rs
+++ b/src/playbook.rs
@@ -84,8 +84,8 @@ where
             E: de::Error,
         {
             match value.to_lowercase().as_str() {
-                "true" | "yes" | "y" | "1" | "on" => Ok(true),
-                "false" | "no" | "n" | "0" | "off" => Ok(false),
+                "true" | "yes" | "y" | "1" | "on" | "t" => Ok(true),
+                "false" | "no" | "n" | "0" | "off" | "f" => Ok(false),
                 _ => Err(de::Error::custom(format!("invalid boolean: {}", value))),
             }
         }

--- a/src/template.rs
+++ b/src/template.rs
@@ -136,8 +136,12 @@ impl TemplateEngine {
         env.add_filter("b64encode", filter_b64encode);
         env.add_filter("b64decode", filter_b64decode);
         env.add_filter("to_json", filter_to_json);
+        env.add_filter("to_nice_json", filter_to_nice_json);
         env.add_filter("from_json", filter_from_json);
         env.add_filter("to_yaml", filter_to_yaml);
+        env.add_filter("to_nice_yaml", filter_to_nice_yaml);
+        env.add_filter("from_yaml", filter_from_yaml);
+        env.add_filter("from_yaml_all", filter_from_yaml_all);
 
         // Ansible-specific filters
         env.add_filter("mandatory", filter_mandatory);
@@ -367,8 +371,8 @@ impl TemplateEngine {
 
         // Handle literal booleans (common case)
         match expression.to_lowercase().as_str() {
-            "true" | "yes" => return Ok(true),
-            "false" | "no" => return Ok(false),
+            "true" | "yes" | "on" | "y" | "t" => return Ok(true),
+            "false" | "no" | "off" | "n" | "f" => return Ok(false),
             _ => {}
         }
 
@@ -768,6 +772,29 @@ fn filter_to_json(value: MiniJinjaValue) -> std::result::Result<String, minijinj
     })
 }
 
+fn filter_to_nice_json(
+    value: MiniJinjaValue,
+    indent: Option<usize>,
+) -> std::result::Result<String, minijinja::Error> {
+    let indent = indent.unwrap_or(4);
+    if indent == 4 {
+        serde_json::to_string_pretty(&value).map_err(|e| {
+            minijinja::Error::new(
+                ErrorKind::InvalidOperation,
+                format!("JSON serialization failed: {}", e),
+            )
+        })
+    } else {
+        let json = serde_json::to_value(&value).map_err(|e| {
+            minijinja::Error::new(
+                ErrorKind::InvalidOperation,
+                format!("JSON serialization failed: {}", e),
+            )
+        })?;
+        format_json_with_indent(&json, indent)
+    }
+}
+
 fn filter_from_json(value: &str) -> std::result::Result<MiniJinjaValue, minijinja::Error> {
     let json: serde_json::Value = serde_json::from_str(value).map_err(|e| {
         minijinja::Error::new(
@@ -783,6 +810,69 @@ fn filter_to_yaml(value: MiniJinjaValue) -> std::result::Result<String, minijinj
         minijinja::Error::new(
             ErrorKind::InvalidOperation,
             format!("YAML serialization failed: {}", e),
+        )
+    })
+}
+
+fn filter_to_nice_yaml(
+    value: MiniJinjaValue,
+    _indent: Option<usize>,
+    _width: Option<usize>,
+) -> std::result::Result<String, minijinja::Error> {
+    serde_yaml::to_string(&value).map_err(|e| {
+        minijinja::Error::new(
+            ErrorKind::InvalidOperation,
+            format!("YAML serialization failed: {}", e),
+        )
+    })
+}
+
+fn filter_from_yaml(value: &str) -> std::result::Result<MiniJinjaValue, minijinja::Error> {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(value).map_err(|e| {
+        minijinja::Error::new(
+            ErrorKind::InvalidOperation,
+            format!("YAML parse failed: {}", e),
+        )
+    })?;
+    Ok(MiniJinjaValue::from_serialize(&yaml))
+}
+
+fn filter_from_yaml_all(value: &str) -> std::result::Result<Vec<MiniJinjaValue>, minijinja::Error> {
+    use serde::Deserialize;
+
+    let mut docs = Vec::new();
+    for doc in serde_yaml::Deserializer::from_str(value) {
+        let yaml = serde_yaml::Value::deserialize(doc).map_err(|e| {
+            minijinja::Error::new(
+                ErrorKind::InvalidOperation,
+                format!("YAML parse failed: {}", e),
+            )
+        })?;
+        docs.push(MiniJinjaValue::from_serialize(&yaml));
+    }
+    Ok(docs)
+}
+
+fn format_json_with_indent(
+    value: &serde_json::Value,
+    indent: usize,
+) -> std::result::Result<String, minijinja::Error> {
+    use serde::Serialize;
+
+    let mut buf = Vec::new();
+    let indent_bytes = vec![b' '; indent];
+    let formatter = serde_json::ser::PrettyFormatter::with_indent(&indent_bytes);
+    let mut ser = serde_json::Serializer::with_formatter(&mut buf, formatter);
+    value.serialize(&mut ser).map_err(|e| {
+        minijinja::Error::new(
+            ErrorKind::InvalidOperation,
+            format!("JSON serialization failed: {}", e),
+        )
+    })?;
+    String::from_utf8(buf).map_err(|e| {
+        minijinja::Error::new(
+            ErrorKind::InvalidOperation,
+            format!("JSON serialization failed: {}", e),
         )
     })
 }
@@ -1370,5 +1460,15 @@ mod tests {
     #[test]
     fn test_filter_b64decode() {
         assert_eq!(filter_b64decode("aGVsbG8=").unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_filter_from_yaml() {
+        let engine = TemplateEngine::new();
+        let vars = HashMap::new();
+        let result = engine
+            .render("{{ ('a: 1' | from_yaml).a }}", &vars)
+            .unwrap();
+        assert_eq!(result.trim(), "1");
     }
 }

--- a/src/vars/mod.rs
+++ b/src/vars/mod.rs
@@ -820,8 +820,8 @@ pub mod resolve {
         match value {
             serde_yaml::Value::Bool(b) => Some(*b),
             serde_yaml::Value::String(s) => match s.to_lowercase().as_str() {
-                "true" | "yes" | "on" | "1" => Some(true),
-                "false" | "no" | "off" | "0" | "" => Some(false),
+                "true" | "yes" | "on" | "1" | "y" | "t" => Some(true),
+                "false" | "no" | "off" | "0" | "" | "n" | "f" => Some(false),
                 _ => None,
             },
             serde_yaml::Value::Number(n) => n.as_i64().map(|i| i != 0),

--- a/tests/yaml_compat_tests.rs
+++ b/tests/yaml_compat_tests.rs
@@ -1123,7 +1123,6 @@ fn test_hash_in_values_vs_comments() {
 // ============================================================================
 
 #[test]
-#[ignore = "to_yaml filter not implemented"]
 fn test_to_yaml_filter() {
     let engine = TemplateEngine::new();
     let mut vars = HashMap::new();
@@ -1140,7 +1139,6 @@ fn test_to_yaml_filter() {
 }
 
 #[test]
-#[ignore = "from_yaml filter not implemented"]
 fn test_from_yaml_filter() {
     let engine = TemplateEngine::new();
     let mut vars = HashMap::new();


### PR DESCRIPTION
### **User description**
## Summary\n- add missing serialization filters to the template engine and enable YAML filter tests\n- normalize ansible.builtin/ansible.legacy module names plus boolean and block parsing edge cases\n- improve CLI tag splitting and extra-vars parsing; update roadmap notes\n\n## Testing\n- cargo test parse_extra_vars (fails in existing tests: Module::diff missing in tests/common and copy_module_tests)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Improve extra-vars parsing with YAML/JSON mapping and shell-word tokenization support

- Normalize Ansible module names (ansible.builtin/ansible.legacy) across codebase

- Expand boolean string variants (y/n/t/f) for consistent Ansible compatibility

- Add missing template engine filters (to_nice_json, to_nice_yaml, from_yaml, from_yaml_all)

- Fix block/rescue/always null handling and tag comma-separation in CLI


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI: Extra-vars & Tags"]
  BOOL["Boolean Parsing"]
  MODULE["Module Names"]
  TEMPLATE["Template Filters"]
  BLOCK["Block Parsing"]
  
  CLI -- "shell-word tokenization" --> PARSE["Enhanced Parsing"]
  BOOL -- "y/n/t/f variants" --> COMPAT["Ansible Compat"]
  MODULE -- "FQCN normalization" --> COMPAT
  TEMPLATE -- "missing filters" --> COMPAT
  BLOCK -- "null defaults" --> COMPAT
  
  PARSE --> RESULT["Improved Edge Case Handling"]
  COMPAT --> RESULT
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Enhanced extra-vars parsing with multiple formats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/adolago/rustible/pull/147/files#diff-38da8705fdf2662e3e19585f900ecaa4856c7edd07d6686cc3a7a8f829fd1653">+88/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>run.rs</strong><dd><code>Add tag normalization for comma-separated values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/adolago/rustible/pull/147/files#diff-7079c843406d39d728ff06f42e40f0db69f90bcc8af65e945d8e70bc8b95c1bf">+38/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>playbook.rs</strong><dd><code>Normalize builtin/legacy module names and boolean variants</code></dd></td>
  <td><a href="https://github.com/adolago/rustible/pull/147/files#diff-32aa738116659b4dcc7e34472372083adef19d3ef5003618d9112efa55ce2bb6">+40/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>task.rs</strong><dd><code>Expand is_truthy boolean string handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/adolago/rustible/pull/147/files#diff-9203dad9236cc07f5e57e1ea81f0903141d47bdf16fce25d321e1244dc39c0b0">+22/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Add y/n/t/f boolean variants to INI parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/adolago/rustible/pull/147/files#diff-f38d8dc6b78429003fc632a8fe2965d0767030c5c1b45bd3f59b7ee3c403fb6b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Normalize FQCN module names in registry lookups</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/adolago/rustible/pull/147/files#diff-90d2c2330dd750ac18b6a3a2b13fcb041216ac7e0efef9a2ff729ebf2184f686">+25/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>playbook.rs</strong><dd><code>Add null-safe block deserialization and boolean variants</code>&nbsp; </dd></td>
  <td><a href="https://github.com/adolago/rustible/pull/147/files#diff-e011eb06bab5a6988ee30982df2356ba1b0a5a80691584c7903de66ddb04758e">+44/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>playbook.rs</strong><dd><code>Expand boolean string variant support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/adolago/rustible/pull/147/files#diff-90450c3243346ca8753dd7e952ebefc2d05a56c7a3b9a35edb4e25c4b8464a00">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>template.rs</strong><dd><code>Implement missing YAML/JSON serialization filters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/adolago/rustible/pull/147/files#diff-94a2be1bc04f2828bc51dc8bfbdc5593caf509f2c6f435755275f71c2d4de379">+102/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Add y/n/t/f boolean variants to resolver</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/adolago/rustible/pull/147/files#diff-e4cf927eb1bf38aae7225dd292d93f8551b02a41994c3787d99cd239e356b4cd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>yaml_compat_tests.rs</strong><dd><code>Enable previously ignored YAML filter tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/adolago/rustible/pull/147/files#diff-94686303bcee128156e8a4ffddd89813fb31f3a5afa928f9159ccb59df56895d">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ROADMAP.md</strong><dd><code>Update roadmap with completed edge case fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/adolago/rustible/pull/147/files#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR closes remaining Ansible compatibility edge cases across boolean parsing, module name normalization, CLI argument handling, and template filters.

**Major Changes:**
- Extended boolean parsing to support single-letter variants consistently across all parsers (playbook, executor, inventory, vars)
- Normalized FQCN module names (with `ansible.builtin` and `ansible.legacy` prefixes) to their short forms throughout the module registry and executor
- Enhanced CLI extra-vars parsing to handle JSON objects, multiple space-separated pairs, and string values containing spaces
- Added comma-separated tag support with proper trimming and normalization
- Implemented missing template filters: `to_nice_json`, `to_nice_yaml`, `from_yaml`, `from_yaml_all`
- Fixed block/rescue/always fields to treat null values as empty lists using `deserialize_seq_or_null`

**Issues Found:**
None - the implementation is solid with comprehensive test coverage for all new functionality.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk.
- All changes are well-contained edge case fixes with comprehensive test coverage. The boolean parsing, FQCN normalization, and CLI parsing enhancements follow established patterns and include proper error handling. No breaking changes or security concerns identified.
- No files require special attention - all changes include appropriate tests and follow consistent patterns.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/cli/commands/mod.rs | Enhanced extra-vars parsing to support JSON mappings, multiple space-separated pairs, and values with spaces. Added comprehensive test coverage. |
| src/executor/playbook.rs | Extended boolean parsing to support y/n/t/f variants and added normalize_builtin_module_name for FQCN handling. Well-tested. |
| src/modules/mod.rs | Added normalize_module_name to strip ansible.builtin and ansible.legacy prefixes. Includes test coverage. |
| src/parser/playbook.rs | Added deserialize_seq_or_null to handle null block/rescue/always fields as empty lists. Extended boolean variants. Well-tested. |
| src/template.rs | Added missing YAML/JSON filters (to_nice_json, to_nice_yaml, from_yaml, from_yaml_all) and extended boolean parsing. Test coverage included. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant Parser
    participant Executor
    participant Module
    participant Template

    User->>CLI: Pass extra-vars with commas/spaces/JSON
    CLI->>CLI: parse_extra_vars()
    CLI->>CLI: Trim and validate input
    alt Contains @file
        CLI->>CLI: Load vars from file
    else Contains no =
        CLI->>Parser: Parse as YAML/JSON mapping
    else Contains whitespace
        CLI->>CLI: shell_words::split()
        CLI->>CLI: Check if all tokens have =
    end
    CLI->>CLI: Store parsed variables

    User->>CLI: Pass tags with commas
    CLI->>CLI: normalize_tags()
    CLI->>CLI: Split by comma and trim

    User->>Parser: Submit playbook with FQCN modules
    Parser->>Parser: Parse boolean variants (y/n/t/f)
    Parser->>Parser: deserialize_seq_or_null() for blocks
    Parser->>Executor: Pass parsed tasks

    Executor->>Executor: normalize_builtin_module_name()
    Executor->>Executor: Strip ansible.builtin/ansible.legacy
    Executor->>Module: Look up normalized module name
    Module->>Module: normalize_module_name()
    Module->>Module: Registry lookup with stripped name
    Module->>Executor: Return module instance

    Executor->>Template: Render template with filters
    Template->>Template: Apply YAML filters (to_yaml, from_yaml)
    Template->>Template: Apply JSON filters (to_nice_json)
    Template->>Template: Parse boolean expressions (y/n/t/f/on/off)
    Template->>Executor: Return rendered output

    Executor->>Executor: Evaluate is_truthy() with extended variants
    Executor->>User: Execute tasks with normalized values
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->