### PR TITLE
Add Ansible parity scorecard tests for issue #284

### DIFF
--- a/tests/fixtures/parity_scorecard_baseline.json
+++ b/tests/fixtures/parity_scorecard_baseline.json
@@ -1,0 +1,1013 @@
+{
+  "modules": [
+    {
+      "name": "file",
+      "description": "File and directory management",
+      "usage_weight": 0.95,
+      "features": [
+        {
+          "name": "path",
+          "description": "Path management",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "state",
+          "description": "State management (file/directory/absent/link)",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "mode",
+          "description": "Permission management",
+          "status": "Full",
+          "weight": 0.9,
+          "notes": null
+        },
+        {
+          "name": "owner",
+          "description": "Owner management",
+          "status": "Full",
+          "weight": 0.8,
+          "notes": null
+        },
+        {
+          "name": "group",
+          "description": "Group management",
+          "status": "Full",
+          "weight": 0.8,
+          "notes": null
+        },
+        {
+          "name": "recurse",
+          "description": "Recursive operations",
+          "status": "Full",
+          "weight": 0.6,
+          "notes": null
+        },
+        {
+          "name": "src",
+          "description": "Source for links",
+          "status": "Full",
+          "weight": 0.5,
+          "notes": null
+        },
+        {
+          "name": "follow",
+          "description": "Follow symlinks",
+          "status": "Partial",
+          "weight": 0.4,
+          "notes": null
+        },
+        {
+          "name": "force",
+          "description": "Force operations",
+          "status": "Full",
+          "weight": 0.4,
+          "notes": null
+        },
+        {
+          "name": "selevel",
+          "description": "SELinux level",
+          "status": "NotApplicable",
+          "weight": 0.1,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "copy",
+      "description": "Copy files to remote",
+      "usage_weight": 0.9,
+      "features": [
+        {
+          "name": "src",
+          "description": "Source file",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "dest",
+          "description": "Destination path",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "content",
+          "description": "Inline content",
+          "status": "Full",
+          "weight": 0.9,
+          "notes": null
+        },
+        {
+          "name": "backup",
+          "description": "Create backup",
+          "status": "Full",
+          "weight": 0.6,
+          "notes": null
+        },
+        {
+          "name": "mode",
+          "description": "File mode",
+          "status": "Full",
+          "weight": 0.8,
+          "notes": null
+        },
+        {
+          "name": "owner",
+          "description": "File owner",
+          "status": "Full",
+          "weight": 0.7,
+          "notes": null
+        },
+        {
+          "name": "group",
+          "description": "File group",
+          "status": "Full",
+          "weight": 0.7,
+          "notes": null
+        },
+        {
+          "name": "validate",
+          "description": "Validation command",
+          "status": "Partial",
+          "weight": 0.4,
+          "notes": null
+        },
+        {
+          "name": "remote_src",
+          "description": "Remote source",
+          "status": "Partial",
+          "weight": 0.3,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "template",
+      "description": "Jinja2 template rendering",
+      "usage_weight": 0.9,
+      "features": [
+        {
+          "name": "src",
+          "description": "Template source",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "dest",
+          "description": "Destination path",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "mode",
+          "description": "File mode",
+          "status": "Full",
+          "weight": 0.8,
+          "notes": null
+        },
+        {
+          "name": "owner",
+          "description": "File owner",
+          "status": "Full",
+          "weight": 0.7,
+          "notes": null
+        },
+        {
+          "name": "group",
+          "description": "File group",
+          "status": "Full",
+          "weight": 0.7,
+          "notes": null
+        },
+        {
+          "name": "backup",
+          "description": "Create backup",
+          "status": "Full",
+          "weight": 0.5,
+          "notes": null
+        },
+        {
+          "name": "validate",
+          "description": "Validation command",
+          "status": "Partial",
+          "weight": 0.4,
+          "notes": null
+        },
+        {
+          "name": "block_start",
+          "description": "Block markers",
+          "status": "Full",
+          "weight": 0.2,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "package",
+      "description": "Generic package management",
+      "usage_weight": 0.85,
+      "features": [
+        {
+          "name": "name",
+          "description": "Package name(s)",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "state",
+          "description": "Package state",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "version",
+          "description": "Package version",
+          "status": "Full",
+          "weight": 0.6,
+          "notes": null
+        },
+        {
+          "name": "use",
+          "description": "Package manager selection",
+          "status": "Partial",
+          "weight": 0.4,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "service",
+      "description": "Service management",
+      "usage_weight": 0.85,
+      "features": [
+        {
+          "name": "name",
+          "description": "Service name",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "state",
+          "description": "Service state",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "enabled",
+          "description": "Start on boot",
+          "status": "Full",
+          "weight": 0.9,
+          "notes": null
+        },
+        {
+          "name": "pattern",
+          "description": "Process pattern match",
+          "status": "Partial",
+          "weight": 0.3,
+          "notes": null
+        },
+        {
+          "name": "sleep",
+          "description": "Sleep between actions",
+          "status": "Partial",
+          "weight": 0.2,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "command",
+      "description": "Execute commands",
+      "usage_weight": 0.8,
+      "features": [
+        {
+          "name": "cmd",
+          "description": "Command string",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "argv",
+          "description": "Command as list",
+          "status": "Full",
+          "weight": 0.7,
+          "notes": null
+        },
+        {
+          "name": "chdir",
+          "description": "Working directory",
+          "status": "Full",
+          "weight": 0.8,
+          "notes": null
+        },
+        {
+          "name": "creates",
+          "description": "Skip if exists",
+          "status": "Full",
+          "weight": 0.7,
+          "notes": null
+        },
+        {
+          "name": "removes",
+          "description": "Skip if not exists",
+          "status": "Full",
+          "weight": 0.6,
+          "notes": null
+        },
+        {
+          "name": "stdin",
+          "description": "Standard input",
+          "status": "Partial",
+          "weight": 0.3,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "shell",
+      "description": "Execute shell commands",
+      "usage_weight": 0.75,
+      "features": [
+        {
+          "name": "cmd",
+          "description": "Shell command",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "chdir",
+          "description": "Working directory",
+          "status": "Full",
+          "weight": 0.8,
+          "notes": null
+        },
+        {
+          "name": "executable",
+          "description": "Shell executable",
+          "status": "Full",
+          "weight": 0.5,
+          "notes": null
+        },
+        {
+          "name": "creates",
+          "description": "Skip if exists",
+          "status": "Full",
+          "weight": 0.6,
+          "notes": null
+        },
+        {
+          "name": "removes",
+          "description": "Skip if not exists",
+          "status": "Full",
+          "weight": 0.5,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "user",
+      "description": "User management",
+      "usage_weight": 0.7,
+      "features": [
+        {
+          "name": "name",
+          "description": "Username",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "state",
+          "description": "User state",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "uid",
+          "description": "User ID",
+          "status": "Full",
+          "weight": 0.6,
+          "notes": null
+        },
+        {
+          "name": "groups",
+          "description": "Groups",
+          "status": "Full",
+          "weight": 0.8,
+          "notes": null
+        },
+        {
+          "name": "shell",
+          "description": "Login shell",
+          "status": "Full",
+          "weight": 0.7,
+          "notes": null
+        },
+        {
+          "name": "home",
+          "description": "Home directory",
+          "status": "Full",
+          "weight": 0.7,
+          "notes": null
+        },
+        {
+          "name": "password",
+          "description": "Password hash",
+          "status": "Partial",
+          "weight": 0.5,
+          "notes": null
+        },
+        {
+          "name": "ssh_key",
+          "description": "SSH key management",
+          "status": "Partial",
+          "weight": 0.4,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "group",
+      "description": "Group management",
+      "usage_weight": 0.65,
+      "features": [
+        {
+          "name": "name",
+          "description": "Group name",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "state",
+          "description": "Group state",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "gid",
+          "description": "Group ID",
+          "status": "Full",
+          "weight": 0.6,
+          "notes": null
+        },
+        {
+          "name": "system",
+          "description": "System group",
+          "status": "Full",
+          "weight": 0.4,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "lineinfile",
+      "description": "Line in file management",
+      "usage_weight": 0.7,
+      "features": [
+        {
+          "name": "path",
+          "description": "File path",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "line",
+          "description": "Line content",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "regexp",
+          "description": "Regex match",
+          "status": "Full",
+          "weight": 0.9,
+          "notes": null
+        },
+        {
+          "name": "state",
+          "description": "Line state",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "insertafter",
+          "description": "Insert after",
+          "status": "Full",
+          "weight": 0.7,
+          "notes": null
+        },
+        {
+          "name": "insertbefore",
+          "description": "Insert before",
+          "status": "Full",
+          "weight": 0.6,
+          "notes": null
+        },
+        {
+          "name": "backrefs",
+          "description": "Backreferences",
+          "status": "Partial",
+          "weight": 0.4,
+          "notes": null
+        },
+        {
+          "name": "firstmatch",
+          "description": "First match only",
+          "status": "Full",
+          "weight": 0.3,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "debug",
+      "description": "Debug output",
+      "usage_weight": 0.8,
+      "features": [
+        {
+          "name": "msg",
+          "description": "Message output",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "var",
+          "description": "Variable output",
+          "status": "Full",
+          "weight": 0.9,
+          "notes": null
+        },
+        {
+          "name": "verbosity",
+          "description": "Verbosity level",
+          "status": "Full",
+          "weight": 0.5,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "stat",
+      "description": "File statistics",
+      "usage_weight": 0.65,
+      "features": [
+        {
+          "name": "path",
+          "description": "File path",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "follow",
+          "description": "Follow symlinks",
+          "status": "Full",
+          "weight": 0.6,
+          "notes": null
+        },
+        {
+          "name": "get_checksum",
+          "description": "Compute checksum",
+          "status": "Full",
+          "weight": 0.8,
+          "notes": null
+        },
+        {
+          "name": "checksum_algorithm",
+          "description": "Hash algorithm",
+          "status": "Full",
+          "weight": 0.5,
+          "notes": null
+        },
+        {
+          "name": "get_mime",
+          "description": "MIME type",
+          "status": "Partial",
+          "weight": 0.3,
+          "notes": null
+        },
+        {
+          "name": "get_attributes",
+          "description": "Extended attributes",
+          "status": "Partial",
+          "weight": 0.2,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "git",
+      "description": "Git repository management",
+      "usage_weight": 0.6,
+      "features": [
+        {
+          "name": "repo",
+          "description": "Repository URL",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "dest",
+          "description": "Destination path",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "version",
+          "description": "Version/branch/tag",
+          "status": "Full",
+          "weight": 0.9,
+          "notes": null
+        },
+        {
+          "name": "force",
+          "description": "Force checkout",
+          "status": "Full",
+          "weight": 0.6,
+          "notes": null
+        },
+        {
+          "name": "update",
+          "description": "Update existing",
+          "status": "Full",
+          "weight": 0.7,
+          "notes": null
+        },
+        {
+          "name": "depth",
+          "description": "Clone depth",
+          "status": "Partial",
+          "weight": 0.4,
+          "notes": null
+        },
+        {
+          "name": "key_file",
+          "description": "SSH key file",
+          "status": "Partial",
+          "weight": 0.3,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "apt",
+      "description": "APT package management",
+      "usage_weight": 0.75,
+      "features": [
+        {
+          "name": "name",
+          "description": "Package name(s)",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "state",
+          "description": "Package state",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "update_cache",
+          "description": "Update cache",
+          "status": "Full",
+          "weight": 0.9,
+          "notes": null
+        },
+        {
+          "name": "cache_valid_time",
+          "description": "Cache validity",
+          "status": "Full",
+          "weight": 0.6,
+          "notes": null
+        },
+        {
+          "name": "deb",
+          "description": "Install .deb file",
+          "status": "Partial",
+          "weight": 0.4,
+          "notes": null
+        },
+        {
+          "name": "dpkg_options",
+          "description": "dpkg options",
+          "status": "Partial",
+          "weight": 0.3,
+          "notes": null
+        },
+        {
+          "name": "autoremove",
+          "description": "Auto remove",
+          "status": "Full",
+          "weight": 0.5,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "yum",
+      "description": "YUM package management",
+      "usage_weight": 0.7,
+      "features": [
+        {
+          "name": "name",
+          "description": "Package name(s)",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "state",
+          "description": "Package state",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "enablerepo",
+          "description": "Enable repo",
+          "status": "Partial",
+          "weight": 0.5,
+          "notes": null
+        },
+        {
+          "name": "disablerepo",
+          "description": "Disable repo",
+          "status": "Partial",
+          "weight": 0.4,
+          "notes": null
+        },
+        {
+          "name": "update_cache",
+          "description": "Update cache",
+          "status": "Full",
+          "weight": 0.6,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "systemd",
+      "description": "Systemd unit management",
+      "usage_weight": 0.8,
+      "features": [
+        {
+          "name": "name",
+          "description": "Unit name",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "state",
+          "description": "Unit state",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "enabled",
+          "description": "Enable unit",
+          "status": "Full",
+          "weight": 0.9,
+          "notes": null
+        },
+        {
+          "name": "daemon_reload",
+          "description": "Reload daemon",
+          "status": "Full",
+          "weight": 0.8,
+          "notes": null
+        },
+        {
+          "name": "masked",
+          "description": "Mask unit",
+          "status": "Partial",
+          "weight": 0.3,
+          "notes": null
+        },
+        {
+          "name": "scope",
+          "description": "Scope",
+          "status": "Partial",
+          "weight": 0.2,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "uri",
+      "description": "HTTP requests",
+      "usage_weight": 0.55,
+      "features": [
+        {
+          "name": "url",
+          "description": "Request URL",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "method",
+          "description": "HTTP method",
+          "status": "Full",
+          "weight": 0.9,
+          "notes": null
+        },
+        {
+          "name": "body",
+          "description": "Request body",
+          "status": "Full",
+          "weight": 0.7,
+          "notes": null
+        },
+        {
+          "name": "headers",
+          "description": "HTTP headers",
+          "status": "Full",
+          "weight": 0.8,
+          "notes": null
+        },
+        {
+          "name": "status_code",
+          "description": "Expected status",
+          "status": "Full",
+          "weight": 0.7,
+          "notes": null
+        },
+        {
+          "name": "return_content",
+          "description": "Return content",
+          "status": "Full",
+          "weight": 0.6,
+          "notes": null
+        },
+        {
+          "name": "validate_certs",
+          "description": "Cert validation",
+          "status": "Partial",
+          "weight": 0.4,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "get_url",
+      "description": "Download files",
+      "usage_weight": 0.6,
+      "features": [
+        {
+          "name": "url",
+          "description": "Download URL",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "dest",
+          "description": "Destination path",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "checksum",
+          "description": "Checksum validation",
+          "status": "Full",
+          "weight": 0.7,
+          "notes": null
+        },
+        {
+          "name": "mode",
+          "description": "File mode",
+          "status": "Full",
+          "weight": 0.6,
+          "notes": null
+        },
+        {
+          "name": "owner",
+          "description": "File owner",
+          "status": "Full",
+          "weight": 0.5,
+          "notes": null
+        },
+        {
+          "name": "force",
+          "description": "Force download",
+          "status": "Full",
+          "weight": 0.5,
+          "notes": null
+        },
+        {
+          "name": "validate_certs",
+          "description": "Cert validation",
+          "status": "Partial",
+          "weight": 0.4,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "set_fact",
+      "description": "Set host facts",
+      "usage_weight": 0.8,
+      "features": [
+        {
+          "name": "key_value",
+          "description": "Set facts",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "cacheable",
+          "description": "Cache facts",
+          "status": "Full",
+          "weight": 0.5,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "name": "wait_for",
+      "description": "Wait for conditions",
+      "usage_weight": 0.55,
+      "features": [
+        {
+          "name": "host",
+          "description": "Host to wait for",
+          "status": "Full",
+          "weight": 0.8,
+          "notes": null
+        },
+        {
+          "name": "port",
+          "description": "Port to wait for",
+          "status": "Full",
+          "weight": 1.0,
+          "notes": null
+        },
+        {
+          "name": "path",
+          "description": "Path to wait for",
+          "status": "Full",
+          "weight": 0.8,
+          "notes": null
+        },
+        {
+          "name": "state",
+          "description": "Wait state",
+          "status": "Full",
+          "weight": 0.9,
+          "notes": null
+        },
+        {
+          "name": "timeout",
+          "description": "Timeout",
+          "status": "Full",
+          "weight": 0.8,
+          "notes": null
+        },
+        {
+          "name": "delay",
+          "description": "Initial delay",
+          "status": "Full",
+          "weight": 0.5,
+          "notes": null
+        },
+        {
+          "name": "search_regex",
+          "description": "Search pattern",
+          "status": "Partial",
+          "weight": 0.4,
+          "notes": null
+        }
+      ]
+    }
+  ],
+  "minimum_score": 0.7
+}

--- a/tests/parity_scorecard_tests.rs
+++ b/tests/parity_scorecard_tests.rs
@@ -4,13 +4,17 @@
 //! CI fails on regressions - scores must not decrease.
 
 use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
 
 // ============================================================================
 // Parity Scoring System
 // ============================================================================
 
 /// Feature parity status
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ParityStatus {
     /// Feature fully implemented and tested
     Full,
@@ -41,7 +45,7 @@ impl ParityStatus {
 }
 
 /// Feature definition with parity tracking
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Feature {
     pub name: String,
     pub description: String,
@@ -72,7 +76,7 @@ impl Feature {
 }
 
 /// Module parity definition
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModuleParity {
     pub name: String,
     pub description: String,
@@ -138,7 +142,7 @@ impl ModuleParity {
 }
 
 /// Overall parity scorecard
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ParityScorecard {
     pub modules: Vec<ModuleParity>,
     /// Minimum acceptable overall score (CI gate)
@@ -486,9 +490,29 @@ fn build_current_scorecard() -> ParityScorecard {
 
 /// Build baseline scorecard (previous known-good state)
 fn build_baseline_scorecard() -> ParityScorecard {
-    // Baseline should match current for tests to pass
-    // In production, this would be loaded from a committed file
-    build_current_scorecard()
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("parity_scorecard_baseline.json");
+    let content = fs::read_to_string(&path)
+        .unwrap_or_else(|_| panic!("Missing baseline scorecard file at {}", path.display()));
+    serde_json::from_str(&content)
+        .unwrap_or_else(|err| panic!("Failed to parse baseline scorecard: {err}"))
+}
+
+#[test]
+#[ignore]
+fn write_baseline_snapshot() {
+    let scorecard = build_current_scorecard();
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("parity_scorecard_baseline.json");
+    let serialized = serde_json::to_string_pretty(&scorecard)
+        .expect("Should serialize baseline scorecard");
+    fs::create_dir_all(path.parent().expect("baseline directory"))
+        .expect("Should create baseline directory");
+    fs::write(&path, serialized).expect("Should write baseline file");
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Usage-weighted Ansible parity scorecard with CI gate
- 28 tests for score computation and regression detection
- Blocks merges that reduce parity scores

## Parity Scoring System

### Status Levels
| Status | Score | Description |
|--------|-------|-------------|
| Full | 1.0 | Feature fully implemented and tested |
| Partial | 0.5 | Feature partially implemented |
| Planned | 0.0 | Feature planned but not implemented |
| NotApplicable | - | Feature not relevant to Rust impl |
| NotPlanned | 0.0 | Feature explicitly not planned |

### Weighted Scoring
- **Feature weights**: Based on usage frequency (0.0 - 1.0)
- **Module weights**: Based on overall module usage (0.0 - 1.0)
- **Overall score**: Weighted average across all modules

## Modules Tracked (20+)
- **File Management**: file, copy, template, lineinfile
- **Package Management**: package, apt, yum
- **Service Management**: service, systemd
- **User/Group**: user, group
- **Commands**: command, shell
- **Utilities**: debug, stat, set_fact, wait_for
- **Network**: uri, get_url
- **Source Control**: git

## CI Gate Features
- **Minimum score**: 70% overall parity required
- **Regression detection**: Per-module and overall tracking
- **High-usage priority**: Modules with >80% usage must have >80% parity
- **Output formats**: Markdown (docs) and JSON (CI automation)

## Test Coverage
- Score computation tests
- Weighted average calculations
- CI threshold enforcement
- Regression detection accuracy
- Output format validation
- Module coverage validation
- CI guards for all invariants

## Test Plan
- [x] All 28 tests pass locally with `cargo test parity_scorecard`
- [x] Current scorecard passes 70% CI gate
- [x] Regression detection correctly identifies score decreases

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)