### PR TITLE
🎨 Palette: Add semantic emojis to interactive menus

### DIFF
--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -105,7 +105,10 @@ impl InteractiveSession {
             return Ok(None);
         }
 
-        let items: Vec<String> = playbooks.iter().map(|p| p.display().to_string()).collect();
+        let items: Vec<String> = playbooks
+            .iter()
+            .map(|p| format!("📖 {}", p.display()))
+            .collect();
 
         let selection = Select::with_theme(&self.theme)
             .with_prompt("Select a playbook")
@@ -132,7 +135,7 @@ impl InteractiveSession {
 
         let mut items: Vec<String> = inventories
             .iter()
-            .map(|p| p.display().to_string())
+            .map(|p| format!("📋 {}", p.display()))
             .collect();
         items.push("✏️ Enter custom path...".to_string());
         items.push("🏠 Use localhost (no inventory)".to_string());
@@ -172,9 +175,14 @@ impl InteractiveSession {
             return Ok(vec![]);
         }
 
+        let display_items: Vec<String> = available_tags
+            .iter()
+            .map(|tag| format!("🏷️  {}", tag))
+            .collect();
+
         let selections = MultiSelect::with_theme(&self.theme)
             .with_prompt("Select tags to run (space to select, enter to confirm)")
-            .items(available_tags)
+            .items(&display_items)
             .interact_on(&self.term)?;
 
         Ok(selections


### PR DESCRIPTION
### **User description**
💡 What: Added semantic emoji prefixes to `dialoguer` selection lists in `src/cli/interactive.rs`.
🎯 Why: To improve visual scannability and consistency with the "Palette" design philosophy, making the CLI more intuitive and pleasant to use.
📸 Before/After:
  - Playbooks: `playbooks/deploy.yml` -> `📖 playbooks/deploy.yml`
  - Inventories: `inventory/hosts.ini` -> `📋 inventory/hosts.ini`
  - Tags: `deploy` -> `🏷️  deploy`
♿ Accessibility: Emojis are announced by screen readers, providing context (e.g., "Open Book playbooks/deploy.yml"), and visual alignment is maintained.

---
*PR created automatically by Jules for task [8884602364285884700](https://jules.google.com/task/8884602364285884700) started by @dolagoartur*


___

### **PR Type**
Enhancement


___

### **Description**
- Add semantic emoji prefixes to interactive selection menus

- Improve visual scannability for playbooks, inventories, and tags

- Enhance CLI user experience with consistent "Palette" design philosophy


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Interactive Selection Menus"] -->|Add emoji prefixes| B["Playbooks 📖"]
  A -->|Add emoji prefixes| C["Inventories 📋"]
  A -->|Add emoji prefixes| D["Tags 🏷️"]
  B --> E["Enhanced Visual Scannability"]
  C --> E
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>interactive.rs</strong><dd><code>Add semantic emojis to selection menus</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/interactive.rs

<ul><li>Added emoji prefix "📖" to playbook selection items<br> <li> Added emoji prefix "📋" to inventory selection items<br> <li> Added emoji prefix "🏷️" to tag selection items with proper spacing<br> <li> Created intermediate <code>display_items</code> vector for tag display formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/425/files#diff-e54475b20e9f2b5da435e6ab781fa7c4c037a5037e06de562d40b6e7378e93e2">+11/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

