### PR TITLE
🎨 Palette: Colorize host names in task output

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2024-05-28 - [Unicode vs Emoji Usage]
 **Learning:** The codebase avoids emojis in banners (e.g., `[==== SUCCESS ====]`) but uses them in interactive menus. For CLI output like task status, text-like Unicode symbols (e.g. `✎` instead of `📝`) are preferred to maintain alignment and professional appearance.
 **Action:** Use Unicode symbols that are 1-cell wide for tabular output; reserve colorful emojis for interactive prompts.
+
+## 2024-05-24 - Task Output Coloring
+**Learning:** Coloring host names in task output to match the status color (e.g. green for OK, red for Failed) significantly improves scannability and visual consistency with the `recap` summary.
+**Action:** Apply consistent color coding for entity names (hosts, tasks) across all output modes to reinforce status at a glance.

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -209,7 +209,14 @@ impl OutputFormatter {
         let padding_len = 11usize.saturating_sub(status.as_str().len());
 
         let host_str = if self.use_color {
-            host.bright_white().bold().to_string()
+            match status {
+                TaskStatus::Ok => host.green().to_string(),
+                TaskStatus::Changed => host.yellow().to_string(),
+                TaskStatus::Skipped => host.cyan().to_string(),
+                TaskStatus::Failed | TaskStatus::Unreachable => host.red().bold().to_string(),
+                TaskStatus::Rescued => host.magenta().to_string(),
+                TaskStatus::Ignored => host.blue().to_string(),
+            }
         } else {
             host.to_string()
         };


### PR DESCRIPTION
Improved CLI task output by colorizing host names based on their execution status.
This makes it easier to quickly scan the output for failures or changes, matching the visual style used in the recap summary.
- **OK**: Green
- **Changed**: Yellow
- **Failed/Unreachable**: Red (Bold)
- **Skipped**: Cyan


---
*PR created automatically by Jules for task [3437227663250959175](https://jules.google.com/task/3437227663250959175) started by @dolagoartur*