### PR TITLE
Fix #165: Implement --ask-become-pass

### DIFF
--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -263,8 +263,10 @@ impl RunArgs {
             extra_vars.insert("ansible_ssh_pass".to_string(), serde_json::json!(password));
         }
 
-        let ask_become_pass =
-            self.ask_become_pass || ctx.config.privilege_escalation.become_ask_pass;
+        let ask_become_pass = Self::should_prompt_become_password(
+            self.ask_become_pass,
+            ctx.config.privilege_escalation.become_ask_pass,
+        );
         let become_password = if ask_become_pass {
             Some(Self::prompt_become_password(ctx)?)
         } else {
@@ -955,6 +957,10 @@ impl RunArgs {
             .collect()
     }
 
+    fn should_prompt_become_password(ask_become_pass: bool, config_ask_pass: bool) -> bool {
+        ask_become_pass || config_ask_pass
+    }
+
     fn prompt_ssh_password(ctx: &CommandContext) -> Result<String> {
         ctx.output.flush();
         let password = dialoguer::Password::new()
@@ -1157,9 +1163,26 @@ mod tests {
     }
 
     #[test]
+    fn test_run_args_ask_become_pass_parsing() {
+        let args =
+            RunArgs::try_parse_from(["run", "playbook.yml", "--ask-become-pass"]).unwrap();
+        assert!(args.ask_become_pass);
+
+        let args = RunArgs::try_parse_from(["run", "playbook.yml", "-K"]).unwrap();
+        assert!(args.ask_become_pass);
+    }
+
+    #[test]
     fn test_run_args_plan_flag() {
         let args = RunArgs::try_parse_from(["run", "playbook.yml", "--plan"]).unwrap();
         assert!(args.plan);
+    }
+
+    #[test]
+    fn test_should_prompt_become_password_gating() {
+        assert!(RunArgs::should_prompt_become_password(true, false));
+        assert!(RunArgs::should_prompt_become_password(false, true));
+        assert!(!RunArgs::should_prompt_become_password(false, false));
     }
 
     #[test]


### PR DESCRIPTION
Closes #165

Issue: Implement --ask-become-pass

Diffstat:
 src/cli/commands/run.rs | 27 +++++++++++++++++++++++++--
 1 file changed, 25 insertions(+), 2 deletions(-)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR successfully implements the `--ask-become-pass` flag functionality by adding secure interactive prompting for privilege escalation.

## Key Changes
- Extracted password prompting logic into `should_prompt_become_password()` helper function that checks both CLI flag and config file settings
- Added `prompt_become_password()` function using `dialoguer::Password` for secure, non-echoed input
- Properly passes the entered become password to `ExecutorConfig` for use during playbook execution
- Added comprehensive unit tests for CLI parsing (`-K` and `--ask-become-pass`) and prompt gating logic

## Implementation Quality
The implementation follows existing patterns in the codebase (mirrors the SSH password prompting), properly integrates with the configuration system, and includes test coverage for all acceptance criteria. The code is clean, well-tested, and secure.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no identified issues
- The implementation is straightforward, follows established patterns in the codebase, uses secure password input methods, includes comprehensive test coverage for all acceptance criteria, and properly integrates with both CLI and config file settings
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/cli/commands/run.rs | Implemented `--ask-become-pass` functionality with secure password prompting, proper CLI flag parsing, and comprehensive test coverage |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI as CLI Parser
    participant RunArgs
    participant Config
    participant Prompt as dialoguer::Password
    participant Executor

    User->>CLI: rustible run playbook.yml --ask-become-pass
    CLI->>RunArgs: Parse CLI arguments
    RunArgs->>RunArgs: Set ask_become_pass = true
    
    RunArgs->>RunArgs: execute()
    RunArgs->>Config: Check config.privilege_escalation.become_ask_pass
    RunArgs->>RunArgs: should_prompt_become_password(ask_become_pass, config_ask_pass)
    
    alt Prompt Required (either flag is true)
        RunArgs->>Prompt: prompt_become_password()
        Prompt->>User: Display secure input prompt
        User->>Prompt: Enter credentials
        Prompt->>RunArgs: Return entered value
        RunArgs->>RunArgs: Store in become_password variable
    else No Prompt Needed
        RunArgs->>RunArgs: Set become_password = None
    end
    
    RunArgs->>Executor: Create ExecutorConfig with become_password
    Executor->>Executor: Execute playbook with privilege escalation
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->