### PR TITLE
🎨 Palette: Improve password prompts with context and icons

### DIFF
--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -5,6 +5,7 @@
 use super::{CommandContext, Runnable};
 use crate::cli::output::RecapStats;
 use anyhow::Result;
+use dialoguer::theme::ColorfulTheme;
 use clap::Parser;
 use indexmap::IndexMap;
 use regex::Regex;
@@ -285,7 +286,7 @@ impl RunArgs {
             .any(|host| runtime.get_var("ansible_ssh_pass", Some(host)).is_some());
         let ssh_password = if !has_extra_ssh_pass && !has_inventory_ssh_pass {
             if self.ask_pass {
-                Some(Self::prompt_ssh_password(ctx)?)
+                Some(Self::prompt_ssh_password(ctx, self.user.as_deref())?)
             } else {
                 crate::cli::env::ssh_password()
             }
@@ -301,7 +302,7 @@ impl RunArgs {
             ctx.config.privilege_escalation.become_ask_pass,
         );
         let become_password = if ask_become_pass {
-            Some(Self::prompt_become_password(ctx)?)
+            Some(Self::prompt_become_password(ctx, &self.become_user)?)
         } else {
             None
         };
@@ -998,18 +999,26 @@ impl RunArgs {
         ask_become_pass || config_ask_pass
     }
 
-    fn prompt_ssh_password(ctx: &CommandContext) -> Result<String> {
+    fn prompt_ssh_password(ctx: &CommandContext, user: Option<&str>) -> Result<String> {
         ctx.output.flush();
-        let password = dialoguer::Password::new()
-            .with_prompt("SSH password")
+        let prompt = if let Some(u) = user {
+            format!("🔑 SSH Password for '{}'", u)
+        } else {
+            "🔑 SSH Password".to_string()
+        };
+
+        let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
+            .with_prompt(prompt)
             .interact()?;
         Ok(password)
     }
 
-    fn prompt_become_password(ctx: &CommandContext) -> Result<String> {
+    fn prompt_become_password(ctx: &CommandContext, user: &str) -> Result<String> {
         ctx.output.flush();
-        let password = dialoguer::Password::new()
-            .with_prompt("Become password")
+        let prompt = format!("⚡ Privilege Escalation Password for '{}'", user);
+
+        let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
+            .with_prompt(prompt)
             .interact()?;
         Ok(password)
     }


### PR DESCRIPTION
Improved the UX of password prompts in the CLI `run` command.

**Changes:**
- Added `dialoguer::theme::ColorfulTheme` to `src/cli/commands/run.rs` imports.
- Updated `prompt_ssh_password` to show "🔑 SSH Password for 'user'" instead of generic "SSH password".
- Updated `prompt_become_password` to show "⚡ Privilege Escalation Password for 'root'" instead of generic "Become password".
- Updated call sites in `execute` method to pass the relevant user context.

**Why:**
- Users running playbooks against multiple environments or with different users found generic prompts confusing.
- Visual polish aligns with the project's interactive mode aesthetics.

**Verification:**
- `cargo check` passed.
- `cargo test --bin rustible cli::commands::run` passed.
- Code review approved.

---
*PR created automatically by Jules for task [9813610784117397096](https://jules.google.com/task/9813610784117397096) started by @dolagoartur*