### PR TITLE
⚡ Bolt: Optimize CopyModule files_differ with stream comparison

### DIFF
--- a/src/modules/copy.rs
+++ b/src/modules/copy.rs
@@ -63,11 +63,37 @@ impl CopyModule {
             return Ok(true);
         }
 
-        // Compare checksums
-        let src_checksum = get_file_checksum(src)?;
-        let dest_checksum = get_file_checksum(dest)?;
+        // Compare content directly using buffered readers to avoid
+        // reading entire files into memory and computing checksums.
+        // This fails fast on first difference.
+        let mut f1 = std::io::BufReader::new(fs::File::open(src)?);
+        let mut f2 = std::io::BufReader::new(fs::File::open(dest)?);
 
-        Ok(src_checksum != dest_checksum)
+        let mut buf1 = [0; 8192];
+        let mut buf2 = [0; 8192];
+
+        loop {
+            let n1 = f1.read(&mut buf1)?;
+            if n1 == 0 {
+                // EOF reached on src. Since sizes are equal, dest should also be at EOF.
+                return Ok(false);
+            }
+
+            // Read corresponding chunk from dest
+            let mut n2_total = 0;
+            while n2_total < n1 {
+                let n2 = f2.read(&mut buf2[n2_total..n1])?;
+                if n2 == 0 {
+                    // Unexpected EOF on dest (sizes were same, but file changed?)
+                    return Ok(true);
+                }
+                n2_total += n2;
+            }
+
+            if buf1[..n1] != buf2[..n1] {
+                return Ok(true);
+            }
+        }
     }
 
     fn copy_content(content: &str, dest: &Path) -> ModuleResult<()> {
@@ -939,5 +965,38 @@ mod tests {
         let backup_path = temp.path().join("test.txt~");
         assert!(backup_path.exists());
         assert_eq!(fs::read_to_string(&backup_path).unwrap(), "Old content");
+    }
+
+    #[test]
+    fn test_files_differ_impl() {
+        let temp = TempDir::new().unwrap();
+        let file1 = temp.path().join("file1");
+        let file2 = temp.path().join("file2");
+
+        // Case 1: Identical files
+        fs::write(&file1, "content").unwrap();
+        fs::write(&file2, "content").unwrap();
+        assert!(!CopyModule::files_differ(&file1, &file2).unwrap());
+
+        // Case 2: Different sizes
+        fs::write(&file2, "content_longer").unwrap();
+        assert!(CopyModule::files_differ(&file1, &file2).unwrap());
+
+        // Case 3: Same size, different content
+        fs::write(&file1, "aaaa").unwrap();
+        fs::write(&file2, "bbbb").unwrap();
+        assert!(CopyModule::files_differ(&file1, &file2).unwrap());
+
+        // Case 4: Large identical files (larger than buffer)
+        let large_content = vec![b'x'; 20000];
+        fs::write(&file1, &large_content).unwrap();
+        fs::write(&file2, &large_content).unwrap();
+        assert!(!CopyModule::files_differ(&file1, &file2).unwrap());
+
+        // Case 5: Large different files (diff at end)
+        let mut large_content2 = large_content.clone();
+        large_content2[19999] = b'y';
+        fs::write(&file2, &large_content2).unwrap();
+        assert!(CopyModule::files_differ(&file1, &file2).unwrap());
     }
 }


### PR DESCRIPTION
### **User description**
💡 What: Optimized `CopyModule::files_differ` to use streaming byte-by-byte comparison.
🎯 Why: To avoid unnecessary full-file reads and expensive checksum computations when checking if a local file needs to be copied.
📊 Impact: Faster idempotency checks for local files, especially large ones. Early exit on difference saves I/O.
🔬 Measurement: Validated with `cargo test --lib modules::copy`. Added `test_files_differ_impl`.

---
*PR created automatically by Jules for task [3625209631531272423](https://jules.google.com/task/3625209631531272423) started by @dolagoartur*


___

### **PR Type**
Enhancement


___

### **Description**
- Replace checksum-based comparison with streaming byte-by-byte comparison

- Avoid full-file reads and expensive SHA hash computations

- Early exit on first difference for faster idempotency checks

- Add comprehensive unit tests for various file comparison scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["files_differ method"] --> B["Check file sizes"]
  B --> C["Size differs?"]
  C -->|Yes| D["Return true"]
  C -->|No| E["Stream comparison"]
  E --> F["Read chunks with BufReader"]
  F --> G["Compare buffers"]
  G --> H["Difference found?"]
  H -->|Yes| I["Return true"]
  H -->|No| J["Continue or EOF?"]
  J -->|EOF| K["Return false"]
  J -->|More data| F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>copy.rs</strong><dd><code>Streaming comparison replaces checksum-based file diffing</code></dd></summary>
<hr>

src/modules/copy.rs

<ul><li>Replace <code>get_file_checksum</code> calls with buffered streaming byte-by-byte <br>comparison<br> <li> Implement loop-based chunk reading with 8KB buffers for memory <br>efficiency<br> <li> Add early exit on first difference detection<br> <li> Add five new test cases covering identical files, different sizes, <br>different content, and large files</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/424/files#diff-62ed97a2a5a2e6ac573985fe37d0ed9ba7360288d6fad537a3e4080222bd2cf7">+63/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

