### PR TITLE
🎨 Palette: Improve vault password prompt UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2024-05-28 - [Unicode vs Emoji Usage]
 **Learning:** The codebase avoids emojis in banners (e.g., `[==== SUCCESS ====]`) but uses them in interactive menus. For CLI output like task status, text-like Unicode symbols (e.g. `✎` instead of `📝`) are preferred to maintain alignment and professional appearance.
 **Action:** Use Unicode symbols that are 1-cell wide for tabular output; reserve colorful emojis for interactive prompts.
+
+## 2026-03-05 - [Consistent Interactive Prompts]
+**Learning:** Inconsistent usage of UI themes (like `dialoguer`'s `ColorfulTheme`) and missing semantic icons in password prompts breaks the visual consistency of the CLI. Using standard themes and icons (e.g., 🔐 for secrets) makes the tool feel more polished and trustworthy.
+**Action:** Always use `ColorfulTheme::default()` for `dialoguer` prompts and include appropriate semantic emojis in prompt text to match the rest of the application.

--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -12,6 +12,7 @@ use argon2::password_hash::SaltString;
 use argon2::{Argon2, PasswordHasher};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use clap::{Parser, Subcommand};
+use dialoguer::theme::ColorfulTheme;
 use rand::rngs::OsRng;
 use rand::RngCore;
 use std::fs;
@@ -318,11 +319,9 @@ fn get_password(password_file: Option<&PathBuf>, ctx: &CommandContext) -> Result
 
     // Prompt for password
     ctx.output.flush();
-    print!("Vault password: ");
-    io::stdout().flush()?;
 
-    let password = dialoguer::Password::new()
-        .with_prompt("Vault password")
+    let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
+        .with_prompt("🔐 Vault password")
         .interact()?;
 
     Ok(password)
@@ -339,9 +338,9 @@ fn get_password_with_confirm(
 
     ctx.output.flush();
 
-    let password = dialoguer::Password::new()
-        .with_prompt("New Vault password")
-        .with_confirmation("Confirm Vault password", "Passwords do not match")
+    let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
+        .with_prompt("🔐 New Vault password")
+        .with_confirmation("🔐 Confirm Vault password", "Passwords do not match")
         .interact()?;
 
     Ok(password)


### PR DESCRIPTION
### **User description**
💡 What: Improved the UX of vault password prompts by adding theming and icons.
🎯 Why: To align with the rest of the CLI's visual style and improve usability/trust.
📸 Before/After:
  Before:
  `Vault password: Vault password: ` (double prompt due to manual print) or just plain text.
  After:
  `🔐 Vault password: ` (colored, bold, with icon)
♿ Accessibility: Better visual distinction of secure input fields.

---
*PR created automatically by Jules for task [1002981026911734995](https://jules.google.com/task/1002981026911734995) started by @dolagoartur*


___

### **PR Type**
Enhancement


___

### **Description**
- Improved vault password prompt UX with ColorfulTheme styling

- Added semantic lock emoji (🔐) to password prompts

- Removed redundant manual print statements for cleaner code

- Documented interactive prompt guidelines in palette documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Password Prompts"] -->|Add ColorfulTheme| B["Styled Prompts"]
  A -->|Add 🔐 Emoji| C["Semantic Icons"]
  A -->|Remove Manual Print| D["Cleaner Code"]
  B --> E["Improved UX"]
  C --> E
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vault.rs</strong><dd><code>Apply ColorfulTheme and emojis to password prompts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/commands/vault.rs

<ul><li>Added <code>ColorfulTheme</code> import from dialoguer<br> <li> Updated <code>get_password()</code> to use themed password prompt with 🔐 emoji<br> <li> Removed manual <code>print!</code> and <code>flush()</code> calls in favor of <code>with_prompt</code><br> <li> Updated <code>get_password_with_confirm()</code> with themed prompts and emoji <br>icons</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/410/files#diff-89bfd2c7810a6cd5c3326c9f47d7b341c45da66702a365ce2f3905deee4409c4">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>palette.md</strong><dd><code>Document interactive prompt styling guidelines</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.Jules/palette.md

<ul><li>Added new guideline entry for consistent interactive prompts<br> <li> Documented best practice of using <code>ColorfulTheme::default()</code> for <br>dialoguer<br> <li> Established convention of using semantic emojis (e.g., 🔐) in prompts</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/410/files#diff-3116cf8aeaf8214fb77f4903fd8ca0fdf7f68c54b21508b4b2191b6540795433">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

