### PR TITLE
🛡️ Sentinel: Fix command injection on Windows in command module

### DIFF
--- a/src/modules/command.rs
+++ b/src/modules/command.rs
@@ -43,12 +43,35 @@ impl CommandModule {
     }
 
     /// Build the command string from params (for display and remote execution)
-    fn get_command_string(&self, params: &ModuleParams) -> ModuleResult<String> {
+    fn get_command_string(
+        &self,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<String> {
         let cmd = self.get_cmd_param(params)?;
         let argv = params.get_vec_string("argv")?;
-        let shell_type = params
-            .get_string("shell_type")?
-            .unwrap_or_else(|| "posix".to_string());
+
+        // Determine shell type
+        let shell_type = if let Some(st) = params.get_string("shell_type")? {
+            st
+        } else {
+            // Auto-detect based on OS family
+            let os_family = context
+                .facts
+                .get("os_family")
+                .or_else(|| context.facts.get("ansible_os_family"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+
+            if os_family.eq_ignore_ascii_case("windows") {
+                // On Windows, default to cmd escaping (double quotes) which works
+                // reasonably well for both cmd.exe and PowerShell, whereas POSIX
+                // single quotes fail completely on cmd.exe.
+                "cmd".to_string()
+            } else {
+                "posix".to_string()
+            }
+        };
 
         if let Some(argv) = argv {
             if argv.is_empty() {
@@ -277,13 +300,13 @@ impl CommandModule {
 
         // In check mode, return what would happen
         if context.check_mode {
-            let cmd = self.get_command_string(params)?;
+            let cmd = self.get_command_string(params, context)?;
             return Ok(ModuleOutput::changed(format!("Would execute: {}", cmd))
                 .with_command_output(Some(String::new()), Some(String::new()), Some(0)));
         }
 
         let mut command = self.build_command(params, context)?;
-        let cmd_display = self.get_command_string(params)?;
+        let cmd_display = self.get_command_string(params, context)?;
 
         // Execute the command
         let output = command.output().map_err(|e| {
@@ -326,7 +349,7 @@ impl CommandModule {
     ) -> ModuleResult<ModuleOutput> {
         let params_clone = params.clone();
         let check_mode = context.check_mode;
-        let cmd_display = self.get_command_string(params)?;
+        let cmd_display = self.get_command_string(params, context)?;
         let options = self.build_execute_options(params, context)?;
         let warn_on_stderr = params.get_bool_or("warn", true);
 
@@ -455,6 +478,7 @@ impl Module for CommandModule {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::modules::ModuleContextBuilder;
     use std::collections::HashMap;
 
     #[test]
@@ -554,7 +578,8 @@ mod tests {
         );
         params.insert("shell_type".to_string(), serde_json::json!("cmd"));
 
-        let cmd = module.get_command_string(&params).unwrap();
+        let context = ModuleContext::default();
+        let cmd = module.get_command_string(&params, &context).unwrap();
         // Should use double quotes for cmd.exe
         assert_eq!(cmd, "\"echo\" \"hello & calc.exe\"");
     }
@@ -569,8 +594,52 @@ mod tests {
         );
         params.insert("shell_type".to_string(), serde_json::json!("powershell"));
 
-        let cmd = module.get_command_string(&params).unwrap();
+        let context = ModuleContext::default();
+        let cmd = module.get_command_string(&params, &context).unwrap();
         // Should use single quotes with doubled single quotes for PowerShell
         assert_eq!(cmd, "'echo' 'hello''world'");
+    }
+
+    #[test]
+    fn test_command_windows_auto_detection() {
+        let module = CommandModule;
+        let mut params: ModuleParams = HashMap::new();
+        params.insert(
+            "argv".to_string(),
+            serde_json::json!(["echo", "hello & calc.exe"]),
+        );
+        // No shell_type specified
+
+        // Create context with Windows OS family
+        let mut facts = HashMap::new();
+        facts.insert("os_family".to_string(), serde_json::json!("Windows"));
+        let context = ModuleContextBuilder::new().facts(facts).build().unwrap();
+
+        let cmd = module.get_command_string(&params, &context).unwrap();
+
+        // Should default to cmd escaping (double quotes) for Windows
+        assert_eq!(cmd, "\"echo\" \"hello & calc.exe\"");
+    }
+
+    #[test]
+    fn test_command_default_posix() {
+        let module = CommandModule;
+        let mut params: ModuleParams = HashMap::new();
+        params.insert(
+            "argv".to_string(),
+            serde_json::json!(["echo", "hello & calc.exe"]),
+        );
+        // No shell_type specified
+
+        // Create context with Linux OS family
+        let mut facts = HashMap::new();
+        facts.insert("os_family".to_string(), serde_json::json!("Debian"));
+        let context = ModuleContextBuilder::new().facts(facts).build().unwrap();
+
+        let cmd = module.get_command_string(&params, &context).unwrap();
+
+        // Should default to posix escaping (single quotes where needed)
+        // 'echo' is safe so it's not quoted. 'hello & calc.exe' is quoted.
+        assert_eq!(cmd, "echo 'hello & calc.exe'");
     }
 }


### PR DESCRIPTION
### **User description**
🛡️ Sentinel: [CRITICAL] Fix command injection vulnerability on Windows

🚨 Severity: CRITICAL
💡 Vulnerability: The `command` module used POSIX-style single-quote escaping by default for `argv` arguments. On Windows hosts where the shell is `cmd.exe` (often the default for OpenSSH), single quotes are not respected as quoting characters. This allowed attackers to inject commands using shell operators like `&` or `|` embedded in arguments, even when using the safer `argv` list format.
🎯 Impact: Remote Code Execution (RCE) on Windows hosts if user-controlled data is passed to `command` module arguments.
🔧 Fix: The module now detects the target OS family from facts. If "Windows" is detected, it defaults to `cmd` style escaping (double quotes), which is respected by both `cmd.exe` and PowerShell, preventing operator injection.
✅ Verification: Added unit tests `test_command_windows_auto_detection` and `test_command_default_posix` to verify correct escaping behavior based on OS family context.


---
*PR created automatically by Jules for task [11246567681579266377](https://jules.google.com/task/11246567681579266377) started by @dolagoartur*


___

### **PR Type**
Bug fix


___

### **Description**
- Fix critical command injection vulnerability on Windows systems

- Auto-detect OS family from facts to determine shell escaping type

- Default to cmd-style escaping (double quotes) for Windows targets

- Add comprehensive tests for Windows and POSIX auto-detection behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["get_command_string receives ModuleContext"] --> B["Check explicit shell_type parameter"]
  B --> C{shell_type specified?}
  C -->|Yes| D["Use specified shell_type"]
  C -->|No| E["Inspect context.facts for os_family"]
  E --> F{OS family is Windows?}
  F -->|Yes| G["Default to cmd escaping"]
  F -->|No| H["Default to posix escaping"]
  D --> I["Return properly escaped command string"]
  G --> I
  H --> I
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>command.rs</strong><dd><code>Auto-detect Windows OS and apply safe escaping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/command.rs

<ul><li>Modified <code>get_command_string</code> method to accept <code>ModuleContext</code> parameter<br> <li> Implemented OS family auto-detection logic using <code>context.facts</code> to <br>determine shell type<br> <li> Changed default shell escaping from POSIX to cmd-style when Windows OS <br>is detected<br> <li> Updated all call sites of <code>get_command_string</code> to pass the context <br>parameter<br> <li> Added two new unit tests for Windows and POSIX auto-detection <br>scenarios<br> <li> Updated existing tests to use <code>ModuleContext</code> with the new method <br>signature</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/409/files#diff-c6bf40ac3cfa3a9d8d59546bebeb27697b83a507ff7bc8592acc69042869a80d">+78/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

