### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU race condition in file modules

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -47,3 +47,8 @@
 **Vulnerability:** The `user` and `script` modules were using hardcoded `/tmp` paths for temporary files. This ignores system configuration (`TMPDIR`) and can cause failures on systems where `/tmp` is mounted with `noexec` or is otherwise restricted.
 **Learning:** Hardcoding `/tmp` is brittle and potentially insecure in multi-tenant environments. Applications should respect environment variables or configuration for temporary directories.
 **Prevention:** Use a helper function to resolve the temporary directory from configuration (e.g., `ansible_remote_tmp`) or environment variables, falling back to `/tmp` only if necessary.
+
+## 2025-05-31 - Insecure File Creation (TOCTOU) in Lineinfile/Blockinfile
+**Vulnerability:** The `lineinfile` and `blockinfile` modules were using `fs::write` followed by `fs::set_permissions`, creating a race condition where the file existed with default permissions (potentially world-readable) before being restricted.
+**Learning:** Convenience functions like `fs::write` are not secure when specific permissions are required for sensitive files. Atomicity is key.
+**Prevention:** Use `std::fs::OpenOptions` with platform-specific extensions (like `OpenOptionsExt` on Unix) to set permissions *at creation time* (e.g., `options.mode(0o600)`).

--- a/src/modules/blockinfile.rs
+++ b/src/modules/blockinfile.rs
@@ -7,8 +7,8 @@ use super::{
     Diff, Module, ModuleClassification, ModuleContext, ModuleError, ModuleOutput, ModuleParams,
     ModuleResult, ParamExt,
 };
+use crate::utils::secure_write_file;
 use std::fs;
-use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
 /// Desired state for a block
@@ -80,11 +80,9 @@ impl BlockinfileModule {
             format!("{}\n", lines.join("\n"))
         };
 
-        fs::write(path, content)?;
-
-        if let Some(mode) = mode {
-            fs::set_permissions(path, fs::Permissions::from_mode(mode))?;
-        }
+        secure_write_file(path, &content, create, mode).map_err(|e| {
+            ModuleError::ExecutionFailed(format!("Failed to write file '{}': {}", path.display(), e))
+        })?;
 
         Ok(())
     }

--- a/src/modules/lineinfile.rs
+++ b/src/modules/lineinfile.rs
@@ -12,11 +12,10 @@ use super::{
     ModuleResult, ParamExt,
 };
 use crate::connection::TransferOptions;
-use crate::utils::get_regex;
+use crate::utils::{get_regex, secure_write_file};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::fs;
-use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
 /// Desired state for a line
@@ -99,11 +98,9 @@ impl LineinfileModule {
             format!("{}\n", lines.join("\n"))
         };
 
-        fs::write(path, content)?;
-
-        if let Some(mode) = mode {
-            fs::set_permissions(path, fs::Permissions::from_mode(mode))?;
-        }
+        secure_write_file(path, &content, create, mode).map_err(|e| {
+            ModuleError::ExecutionFailed(format!("Failed to write file '{}': {}", path.display(), e))
+        })?;
 
         Ok(())
     }

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -1,0 +1,144 @@
+//! Filesystem utility functions.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+
+/// Write content to a file with secure permission handling.
+///
+/// This function uses `OpenOptions` to atomically set permissions when creating a new file
+/// on Unix systems, preventing TOCTOU race conditions where a file might be created
+/// with default permissions (e.g., world-readable) before being restricted.
+///
+/// # Arguments
+///
+/// * `path` - Path to the file
+/// * `content` - Content to write
+/// * `create` - Whether to create the file if it doesn't exist. If false and file doesn't exist, fails.
+/// * `mode` - Optional file mode (permissions) to set (Unix only)
+pub fn secure_write_file(
+    path: &Path,
+    content: &str,
+    create: bool,
+    mode: Option<u32>,
+) -> std::io::Result<()> {
+    let mut options = OpenOptions::new();
+    options.write(true).truncate(true);
+
+    if create {
+        options.create(true);
+    } else {
+        options.create(false);
+    }
+
+    #[cfg(unix)]
+    if let Some(m) = mode {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(m);
+    }
+
+    let mut file = options.open(path)?;
+    file.write_all(content.as_bytes())?;
+
+    // On Unix, OpenOptions.mode() only applies when a NEW file is created.
+    // If the file already existed, we must explicitly set permissions to ensure they match.
+    // If it was just created, this is redundant but harmless (and ensures consistency).
+    #[cfg(unix)]
+    if let Some(m) = mode {
+        use std::os::unix::fs::PermissionsExt;
+        let metadata = file.metadata()?;
+        if (metadata.permissions().mode() & 0o7777) != m {
+            let mut perms = metadata.permissions();
+            perms.set_mode(m);
+            file.set_permissions(perms)?;
+        }
+    }
+
+    // On non-Unix systems, we can't easily set mode atomically or via OpenOptions,
+    // but we can try to set it after writing if supported/needed.
+    // For now, this is a no-op as Rust's std::fs::Permissions handles basic readonly/etc.
+    // but not full octal modes on Windows.
+    #[cfg(not(unix))]
+    if let Some(_m) = mode {
+        // Mode setting not fully supported on non-Unix platforms in this context
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_secure_write_file_create() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("test.txt");
+        let content = "hello world";
+
+        secure_write_file(&path, content, true, None).unwrap();
+
+        assert!(path.exists());
+        assert_eq!(fs::read_to_string(&path).unwrap(), content);
+    }
+
+    #[test]
+    fn test_secure_write_file_no_create_fails() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("test.txt");
+        let content = "hello world";
+
+        let result = secure_write_file(&path, content, false, None);
+        assert!(result.is_err());
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn test_secure_write_file_overwrite() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("test.txt");
+        fs::write(&path, "old content").unwrap();
+
+        secure_write_file(&path, "new content", true, None).unwrap();
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), "new content");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_secure_write_file_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("secret.txt");
+        let content = "secret";
+        let mode = 0o600;
+
+        secure_write_file(&path, content, true, Some(mode)).unwrap();
+
+        let meta = fs::metadata(&path).unwrap();
+        assert_eq!(meta.permissions().mode() & 0o7777, mode);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_secure_write_file_update_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("secret.txt");
+        let content = "secret";
+
+        // Create with 0644
+        secure_write_file(&path, content, true, Some(0o644)).unwrap();
+        let meta = fs::metadata(&path).unwrap();
+        assert_eq!(meta.permissions().mode() & 0o7777, 0o644);
+
+        // Update to 0600
+        secure_write_file(&path, content, true, Some(0o600)).unwrap();
+        let meta = fs::metadata(&path).unwrap();
+        assert_eq!(meta.permissions().mode() & 0o7777, 0o600);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,6 +3,9 @@
 pub mod regex_cache;
 pub use regex_cache::get_regex;
 
+pub mod fs;
+pub use fs::secure_write_file;
+
 use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
 use std::fs::File;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The lineinfile and blockinfile modules were creating files with default permissions before restricting them, creating a Time-of-Check Time-of-Use (TOCTOU) race condition where sensitive files could be briefly exposed.
🎯 Impact: Attackers on the same system could potentially open sensitive files (like authorized_keys or config files) during the race window.
🔧 Fix: Introduced secure_write_file utility that uses OpenOptionsExt to set permissions atomically at creation time on Unix systems. Refactored affected modules to use this utility.
✅ Verification: Added unit tests in src/utils/fs.rs confirming permission setting logic. Verified existing module tests pass.

---
*PR created automatically by Jules for task [17019273659675012980](https://jules.google.com/task/17019273659675012980) started by @dolagoartur*