### PR TITLE
Add autofix error hints to diagnostic helpers

### DIFF
--- a/examples/rich_error_demo.rs
+++ b/examples/rich_error_demo.rs
@@ -46,10 +46,8 @@ fn main() {
 
     let diag = module_not_found_error(
         "playbook.yml",
-        playbook_source,
-        24,
-        7,
         "pacakge",
+        Span::from_line_col(playbook_source, 24, 7, 7),
         &["package", "apt", "yum", "dnf", "pip"],
     );
     diag.eprint_with_source(playbook_source);

--- a/src/diagnostics/rich_errors.rs
+++ b/src/diagnostics/rich_errors.rs
@@ -480,6 +480,9 @@ fn insert_code(
 // ---------------------------------------------------------------------------
 
 /// YAML syntax error with source span and hint.
+///
+/// Detects tabs and missing-colon patterns near the error location and
+/// attaches auto-fix [`Suggestion`]s when possible.
 pub fn yaml_syntax_error(
     path: impl AsRef<Path>,
     source: &str,
@@ -487,17 +490,68 @@ pub fn yaml_syntax_error(
     column: usize,
     message: &str,
 ) -> RichDiagnostic {
-    RichDiagnostic::error(
+    let span = Span::from_line_col(source, line, column, 1);
+    let mut diag = RichDiagnostic::error(
         format!("YAML syntax error: {}", message),
         path.as_ref(),
-        Span::from_line_col(source, line, column, 1),
+        span,
     )
     .with_code("E0001")
     .with_label("invalid YAML syntax")
-    .with_help("Check indentation, colons, and list markers")
+    .with_help("Check indentation, colons, and list markers");
+
+    // Try to get the offending line for pattern detection.
+    if let Some(raw_line) = source.lines().nth(line.saturating_sub(1)) {
+        // Detect tab characters.
+        if let Some(tab_pos) = raw_line.find('\t') {
+            let line_start = offset_of_line(source, line);
+            let tab_span = Span {
+                start: line_start + tab_pos,
+                end: line_start + tab_pos + 1,
+                line,
+                column: tab_pos + 1,
+            };
+            diag = diag.with_suggestion(Suggestion::new(
+                "Replace tab with spaces",
+                Some(tab_span),
+                Some("  ".to_string()),
+            ));
+        }
+
+        // Detect missing colon – simple heuristic: a line that looks like
+        // `key value` without a colon (trimmed, no leading `-`, not a comment).
+        let trimmed = raw_line.trim();
+        if !trimmed.is_empty()
+            && !trimmed.starts_with('#')
+            && !trimmed.starts_with('-')
+            && !trimmed.contains(':')
+        {
+            if let Some(space_idx) = trimmed.find(' ') {
+                let fixed = format!("{}: {}", &trimmed[..space_idx], &trimmed[space_idx + 1..]);
+                let line_start = offset_of_line(source, line);
+                let content_offset = raw_line.len() - raw_line.trim_start().len();
+                let fix_span = Span {
+                    start: line_start + content_offset,
+                    end: line_start + raw_line.len(),
+                    line,
+                    column: content_offset + 1,
+                };
+                diag = diag.with_suggestion(Suggestion::new(
+                    format!("Add missing colon: `{}`", fixed),
+                    Some(fix_span),
+                    Some(fixed),
+                ));
+            }
+        }
+    }
+
+    diag
 }
 
 /// Template syntax error with source span and hint.
+///
+/// Detects unclosed `{{` / `{%` delimiters near the error location and
+/// attaches auto-fix [`Suggestion`]s when possible.
 pub fn template_syntax_error(
     path: impl AsRef<Path>,
     source: &str,
@@ -505,14 +559,59 @@ pub fn template_syntax_error(
     column: usize,
     message: &str,
 ) -> RichDiagnostic {
-    RichDiagnostic::error(
+    let span = Span::from_line_col(source, line, column, 1);
+    let mut diag = RichDiagnostic::error(
         format!("Template syntax error: {}", message),
         path.as_ref(),
-        Span::from_line_col(source, line, column, 1),
+        span,
     )
     .with_code("E0002")
     .with_label("invalid template syntax")
-    .with_help("Check {{ }} delimiters and filter names")
+    .with_help("Check {{ }} delimiters and filter names");
+
+    if let Some(raw_line) = source.lines().nth(line.saturating_sub(1)) {
+        let line_start = offset_of_line(source, line);
+
+        // Detect unclosed {{ without }}
+        if raw_line.contains("{{") && !raw_line.contains("}}") {
+            if let Some(pos) = raw_line.find("{{") {
+                let expr = raw_line[pos + 2..].trim();
+                let replacement = format!("{{{{ {} }}}}", expr);
+                let open_span = Span {
+                    start: line_start + pos,
+                    end: line_start + raw_line.len(),
+                    line,
+                    column: pos + 1,
+                };
+                diag = diag.with_suggestion(Suggestion::new(
+                    format!("Close the expression: `{}`", replacement),
+                    Some(open_span),
+                    Some(replacement),
+                ));
+            }
+        }
+
+        // Detect unclosed {%  without %}
+        if raw_line.contains("{%") && !raw_line.contains("%}") {
+            if let Some(pos) = raw_line.find("{%") {
+                let tag_body = raw_line[pos + 2..].trim();
+                let replacement = format!("{{% {} %}}", tag_body);
+                let open_span = Span {
+                    start: line_start + pos,
+                    end: line_start + raw_line.len(),
+                    line,
+                    column: pos + 1,
+                };
+                diag = diag.with_suggestion(Suggestion::new(
+                    format!("Close the block tag: `{}`", replacement),
+                    Some(open_span),
+                    Some(replacement),
+                ));
+            }
+        }
+    }
+
+    diag
 }
 
 /// Undefined variable error with suggestions.
@@ -547,19 +646,35 @@ pub fn undefined_variable_error(
 }
 
 /// Module not found diagnostic.
+///
+/// When `known_modules` is non-empty, uses [`suggest_similar`] to attach
+/// did-you-mean [`Suggestion`]s.
 pub fn module_not_found_error(
     path: impl AsRef<Path>,
     module: &str,
     span: Span,
+    known_modules: &[&str],
 ) -> RichDiagnostic {
-    RichDiagnostic::error(
+    let mut diag = RichDiagnostic::error(
         format!("Module '{}' not found", module),
         path.as_ref(),
         span,
     )
     .with_code("E0004")
     .with_label("unknown module")
-    .with_help("Check module name or install required collection")
+    .with_help("Check module name or install required collection");
+
+    let suggestions = suggest_similar(module, known_modules);
+    if let Some(first) = suggestions.first() {
+        diag = diag.with_note(format!("Did you mean '{}' ?", first));
+        diag = diag.with_suggestion(Suggestion::new(
+            format!("Replace '{}' with '{}'", module, first),
+            Some(span),
+            Some(first.to_string()),
+        ));
+    }
+
+    diag
 }
 
 /// Invalid module argument diagnostic.
@@ -580,6 +695,8 @@ pub fn invalid_module_args_error(
 }
 
 /// Missing required argument diagnostic.
+///
+/// Attaches a [`Suggestion`] showing example YAML for the missing argument.
 pub fn missing_required_arg_error(
     path: impl AsRef<Path>,
     module: &str,
@@ -594,35 +711,133 @@ pub fn missing_required_arg_error(
     .with_code("E0020")
     .with_label("missing required argument")
     .with_help("Add the required argument to the module call")
+    .with_suggestion(Suggestion::new(
+        format!("Add '{}: <value>' to the module parameters", arg),
+        None,
+        None,
+    ))
 }
 
 /// Connection error diagnostic.
+///
+/// Pattern-matches on common error messages (refused, timeout, auth) to
+/// provide contextual fix suggestions.
 pub fn connection_error(
     path: impl AsRef<Path>,
     host: &str,
     message: &str,
     span: Span,
 ) -> RichDiagnostic {
-    RichDiagnostic::error(
+    let msg_lower = message.to_lowercase();
+    let mut diag = RichDiagnostic::error(
         format!("Connection error for {}: {}", host, message),
         path.as_ref(),
         span,
     )
     .with_code("E0030")
     .with_label("connection failed")
-    .with_help("Verify host reachability and credentials")
+    .with_help("Verify host reachability and credentials");
+
+    if msg_lower.contains("refused") {
+        diag = diag.with_suggestion(Suggestion::new(
+            format!("Verify the SSH/service is running on {}", host),
+            None,
+            None,
+        ));
+        diag = diag.with_suggestion(Suggestion::new(
+            "Check firewall rules allow the connection port",
+            None,
+            None,
+        ));
+    } else if msg_lower.contains("timed out") || msg_lower.contains("timeout") {
+        diag = diag.with_suggestion(Suggestion::new(
+            format!("Verify {} is reachable (ping or traceroute)", host),
+            None,
+            None,
+        ));
+        diag = diag.with_suggestion(Suggestion::new(
+            "Check firewall rules and network routing",
+            None,
+            None,
+        ));
+    } else if msg_lower.contains("auth") || msg_lower.contains("permission denied") {
+        diag = diag.with_suggestion(Suggestion::new(
+            "Check SSH key or credentials configuration",
+            None,
+            None,
+        ));
+        diag = diag.with_suggestion(Suggestion::new(
+            "Verify the remote user has access to the target host",
+            None,
+            None,
+        ));
+    }
+
+    diag
 }
 
+/// Compute the byte offset of the start of the given 1-based `line` in
+/// `source`. Returns 0 if the line is out of range.
+fn offset_of_line(source: &str, line: usize) -> usize {
+    let mut offset = 0usize;
+    for (idx, raw_line) in source.lines().enumerate() {
+        if idx + 1 == line {
+            return offset;
+        }
+        offset += raw_line.len() + 1;
+    }
+    0
+}
+
+/// Levenshtein edit distance (simple inline implementation).
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a_bytes = a.as_bytes();
+    let b_bytes = b.as_bytes();
+    let a_len = a_bytes.len();
+    let b_len = b_bytes.len();
+
+    let mut prev: Vec<usize> = (0..=b_len).collect();
+    let mut curr = vec![0usize; b_len + 1];
+
+    for i in 1..=a_len {
+        curr[0] = i;
+        for j in 1..=b_len {
+            let cost = if a_bytes[i - 1] == b_bytes[j - 1] { 0 } else { 1 };
+            curr[j] = (prev[j] + 1)
+                .min(curr[j - 1] + 1)
+                .min(prev[j - 1] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+
+    prev[b_len]
+}
+
+/// Find candidates similar to `target` using prefix/contains matching and
+/// Levenshtein edit distance. Returns up to 3 matches sorted by relevance.
 fn suggest_similar(target: &str, candidates: &[&str]) -> Vec<String> {
-    let mut matches: Vec<String> = candidates
+    // Score each candidate – lower is better.
+    // Prefix/contains matches get score 0, otherwise use edit distance.
+    let max_dist = (target.len() / 2).max(2);
+    let mut scored: Vec<(usize, &str)> = candidates
         .iter()
-        .filter(|c| c.starts_with(target) || target.starts_with(*c) || c.contains(target))
-        .map(|c| c.to_string())
+        .filter_map(|c| {
+            if c.starts_with(target) || target.starts_with(*c) || c.contains(target) {
+                Some((0, *c))
+            } else {
+                let dist = levenshtein(target, c);
+                if dist <= max_dist {
+                    Some((dist, *c))
+                } else {
+                    None
+                }
+            }
+        })
         .collect();
 
-    matches.sort();
-    matches.truncate(3);
-    matches
+    scored.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(b.1)));
+    scored.truncate(3);
+    scored.into_iter().map(|(_, s)| s.to_string()).collect()
 }
 
 #[cfg(test)]
@@ -642,5 +857,184 @@ mod tests {
         let diag = RichDiagnostic::error("test", "file.yml", Span::new(0, 0));
         let rendered = diag.render();
         assert!(rendered.contains("test"));
+    }
+
+    // --- Levenshtein ---
+
+    #[test]
+    fn test_levenshtein_identical() {
+        assert_eq!(levenshtein("abc", "abc"), 0);
+    }
+
+    #[test]
+    fn test_levenshtein_basic() {
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
+        assert_eq!(levenshtein("", "abc"), 3);
+        assert_eq!(levenshtein("abc", ""), 3);
+    }
+
+    #[test]
+    fn test_levenshtein_single_edit() {
+        assert_eq!(levenshtein("file", "fiel"), 2); // transposition = 2 ops
+        assert_eq!(levenshtein("copy", "cop"), 1);
+        assert_eq!(levenshtein("copy", "copyx"), 1);
+    }
+
+    // --- suggest_similar with edit distance ---
+
+    #[test]
+    fn test_suggest_similar_prefix() {
+        let result = suggest_similar("cop", &["copy", "file", "template"]);
+        assert!(result.contains(&"copy".to_string()));
+    }
+
+    #[test]
+    fn test_suggest_similar_edit_distance() {
+        // "flie" is edit-distance 2 from "file" – should match
+        let result = suggest_similar("flie", &["file", "copy", "template"]);
+        assert!(result.contains(&"file".to_string()));
+    }
+
+    #[test]
+    fn test_suggest_similar_no_match() {
+        let result = suggest_similar("zzzzz", &["file", "copy", "template"]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_suggest_similar_max_three() {
+        let result = suggest_similar("a", &["a1", "a2", "a3", "a4"]);
+        assert!(result.len() <= 3);
+    }
+
+    // --- yaml_syntax_error suggestions ---
+
+    #[test]
+    fn test_yaml_syntax_error_tab_suggestion() {
+        let source = "\tname: foo";
+        let diag = yaml_syntax_error("test.yml", source, 1, 1, "tab character");
+        assert!(!diag.suggestions.is_empty());
+        let tab_sugg = &diag.suggestions[0];
+        assert!(tab_sugg.message.contains("tab"));
+        assert_eq!(tab_sugg.replacement.as_deref(), Some("  "));
+    }
+
+    #[test]
+    fn test_yaml_syntax_error_missing_colon() {
+        let source = "name foo";
+        let diag = yaml_syntax_error("test.yml", source, 1, 1, "missing colon");
+        let colon_sugg = diag.suggestions.iter().find(|s| s.message.contains("colon"));
+        assert!(colon_sugg.is_some());
+        let sugg = colon_sugg.unwrap();
+        assert_eq!(sugg.replacement.as_deref(), Some("name: foo"));
+    }
+
+    #[test]
+    fn test_yaml_syntax_error_tab_patch_snippet() {
+        let source = "\tname: foo";
+        let diag = yaml_syntax_error("test.yml", source, 1, 1, "tab character");
+        let tab_sugg = &diag.suggestions[0];
+        let patch = tab_sugg.patch_snippet(source);
+        assert!(patch.is_some());
+        let patch_str = patch.unwrap();
+        assert!(patch_str.contains("+ "));
+        assert!(patch_str.contains("- \tname: foo"));
+    }
+
+    // --- template_syntax_error suggestions ---
+
+    #[test]
+    fn test_template_unclosed_expression() {
+        let source = "{{ foo";
+        let diag = template_syntax_error("test.yml", source, 1, 1, "unclosed expression");
+        let sugg = diag.suggestions.iter().find(|s| s.message.contains("Close"));
+        assert!(sugg.is_some());
+        assert!(sugg.unwrap().replacement.as_ref().unwrap().contains("}}"));
+    }
+
+    #[test]
+    fn test_template_unclosed_block_tag() {
+        let source = "{% if true";
+        let diag = template_syntax_error("test.yml", source, 1, 1, "unclosed block");
+        let sugg = diag.suggestions.iter().find(|s| s.message.contains("block tag"));
+        assert!(sugg.is_some());
+        assert!(sugg.unwrap().replacement.as_ref().unwrap().contains("%}"));
+    }
+
+    #[test]
+    fn test_template_no_suggestion_when_closed() {
+        let source = "{{ foo }}";
+        let diag = template_syntax_error("test.yml", source, 1, 1, "other error");
+        assert!(diag.suggestions.is_empty());
+    }
+
+    // --- module_not_found_error suggestions ---
+
+    #[test]
+    fn test_module_not_found_did_you_mean() {
+        let diag = module_not_found_error(
+            "test.yml",
+            "coppy",
+            Span::new(0, 5),
+            &["copy", "file", "template"],
+        );
+        assert!(!diag.suggestions.is_empty());
+        assert!(diag.suggestions[0].message.contains("copy"));
+    }
+
+    #[test]
+    fn test_module_not_found_no_known() {
+        let diag = module_not_found_error("test.yml", "coppy", Span::new(0, 5), &[]);
+        assert!(diag.suggestions.is_empty());
+    }
+
+    // --- missing_required_arg_error suggestions ---
+
+    #[test]
+    fn test_missing_required_arg_has_suggestion() {
+        let diag = missing_required_arg_error("test.yml", "copy", "src", Span::new(0, 4));
+        assert_eq!(diag.suggestions.len(), 1);
+        assert!(diag.suggestions[0].message.contains("src"));
+        assert!(diag.suggestions[0].message.contains("<value>"));
+    }
+
+    // --- connection_error suggestions ---
+
+    #[test]
+    fn test_connection_error_refused() {
+        let diag = connection_error("test.yml", "web01", "Connection refused", Span::new(0, 5));
+        assert!(diag.suggestions.len() >= 2);
+        assert!(diag.suggestions.iter().any(|s| s.message.contains("SSH")));
+        assert!(diag.suggestions.iter().any(|s| s.message.contains("firewall")));
+    }
+
+    #[test]
+    fn test_connection_error_timeout() {
+        let diag = connection_error("test.yml", "web01", "Connection timed out", Span::new(0, 5));
+        assert!(diag.suggestions.len() >= 2);
+        assert!(diag.suggestions.iter().any(|s| s.message.contains("reachable")));
+    }
+
+    #[test]
+    fn test_connection_error_auth() {
+        let diag = connection_error("test.yml", "web01", "Permission denied", Span::new(0, 5));
+        assert!(diag.suggestions.len() >= 2);
+        assert!(diag.suggestions.iter().any(|s| s.message.contains("SSH key")));
+    }
+
+    #[test]
+    fn test_connection_error_generic() {
+        let diag = connection_error("test.yml", "web01", "unknown failure", Span::new(0, 5));
+        assert!(diag.suggestions.is_empty());
+    }
+
+    // --- offset_of_line helper ---
+
+    #[test]
+    fn test_offset_of_line() {
+        let source = "abc\ndef\nghi";
+        assert_eq!(offset_of_line(source, 1), 0);
+        assert_eq!(offset_of_line(source, 2), 4);
+        assert_eq!(offset_of_line(source, 3), 8);
     }
 }


### PR DESCRIPTION
### **User description**
## Summary
- Enhance `yaml_syntax_error`, `template_syntax_error`, `module_not_found_error`, `missing_required_arg_error`, and `connection_error` to attach actionable `Suggestion` objects with fix hints and patch snippets
- Improve `suggest_similar` with Levenshtein edit distance for better fuzzy matching (no new dependencies)
- Add 20 new tests covering all new suggestion logic

Closes #331

## Test plan
- [ ] `cargo build` compiles cleanly (no new errors)
- [ ] `cargo test -p rustible -- rich_errors` — all new tests pass
- [ ] `cargo test` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add autofix suggestions to five diagnostic helpers with pattern detection
  - yaml_syntax_error: detects tabs and missing colons
  - template_syntax_error: detects unclosed {{ }} and {% %} delimiters
  - module_not_found_error: suggests similar modules via fuzzy matching
  - missing_required_arg_error: shows example YAML format
  - connection_error: contextual fixes for refused/timeout/auth errors

- Implement Levenshtein edit distance for improved fuzzy matching without new dependencies

- Add 20+ comprehensive tests covering all suggestion logic and edge cases

- Add helper functions offset_of_line and levenshtein for pattern detection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Error Helpers"] -->|"Add Suggestions"| B["yaml_syntax_error"]
  A -->|"Add Suggestions"| C["template_syntax_error"]
  A -->|"Add Suggestions"| D["module_not_found_error"]
  A -->|"Add Suggestions"| E["missing_required_arg_error"]
  A -->|"Add Suggestions"| F["connection_error"]
  D -->|"Uses"| G["suggest_similar"]
  G -->|"Uses"| H["Levenshtein Distance"]
  B -->|"Detects"| I["Tabs & Missing Colons"]
  C -->|"Detects"| J["Unclosed Delimiters"]
  F -->|"Pattern Matches"| K["Connection Errors"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rich_error_demo.rs</strong><dd><code>Update demo to use new error API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/rich_error_demo.rs

<ul><li>Update module_not_found_error call to use new Span-based API<br> <li> Pass known_modules list for fuzzy matching suggestions<br> <li> Remove old line/column parameters in favor of Span::from_line_col</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/423/files#diff-eeb87a537925e6bf26bb6073550ca3b4a0da7c95dd6e52f34a034a90e5e60f98">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rich_errors.rs</strong><dd><code>Add autofix suggestions and fuzzy matching to diagnostics</code></dd></summary>
<hr>

src/diagnostics/rich_errors.rs

<ul><li>Enhance yaml_syntax_error with tab detection and missing colon <br>suggestions<br> <li> Enhance template_syntax_error with unclosed {{ }} and {% %} detection<br> <li> Enhance module_not_found_error to accept known_modules and suggest <br>similar<br> <li> Enhance missing_required_arg_error with example YAML suggestion<br> <li> Enhance connection_error with pattern-matched contextual suggestions <br>for refused/timeout/auth<br> <li> Implement levenshtein function for edit distance calculation<br> <li> Implement offset_of_line helper for byte offset computation<br> <li> Improve suggest_similar with Levenshtein distance and scoring logic<br> <li> Add 20+ tests for all new suggestion patterns and edge cases</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/423/files#diff-9686125e644ae6ebc254b7dce08d0c782ba8877728e376f452e7c16f50b6b12a">+410/-16</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

