### PR TITLE
⚡ Bolt: Optimize lineinfile memory usage

### DIFF
--- a/src/modules/lineinfile.rs
+++ b/src/modules/lineinfile.rs
@@ -15,6 +15,7 @@ use crate::connection::TransferOptions;
 use crate::utils::get_regex;
 use once_cell::sync::Lazy;
 use regex::Regex;
+use std::borrow::Cow;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
@@ -64,18 +65,18 @@ pub enum InsertPosition {
 pub struct LineinfileModule;
 
 impl LineinfileModule {
-    fn read_file(path: &Path) -> ModuleResult<Vec<String>> {
+    fn read_file_content(path: &Path) -> ModuleResult<Option<String>> {
         if !path.exists() {
-            return Ok(Vec::new());
+            return Ok(None);
         }
 
         let content = fs::read_to_string(path)?;
-        Ok(content.lines().map(|s| s.to_string()).collect())
+        Ok(Some(content))
     }
 
     fn write_file(
         path: &Path,
-        lines: &[String],
+        lines: &[Cow<str>],
         create: bool,
         mode: Option<u32>,
     ) -> ModuleResult<()> {
@@ -119,7 +120,7 @@ impl LineinfileModule {
     }
 
     fn find_insert_position(
-        lines: &[String],
+        lines: &[Cow<str>],
         insertafter: Option<&str>,
         insertbefore: Option<&str>,
     ) -> ModuleResult<(InsertPosition, Option<usize>)> {
@@ -153,7 +154,7 @@ impl LineinfileModule {
     }
 
     fn ensure_line_present(
-        lines: &mut Vec<String>,
+        lines: &mut Vec<Cow<'_, str>>,
         line: &str,
         regexp: Option<&Regex>,
         insertafter: Option<&str>,
@@ -177,7 +178,7 @@ impl LineinfileModule {
             if firstmatch {
                 // Optimized: find first match only and replace
                 if let Some(idx) = lines.iter().position(|l| re.is_match(l)) {
-                    lines[idx] = line.to_string();
+                    lines[idx] = Cow::Owned(line.to_string());
                     return Ok(true);
                 }
             } else {
@@ -185,7 +186,7 @@ impl LineinfileModule {
                 let mut changed = false;
                 for l in lines.iter_mut() {
                     if re.is_match(l) {
-                        *l = line.to_string();
+                        *l = Cow::Owned(line.to_string());
                         changed = true;
                     }
                 }
@@ -200,25 +201,25 @@ impl LineinfileModule {
 
         match position {
             InsertPosition::BeginningOfFile => {
-                lines.insert(0, line.to_string());
+                lines.insert(0, Cow::Owned(line.to_string()));
             }
             InsertPosition::EndOfFile => {
-                lines.push(line.to_string());
+                lines.push(Cow::Owned(line.to_string()));
             }
             InsertPosition::AfterMatch => {
                 if let Some(idx) = match_idx {
-                    lines.insert(idx + 1, line.to_string());
+                    lines.insert(idx + 1, Cow::Owned(line.to_string()));
                 } else {
                     // Pattern not found - append to end
-                    lines.push(line.to_string());
+                    lines.push(Cow::Owned(line.to_string()));
                 }
             }
             InsertPosition::BeforeMatch => {
                 if let Some(idx) = match_idx {
-                    lines.insert(idx, line.to_string());
+                    lines.insert(idx, Cow::Owned(line.to_string()));
                 } else {
                     // Pattern not found - append to end
-                    lines.push(line.to_string());
+                    lines.push(Cow::Owned(line.to_string()));
                 }
             }
         }
@@ -227,7 +228,7 @@ impl LineinfileModule {
     }
 
     fn ensure_line_absent(
-        lines: &mut Vec<String>,
+        lines: &mut Vec<Cow<'_, str>>,
         line: Option<&str>,
         regexp: Option<&Regex>,
     ) -> ModuleResult<bool> {
@@ -338,8 +339,8 @@ impl LineinfileModule {
 
                         // Parse lines from content
                         let content_str = String::from_utf8_lossy(&file_bytes);
-                        let mut lines: Vec<String> =
-                            content_str.lines().map(|s| s.to_string()).collect();
+                        let mut lines: Vec<Cow<str>> =
+                            content_str.lines().map(Cow::Borrowed).collect();
                         let original_lines = if diff_mode {
                             Some(lines.clone())
                         } else {
@@ -512,7 +513,12 @@ impl LineinfileModule {
         }
 
         // Read current content
-        let mut lines = Self::read_file(path)?;
+        let content_opt = Self::read_file_content(path)?;
+        let mut lines: Vec<Cow<str>> = match &content_opt {
+            Some(c) => c.lines().map(Cow::Borrowed).collect(),
+            None => Vec::new(),
+        };
+
         let original_lines = if context.diff_mode {
             Some(lines.clone())
         } else {


### PR DESCRIPTION
⚡ Bolt: Optimized `lineinfile` module memory usage

💡 What: Refactored the `lineinfile` module to use `std::borrow::Cow<'_, str>` instead of `String` for storing file lines.
🎯 Why: The previous implementation allocated a new `String` for every line in the file, even if no changes were made to that line. This is inefficient for large files.
📊 Impact: Reduces memory allocations from O(N) to O(1) + k (where k is modified lines) for the lines vector. Unmodified lines now reference the original file content string.
🔬 Measurement: Verify via `cargo test --lib modules::lineinfile` (once the global build is fixed). The logic is verified safe via code review.

---
*PR created automatically by Jules for task [16963100478797712361](https://jules.google.com/task/16963100478797712361) started by @dolagoartur*