### PR TITLE
🛡️ Sentinel: [MEDIUM] Add max_content_length to uri module to prevent DoS

### DIFF
--- a/src/modules/uri.rs
+++ b/src/modules/uri.rs
@@ -58,6 +58,9 @@ const DEFAULT_RETRY_DELAY_SECS: u64 = 1;
 /// Maximum retry delay in seconds (for exponential backoff)
 const MAX_RETRY_DELAY_SECS: u64 = 60;
 
+/// Default maximum content length (10MB) to prevent DoS
+const DEFAULT_MAX_CONTENT_LENGTH: u64 = 10 * 1024 * 1024;
+
 /// Supported authentication types
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum AuthType {
@@ -335,9 +338,10 @@ impl UriModule {
 
     /// Process the response and build UriResponse
     async fn process_response(
-        response: Response,
+        mut response: Response,
         original_url: &str,
         return_content: bool,
+        max_content_length: u64,
     ) -> ModuleResult<UriResponse> {
         let status_code = response.status().as_u16();
         let status_reason = response
@@ -361,9 +365,34 @@ impl UriModule {
 
         // Get response body if requested
         let (content, json) = if return_content {
-            let body_text = response.text().await.map_err(|e| {
-                ModuleError::ExecutionFailed(format!("Failed to read response body: {}", e))
-            })?;
+            // Check content length header if available
+            if let Some(len) = content_length {
+                if len > max_content_length {
+                    return Err(ModuleError::ExecutionFailed(format!(
+                        "Response content length {} exceeds limit of {}",
+                        len, max_content_length
+                    )));
+                }
+            }
+
+            // Stream the body with a limit
+            let mut body_bytes = Vec::new();
+
+            while let Some(chunk) = response.chunk().await.map_err(|e| {
+                ModuleError::ExecutionFailed(format!("Failed to read response chunk: {}", e))
+            })? {
+                if (body_bytes.len() as u64 + chunk.len() as u64) > max_content_length {
+                    return Err(ModuleError::ExecutionFailed(format!(
+                        "Response content length exceeds limit of {}",
+                        max_content_length
+                    )));
+                }
+
+                body_bytes.extend_from_slice(&chunk);
+            }
+
+            // Convert to string (lossy to handle non-UTF8 safely)
+            let body_text = String::from_utf8_lossy(&body_bytes).to_string();
 
             // Try to parse as JSON
             let json_value = serde_json::from_str::<Value>(&body_text).ok();
@@ -418,6 +447,7 @@ impl UriModule {
         follow_redirects: bool,
         max_redirects: usize,
         return_content: bool,
+        max_content_length: u64,
         status_code_list: Vec<u16>,
         retries: u32,
         retry_delay_secs: u64,
@@ -508,7 +538,8 @@ impl UriModule {
         .await?;
 
         // Process response
-        let uri_response = Self::process_response(response, &url, return_content).await?;
+        let uri_response =
+            Self::process_response(response, &url, return_content, max_content_length).await?;
 
         // Validate status code
         let status_valid = Self::validate_status(uri_response.status_code, &status_code_list);
@@ -665,6 +696,15 @@ impl Module for UriModule {
             }
         }
 
+        // Validate max_content_length
+        if let Some(len) = params.get_i64("max_content_length")? {
+            if len <= 0 {
+                return Err(ModuleError::InvalidParameter(
+                    "max_content_length must be a positive integer".to_string(),
+                ));
+            }
+        }
+
         Ok(())
     }
 
@@ -740,6 +780,12 @@ impl Module for UriModule {
             .unwrap_or(10);
         let return_content = params.get_bool_or("return_content", true);
 
+        // Max content length
+        let max_content_length = params
+            .get_i64("max_content_length")?
+            .map(|l| l as u64)
+            .unwrap_or(DEFAULT_MAX_CONTENT_LENGTH);
+
         // Status code validation
         let status_code_list: Vec<u16> = params
             .get("status_code")
@@ -793,6 +839,7 @@ impl Module for UriModule {
             follow_redirects,
             max_redirects,
             return_content,
+            max_content_length,
             status_code_list,
             retries,
             retry_delay_secs,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -87,7 +87,6 @@ pub mod locking;
 pub mod manager;
 pub mod manifest;
 pub mod persistence;
-pub mod rollback;
 pub mod storage;
 
 use std::collections::HashMap;

--- a/tests/uri_security_test.rs
+++ b/tests/uri_security_test.rs
@@ -1,0 +1,74 @@
+use rustible::modules::uri::UriModule;
+use rustible::modules::{Module, ModuleContext, ModuleParams};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+use std::collections::HashMap;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_uri_module_max_content_length_exceeded() {
+    let mock_server = MockServer::start().await;
+
+    // Create a response body larger than the limit we'll set (100 bytes)
+    // 200 bytes of 'a'
+    let body = "a".repeat(200);
+
+    Mock::given(method("GET"))
+        .and(path("/large"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(body))
+        .mount(&mock_server)
+        .await;
+
+    let module = UriModule;
+    let mut params: ModuleParams = HashMap::new();
+    params.insert("url".to_string(), json!(format!("{}/large", mock_server.uri())));
+    params.insert("max_content_length".to_string(), json!(100)); // Set limit to 100 bytes
+
+    let context = ModuleContext::default();
+
+    // Execute
+    // Note: execute calls runtime.block_on internally, so we don't await it here.
+    // However, since we are already in a tokio runtime (via #[tokio::test]),
+    // the module's internal block_on might panic if it tries to start a new runtime.
+    // Let's check implementation of execute.
+    // It tries Handle::try_current() and spawns a thread if present.
+    // So it should be fine.
+
+    let result = module.execute(&params, &context);
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("exceeds limit"));
+}
+
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_uri_module_within_limit() {
+    let mock_server = MockServer::start().await;
+
+    // Response body smaller than limit
+    let body = "ok";
+
+    Mock::given(method("GET"))
+        .and(path("/ok"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(body))
+        .mount(&mock_server)
+        .await;
+
+    let module = UriModule;
+    let mut params: ModuleParams = HashMap::new();
+    params.insert("url".to_string(), json!(format!("{}/ok", mock_server.uri())));
+    params.insert("max_content_length".to_string(), json!(100)); // Set limit to 100 bytes
+
+    let context = ModuleContext::default();
+
+    // Execute
+    let result = module.execute(&params, &context);
+
+    assert!(result.is_ok());
+    let output = result.unwrap();
+    // In strict mode, output might be JSON value, but here ModuleOutput struct
+    // Check content
+    let content = output.data.get("content").unwrap().as_str().unwrap();
+    assert_eq!(content, "ok");
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `uri` module was reading the entire response body into memory without a limit when `return_content` was true. This could lead to Denial of Service (DoS) via memory exhaustion if a large response was received.
🎯 Impact: An attacker controlling a URL targeted by the `uri` module could crash the application by serving a very large response.
🔧 Fix: Implemented `max_content_length` parameter (default 10MB). The module now streams the response body and errors out if the limit is exceeded.
✅ Verification: Added `tests/uri_security_test.rs` which verifies that downloads exceeding the limit are rejected.

Note: Also fixed a duplicate module definition in `src/state/mod.rs`.

---
*PR created automatically by Jules for task [4890665964273902401](https://jules.google.com/task/4890665964273902401) started by @dolagoartur*