### PR TITLE
feat(diagnostics): surface rich parse/template errors

### DIFF
--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 use clap::Parser;
 use indexmap::IndexMap;
 use regex::Regex;
+use rustible::diagnostics::yaml_syntax_error;
 use std::path::PathBuf;
 use std::time::Instant;
 
@@ -122,8 +123,12 @@ impl RunArgs {
                 if let Some(sp) = spinner {
                     sp.finish_and_clear();
                 }
-                ctx.output
-                    .error(&format!("Failed to parse playbook: {}", e));
+                if let Some(rendered) = e.render_diagnostic() {
+                    ctx.output.diagnostic(&rendered);
+                } else {
+                    ctx.output
+                        .error(&format!("Failed to parse playbook: {}", e));
+                }
                 return Ok(1);
             }
         };
@@ -226,7 +231,23 @@ impl RunArgs {
             ctx.output
                 .plan("WARNING: Running in PLAN MODE - showing execution plan only");
             let playbook_content = std::fs::read_to_string(&self.playbook)?;
-            let playbook_yaml: serde_yaml::Value = serde_yaml::from_str(&playbook_content)?;
+            let playbook_yaml: serde_yaml::Value = match serde_yaml::from_str(&playbook_content) {
+                Ok(value) => value,
+                Err(e) => {
+                    let (line, col) =
+                        e.location().map_or((1, 1), |loc| (loc.line(), loc.column()));
+                    let diagnostic = yaml_syntax_error(
+                        &self.playbook,
+                        &playbook_content,
+                        line,
+                        col,
+                        &e.to_string(),
+                    );
+                    ctx.output
+                        .diagnostic(&diagnostic.render_with_source(Some(&playbook_content)));
+                    return Ok(1);
+                }
+            };
             if let Some(plays) = playbook_yaml.as_sequence() {
                 let extra_vars_for_plan: std::collections::HashMap<String, serde_yaml::Value> =
                     ctx.parse_extra_vars()?;
@@ -299,8 +320,12 @@ impl RunArgs {
         let results = match executor.run_playbook(&playbook).await {
             Ok(results) => results,
             Err(e) => {
-                ctx.output
-                    .error(&format!("Playbook execution failed: {}", e));
+                if let Some(rendered) = e.render_diagnostic() {
+                    ctx.output.diagnostic(&rendered);
+                } else {
+                    ctx.output
+                        .error(&format!("Playbook execution failed: {}", e));
+                }
                 return Ok(2);
             }
         };

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -511,6 +511,20 @@ impl OutputFormatter {
         }
     }
 
+    /// Print a diagnostic message without extra prefixes
+    pub fn diagnostic(&self, message: &str) {
+        if self.json_mode {
+            let err = serde_json::json!({
+                "type": "diagnostic",
+                "message": message
+            });
+            eprintln!("{}", serde_json::to_string(&err).unwrap());
+            return;
+        }
+
+        eprintln!("{}", message);
+    }
+
     /// Print a warning message
     pub fn warning(&self, message: &str) {
         if self.json_mode {

--- a/src/executor/errors.rs
+++ b/src/executor/errors.rs
@@ -1,5 +1,7 @@
 use thiserror::Error;
 
+use crate::diagnostics::RichDiagnostic;
+
 /// Errors that can occur during playbook and task execution.
 ///
 /// This enum covers all error conditions that may arise during the
@@ -38,6 +40,17 @@ pub enum ExecutorError {
     #[error("Playbook parse error: {0}")]
     ParseError(String),
 
+    /// Rich diagnostic error with source context.
+    #[error("{message}")]
+    Diagnostic {
+        /// Primary error message
+        message: String,
+        /// Rich diagnostic details
+        diagnostic: RichDiagnostic,
+        /// Source content for rendering (optional)
+        source_text: Option<String>,
+    },
+
     /// An I/O operation failed.
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
@@ -59,3 +72,27 @@ pub enum ExecutorError {
 ///
 /// A type alias for `Result<T, ExecutorError>` used throughout the executor module.
 pub type ExecutorResult<T> = Result<T, ExecutorError>;
+
+impl ExecutorError {
+    /// Create a diagnostic error from a RichDiagnostic.
+    pub fn diagnostic(diagnostic: RichDiagnostic, source: Option<String>) -> Self {
+        let message = diagnostic.message.clone();
+        Self::Diagnostic {
+            message,
+            diagnostic,
+            source_text: source,
+        }
+    }
+
+    /// Render the diagnostic if present.
+    pub fn render_diagnostic(&self) -> Option<String> {
+        match self {
+            ExecutorError::Diagnostic {
+                diagnostic,
+                source_text,
+                ..
+            } => Some(diagnostic.render_with_source(source_text.as_deref())),
+            _ => None,
+        }
+    }
+}

--- a/src/executor/playbook.rs
+++ b/src/executor/playbook.rs
@@ -110,6 +110,7 @@ where
     }
 }
 
+use crate::diagnostics::yaml_syntax_error;
 use crate::executor::task::{Handler, Task};
 use crate::executor::{ExecutorError, ExecutorResult};
 
@@ -148,8 +149,15 @@ impl Playbook {
     /// Parse a playbook from YAML content
     pub fn parse(content: &str, path: Option<PathBuf>) -> ExecutorResult<Self> {
         // Ansible playbooks are arrays of plays at the top level
-        let plays: Vec<PlayDefinition> = serde_yaml::from_str(content)
-            .map_err(|e| ExecutorError::ParseError(format!("YAML parse error: {}", e)))?;
+        let plays: Vec<PlayDefinition> = serde_yaml::from_str(content).map_err(|e| {
+            let (line, col) = e.location().map_or((1, 1), |loc| (loc.line(), loc.column()));
+            let path_buf = path
+                .clone()
+                .unwrap_or_else(|| PathBuf::from("<string>"));
+            let diagnostic =
+                yaml_syntax_error(path_buf, content, line, col, &e.to_string());
+            ExecutorError::diagnostic(diagnostic, Some(content.to_string()))
+        })?;
 
         if plays.is_empty() {
             return Err(ExecutorError::ParseError(
@@ -1506,6 +1514,22 @@ mod tests {
         let task = &play.tasks[0];
         assert_eq!(task.name, "Debug message");
         assert_eq!(task.module, "debug");
+    }
+
+    #[test]
+    fn test_parse_invalid_yaml_diagnostic() {
+        let yaml = r#"
+- name: Bad Play
+  hosts all
+  tasks:
+    - debug:
+        msg: "oops"
+"#;
+
+        let err = Playbook::parse(yaml, None).unwrap_err();
+        let rendered = err.render_diagnostic().expect("expected diagnostic");
+        assert!(rendered.contains("E0010"));
+        assert!(rendered.contains("syntax error"));
     }
 
     #[test]

--- a/src/executor/task.rs
+++ b/src/executor/task.rs
@@ -40,6 +40,8 @@ static TEMPLATE_CHECK_REGEX: Lazy<regex::Regex> =
 use crate::executor::parallelization::ParallelizationManager;
 use crate::executor::runtime::{ExecutionContext, RegisteredResult, RuntimeContext};
 use crate::executor::{ExecutorError, ExecutorResult};
+use crate::diagnostics::template_syntax_error;
+use crate::error::Error;
 use crate::modules::ModuleRegistry;
 use crate::template::TEMPLATE_ENGINE;
 
@@ -2545,7 +2547,7 @@ fn template_value(
     // Use the unified template engine for all value rendering
     TEMPLATE_ENGINE
         .render_value(value, vars)
-        .map_err(|e| ExecutorError::RuntimeError(format!("Template error: {}", e)))
+        .map_err(|e| template_error_from_value(value, e))
 }
 
 /// Template a string using variables
@@ -2558,7 +2560,52 @@ fn template_string(template: &str, vars: &IndexMap<String, JsonValue>) -> Execut
     // Use the unified template engine for all string rendering
     TEMPLATE_ENGINE
         .render_with_indexmap(template, vars)
-        .map_err(|e| ExecutorError::RuntimeError(format!("Template error: {}", e)))
+        .map_err(|e| template_error_to_executor(template, e))
+}
+
+fn template_error_from_value(value: &JsonValue, error: Error) -> ExecutorError {
+    let source = template_source_for_value(value);
+    template_error_to_executor(&source, error)
+}
+
+fn template_source_for_value(value: &JsonValue) -> String {
+    match value {
+        JsonValue::String(s) => s.clone(),
+        _ => serde_yaml::to_string(value).unwrap_or_else(|_| value.to_string()),
+    }
+}
+
+fn template_error_to_executor(template_source: &str, error: Error) -> ExecutorError {
+    match error {
+        Error::Template(mini_err) => {
+            let message = mini_err
+                .detail()
+                .map(str::to_string)
+                .unwrap_or_else(|| mini_err.to_string());
+            let line = mini_err.line().unwrap_or(1);
+            let col = 1;
+            let name = mini_err.name().unwrap_or("<template>");
+            let file = if name.starts_with("__rustible_template_") {
+                "<template>"
+            } else {
+                name
+            };
+            let diagnostic =
+                template_syntax_error(file, template_source, line, col, &message);
+            ExecutorError::diagnostic(diagnostic, Some(template_source.to_string()))
+        }
+        Error::TemplateRender { message, .. } => {
+            let diagnostic =
+                template_syntax_error("<template>", template_source, 1, 1, &message);
+            ExecutorError::diagnostic(diagnostic, Some(template_source.to_string()))
+        }
+        Error::TemplateSyntax { message, .. } => {
+            let diagnostic =
+                template_syntax_error("<template>", template_source, 1, 1, &message);
+            ExecutorError::diagnostic(diagnostic, Some(template_source.to_string()))
+        }
+        other => ExecutorError::RuntimeError(format!("Template error: {}", other)),
+    }
 }
 
 /// Convert JSON value to string for templating
@@ -2888,7 +2935,7 @@ fn evaluate_expression(expr: &str, vars: &IndexMap<String, JsonValue>) -> Execut
     // Use the unified template engine for all condition evaluation
     TEMPLATE_ENGINE
         .evaluate_condition(expr, vars)
-        .map_err(|e| ExecutorError::RuntimeError(format!("Template error: {}", e)))
+        .map_err(|e| template_error_to_executor(expr, e))
 }
 
 /// Check if a JSON value is "truthy"
@@ -3002,6 +3049,15 @@ mod tests {
 
         let result = template_string("Count: {{ count }}", &vars).unwrap();
         assert_eq!(result, "Count: 42");
+    }
+
+    #[test]
+    fn test_template_string_diagnostic() {
+        let vars = IndexMap::new();
+        let err = template_string("Hello {{", &vars).unwrap_err();
+        let rendered = err.render_diagnostic().expect("expected diagnostic");
+        assert!(rendered.contains("E0020"));
+        assert!(rendered.contains("template error"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Threads RichDiagnostic into YAML parse and template failures and renders diagnostics in CLI output with error codes and source spans.

## Changes

- Added `ExecutorError::Diagnostic` with rendering support
- Mapped YAML parse errors to `E0010` diagnostics with spans
- Mapped template errors to `E0020` diagnostics with source context
- Rendered diagnostics in `run`/plan mode without prefix noise
- Added tests for YAML and template diagnostics

## Testing

- `cargo test --lib -- parse_invalid_yaml_diagnostic template_string_diagnostic`

Closes #188
