### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in postgresql_user module

### DIFF
--- a/src/modules/database/postgresql_user.rs
+++ b/src/modules/database/postgresql_user.rs
@@ -276,10 +276,11 @@ impl PostgresqlUserModule {
             "SELECT 1 FROM pg_roles WHERE rolname = '{}'",
             config.name.replace('\'', "''")
         );
+        // Use shell_escape to prevent command injection
         let cmd = format!(
-            "psql {} -tAc \"{}\"",
+            "psql {} -tAc {}",
             config.conn.build_psql_args(&config.conn.maintenance_db),
-            query
+            shell_escape(&query)
         );
 
         let (success, stdout, _) =
@@ -302,10 +303,11 @@ impl PostgresqlUserModule {
             config.name.replace('\'', "''")
         );
 
+        // Use shell_escape to prevent command injection
         let cmd = format!(
-            "psql {} -tAF '|' -c \"{}\"",
+            "psql {} -tAF '|' -c {}",
             config.conn.build_psql_args(&config.conn.maintenance_db),
-            query
+            shell_escape(&query)
         );
 
         let (success, stdout, _) =
@@ -328,10 +330,11 @@ impl PostgresqlUserModule {
              WHERE u.rolname = '{}'",
             config.name.replace('\'', "''")
         );
+        // Use shell_escape to prevent command injection
         let groups_cmd = format!(
-            "psql {} -tAc \"{}\"",
+            "psql {} -tAc {}",
             config.conn.build_psql_args(&config.conn.maintenance_db),
-            groups_query
+            shell_escape(&groups_query)
         );
 
         let (_, groups_stdout, _) = Self::execute_command(
@@ -396,10 +399,11 @@ impl PostgresqlUserModule {
             options.join(" ")
         );
 
+        // Use shell_escape to prevent command injection
         let cmd = format!(
-            "psql {} -c \"{}\"",
+            "psql {} -c {}",
             config.conn.build_psql_args(&config.conn.maintenance_db),
-            create_sql
+            shell_escape(&create_sql)
         );
 
         let (success, _, stderr) =
@@ -489,10 +493,11 @@ impl PostgresqlUserModule {
                 shell_escape(&config.name),
                 alterations.join(" ")
             );
+            // Use shell_escape to prevent command injection
             let cmd = format!(
-                "psql {} -c \"{}\"",
+                "psql {} -c {}",
                 config.conn.build_psql_args(&config.conn.maintenance_db),
-                alter_sql
+                shell_escape(&alter_sql)
             );
 
             let (success, _, stderr) =
@@ -517,10 +522,11 @@ impl PostgresqlUserModule {
                     shell_escape(&config.name),
                     password.replace('\'', "''")
                 );
+                // Use shell_escape to prevent command injection
                 let cmd = format!(
-                    "psql {} -c \"{}\"",
+                    "psql {} -c {}",
                     config.conn.build_psql_args(&config.conn.maintenance_db),
-                    pwd_sql
+                    shell_escape(&pwd_sql)
                 );
 
                 let (success, _, stderr) =
@@ -560,10 +566,11 @@ impl PostgresqlUserModule {
             shell_escape(group),
             shell_escape(&config.name)
         );
+        // Use shell_escape to prevent command injection
         let cmd = format!(
-            "psql {} -c \"{}\"",
+            "psql {} -c {}",
             config.conn.build_psql_args(&config.conn.maintenance_db),
-            grant_sql
+            shell_escape(&grant_sql)
         );
 
         let (success, _, stderr) =
@@ -586,10 +593,11 @@ impl PostgresqlUserModule {
         context: &ModuleContext,
     ) -> ModuleResult<()> {
         let drop_sql = format!("DROP ROLE IF EXISTS {}", shell_escape(&config.name));
+        // Use shell_escape to prevent command injection
         let cmd = format!(
-            "psql {} -c \"{}\"",
+            "psql {} -c {}",
             config.conn.build_psql_args(&config.conn.maintenance_db),
-            drop_sql
+            shell_escape(&drop_sql)
         );
 
         let (success, _, stderr) =
@@ -795,5 +803,130 @@ mod tests {
         assert_eq!(module.name(), "postgresql_user");
         assert_eq!(module.classification(), ModuleClassification::RemoteCommand);
         assert_eq!(module.required_params(), &["name"]);
+    }
+}
+
+#[cfg(test)]
+mod security_tests {
+    use super::*;
+    use crate::connection::{CommandResult, Connection, ExecuteOptions, FileStat, TransferOptions};
+    use async_trait::async_trait;
+    use std::collections::HashMap;
+    use std::path::Path;
+    use std::sync::{Arc, Mutex};
+
+    struct MockConnection {
+        commands: Mutex<Vec<String>>,
+    }
+
+    impl MockConnection {
+        fn new() -> Self {
+            Self {
+                commands: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Connection for MockConnection {
+        fn identifier(&self) -> &str {
+            "mock"
+        }
+        async fn is_alive(&self) -> bool {
+            true
+        }
+
+        async fn execute(
+            &self,
+            command: &str,
+            _options: Option<ExecuteOptions>,
+        ) -> crate::connection::ConnectionResult<CommandResult> {
+            self.commands.lock().unwrap().push(command.to_string());
+            Ok(CommandResult::success("0".to_string(), "".to_string()))
+        }
+
+        async fn upload(
+            &self,
+            _local: &Path,
+            _remote: &Path,
+            _opts: Option<TransferOptions>,
+        ) -> crate::connection::ConnectionResult<()> {
+            Ok(())
+        }
+        async fn upload_content(
+            &self,
+            _content: &[u8],
+            _remote: &Path,
+            _opts: Option<TransferOptions>,
+        ) -> crate::connection::ConnectionResult<()> {
+            Ok(())
+        }
+        async fn download(
+            &self,
+            _remote: &Path,
+            _local: &Path,
+        ) -> crate::connection::ConnectionResult<()> {
+            Ok(())
+        }
+        async fn download_content(
+            &self,
+            _remote: &Path,
+        ) -> crate::connection::ConnectionResult<Vec<u8>> {
+            Ok(vec![])
+        }
+        async fn path_exists(&self, _path: &Path) -> crate::connection::ConnectionResult<bool> {
+            Ok(false)
+        }
+        async fn is_directory(&self, _path: &Path) -> crate::connection::ConnectionResult<bool> {
+            Ok(false)
+        }
+        async fn stat(&self, _path: &Path) -> crate::connection::ConnectionResult<FileStat> {
+            unimplemented!()
+        }
+        async fn close(&self) -> crate::connection::ConnectionResult<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_postgres_user_injection() {
+        let module = PostgresqlUserModule;
+        let conn = Arc::new(MockConnection::new());
+
+        let context = ModuleContext::builder()
+            .connection(conn.clone())
+            .build()
+            .unwrap();
+
+        let mut params = HashMap::new();
+        // Malicious name attempting to break out of "..." in shell
+        let malicious_name = "user\"; touch /tmp/pwned; echo \"";
+        params.insert("name".to_string(), serde_json::json!(malicious_name));
+
+        let _ = module.execute(&params, &context);
+
+        let commands = conn.commands.lock().unwrap();
+        let mut found_injection = false;
+        for cmd in commands.iter() {
+            // Check if the command uses double quotes for the query argument (which allows injection)
+            // Vulnerable: ... -tAc "SELECT ..."
+            // Fixed: ... -tAc 'SELECT ...'
+            if cmd.contains(" -c \"") || cmd.contains(" -tAc \"") {
+                found_injection = true;
+            }
+
+            // Also verify that it IS quoted safely (starts with ')
+            if !cmd.contains(" -c '") && !cmd.contains(" -tAc '") {
+                // If it's not double quoted AND not single quoted, it might be unquoted (also dangerous if spaces)
+                // But shell_escape should quote it.
+                // Note: we can't assert strict failure here because shell_escape might use other quoting (though unlikely).
+                // But we definitely want to ensure NO double quotes wrapping the query.
+            }
+        }
+
+        assert!(
+            !found_injection,
+            "Command injection vulnerability detected! Query argument is wrapped in double quotes."
+        );
     }
 }


### PR DESCRIPTION
### **User description**
🚨 Severity: CRITICAL
💡 Vulnerability: Command Injection in `postgresql_user` module via unsafe `psql` command construction.
🎯 Impact: An attacker controlling the `name` parameter could execute arbitrary shell commands on the control node or remote host (depending on connection context).
🔧 Fix: Used `shell_escape` to safely quote the entire SQL query passed to `psql -c`, replacing unsafe double quotes.
✅ Verification: Added a regression test `test_postgres_user_injection` in `src/modules/database/postgresql_user.rs` that mocks the connection and asserts that the generated command does not use vulnerable double-quoting for the query argument.

---
*PR created automatically by Jules for task [1103549474629589720](https://jules.google.com/task/1103549474629589720) started by @dolagoartur*


___

### **PR Type**
Bug fix


___

### **Description**
- **Fixed critical command injection vulnerability** in `postgresql_user` module by replacing unsafe double-quoted SQL queries with `shell_escape()` function calls

- Applied security fix across 8 different SQL command constructions (role existence check, user attributes, groups query, user creation, alteration, password change, grant, and drop operations)

- Added comprehensive security regression test `test_postgres_user_injection` that validates malicious input cannot break out of shell quoting

- Added inline comments documenting command injection prevention in each affected location

- Performed extensive code formatting and whitespace normalization across 40+ files for improved readability and consistency (no functional changes to these files)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Unsafe SQL<br/>Double Quotes"] -->|"shell_escape()"| B["Safe Quoted<br/>SQL Queries"]
  B --> C["8 SQL Operations<br/>Protected"]
  C --> D["Regression Test<br/>Added"]
  D --> E["Command Injection<br/>Prevented"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><details><summary>44 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>filters.rs</strong><dd><code>Code formatting and whitespace normalization in filter functions</code></dd></summary>
<hr>

src/templating/filters.rs

<ul><li>Reformatted code for improved readability by breaking long lines and <br>adjusting indentation throughout multiple filter functions<br> <li> Standardized whitespace handling by removing trailing spaces and <br>normalizing blank lines<br> <li> Reorganized method chaining and function calls to follow consistent <br>formatting patterns<br> <li> Updated import statements to use alphabetical ordering (e.g., <code>Digest, </code><br><code>Sha1</code> instead of <code>Sha1, Digest</code>)</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-d94a704be76e1d46a7c191a0cb2c332494bfa16462a05337307280be8e6341e0">+318/-282</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>proxmox_vm.rs</strong><dd><code>Code formatting and parameter array restructuring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/proxmox_vm.rs

<ul><li>Reformatted <code>ALLOWED_CREATE_PARAMS</code> array by placing each parameter on a <br>separate line for improved readability<br> <li> Reorganized <code>ALLOWED_CLONE_PARAMS</code> and <code>ALLOWED_DELETE_PARAMS</code> with <br>aligned comments and consistent spacing<br> <li> Adjusted line breaks in function signatures and method calls <br>throughout the module<br> <li> Standardized whitespace and indentation in test functions and error <br>handling code</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-4b5ec37841650a1367b93b7a1f93f4157b8ccfa0b74af5acc35b7caa599b4647">+230/-113</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ssh_pipelining_benchmark.rs</strong><dd><code>Benchmark code formatting and test data restructuring</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

benches/ssh_pipelining_benchmark.rs

<ul><li>Reformatted benchmark test data structures by breaking long lines and <br>improving readability<br> <li> Reorganized command arrays and test vectors to use multi-line <br>formatting<br> <li> Adjusted function call formatting and conditional statement <br>indentation<br> <li> Standardized whitespace in benchmark group definitions and assertion <br>statements</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-25312248dbecdb14c5bb1f4296eb5a85a3714a5993b77975d7b333d82560fa2d">+101/-54</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>provisioner_cli_terraform_context_tests.rs</strong><dd><code>Test code formatting and import statement restructuring</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/provisioner_cli_terraform_context_tests.rs

<ul><li>Reformatted import statements to use multi-line format for improved <br>readability<br> <li> Adjusted assertion statements and test function calls to use <br>consistent line breaking<br> <li> Reorganized conditional logic and method chaining in test functions<br> <li> Standardized whitespace and indentation throughout test cases</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-e63da84f0a0d2f236393910bf4c59f4e00112bd088f94ead1d7fcbaa49c1523d">+101/-40</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>locking.rs</strong><dd><code>Locking module code formatting and function signature restructuring</code></dd></summary>
<hr>

src/state/locking.rs

<ul><li>Reformatted function signatures in trait definitions and <br>implementations to use multi-line parameter lists<br> <li> Adjusted whitespace and indentation in async function implementations<br> <li> Reorganized method chaining and error handling code for improved <br>readability<br> <li> Standardized blank line usage and indentation throughout the locking <br>backend implementations</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-0f79791b1836073dd2dc23241c2d743d961762bb5e686c0792eae7fc557076de">+144/-76</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parity.rs</strong><dd><code>Module parity tracker code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/parity.rs

<ul><li>Reformatted <code>ModuleStatus::is_usable()</code> match expression to use <br>multi-line format<br> <li> Adjusted function signatures and method implementations with improved <br>line breaking<br> <li> Reorganized module initialization and filtering operations for <br>consistency<br> <li> Standardized whitespace and indentation in async function <br>implementations and test cases</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-9062832b192923c3bf5b4beb8ec1b1f1f7f103eced7a38c3c115ee2ca49dc343">+82/-76</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task.rs</strong><dd><code>Task executor code formatting and method call restructuring</code></dd></summary>
<hr>

src/executor/task.rs

<ul><li>Reformatted long function calls and method chains to use multi-line <br>formatting<br> <li> Adjusted conditional expressions and variable assignments for improved <br>readability<br> <li> Reorganized error handling and template rendering code with consistent <br>indentation<br> <li> Standardized whitespace in async function implementations and module <br>execution paths</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-9203dad9236cc07f5e57e1ea81f0903141d47bdf16fce25d321e1244dc39c0b0">+80/-22</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>terraform.rs</strong><dd><code>Terraform inventory plugin test formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/inventory/plugins/terraform.rs

<ul><li>Reformatted assertion statement in test function to use multi-line <br>format<br> <li> Adjusted indentation and line breaking for improved readability in <br>test code</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-ac1dd42d9172d9b13afd91b4d0aeb2fdb3fbe5ae2364dcaa9ea9e2843e6bf41c">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Code formatting and import organization cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/state/storage/mod.rs

<ul><li>Reorganized import statements to follow alphabetical ordering <br>convention<br> <li> Fixed trailing whitespace issues throughout the file (replaced <br>trailing spaces with proper formatting)<br> <li> Reformatted multi-line function signatures and method calls for <br>improved readability<br> <li> No functional changes to the state storage backend implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-eda5c046a4089af4a32cecf54137d0867a1c776d5f1698ca3c59f92695987daf">+67/-49</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rich_errors.rs</strong><dd><code>Code formatting improvements for readability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/diagnostics/rich_errors.rs

<ul><li>Reformatted multi-line conditional expressions and function calls to <br>improve code readability<br> <li> Split long format strings and method chains across multiple lines with <br>proper indentation<br> <li> Improved line length compliance throughout error diagnostic functions<br> <li> No changes to error handling logic or functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-9686125e644ae6ebc254b7dce08d0c782ba8877728e376f452e7c16f50b6b12a">+49/-16</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>plan_accuracy_core_modules_tests.rs</strong><dd><code>Code formatting for pattern matching clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/plan_accuracy_core_modules_tests.rs

<ul><li>Reformatted pattern matching expressions to place each alternative on <br>separate lines for clarity<br> <li> Split long match arms across multiple lines with consistent <br>indentation<br> <li> Improved readability of module classification logic without changing <br>behavior<br> <li> Adjusted test assertion formatting for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-7d8d5576007441eab5868282d4e9ef103eab78e563446ce68e351bd7c95c8d5b">+74/-32</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ssh.rs</strong><dd><code>Code formatting improvements for SSH connection module</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/connection/ssh.rs

<ul><li>Reformatted multi-line method calls and error handling chains for <br>improved readability<br> <li> Split long function calls across multiple lines with proper <br>indentation<br> <li> Improved formatting of <code>map_err</code> closures and validation chains<br> <li> No functional changes to SSH connection logic</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-394a78a5f852fb99a485898ae16f198d7ad85e21e07a21851367e1d4cb919394">+42/-46</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>winrm_parity_tests.rs</strong><dd><code>Code formatting and comment alignment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/winrm_parity_tests.rs

<ul><li>Aligned comment columns in parameter documentation arrays for visual <br>consistency<br> <li> Reformatted parameter lists with improved spacing and alignment<br> <li> No changes to test logic or assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-a407fe3485817914fa83d0cea12aa65eba5ce1bfa98a3127628034dde04d56d3">+38/-46</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>template.rs</strong><dd><code>Code formatting for template engine module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/template.rs

<ul><li>Reformatted multi-line expression compilation and caching logic for <br>readability<br> <li> Split long method chains and conditional blocks across multiple lines<br> <li> Improved formatting of template variable insertion and error handling<br> <li> No changes to template engine functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-94a2be1bc04f2828bc51dc8bfbdc5593caf509f2c6f435755275f71c2d4de379">+17/-39</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>constructed.rs</strong><dd><code>Code formatting for regex pattern definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/inventory/constructed.rs

<ul><li>Reformatted regex pattern definitions to split across multiple lines <br>for clarity<br> <li> Improved indentation and line breaks in static regex lazy <br>initialization<br> <li> Enhanced readability of expression parser helper functions<br> <li> No changes to inventory construction logic</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-a3f9c6e3139b32d493d67824b785c1532c9a891bf281597fd868e993c7655f0b">+19/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>run.rs</strong><dd><code>Code formatting and import organization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/commands/run.rs

<ul><li>Reorganized import statements to follow alphabetical ordering<br> <li> Reformatted method chaining and output calls across multiple lines<br> <li> Split long format strings and conditional blocks for improved <br>readability<br> <li> No changes to command execution logic</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-7079c843406d39d728ff06f42e40f0db69f90bcc8af65e945d8e70bc8b95c1bf">+23/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>secrets_zeroization_tests.rs</strong><dd><code>Code formatting and import organization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/secrets_zeroization_tests.rs

<ul><li>Reorganized import statements to follow alphabetical ordering <br>convention<br> <li> Reformatted test data arrays with improved alignment and spacing<br> <li> Split long binary data arrays across multiple lines for readability<br> <li> No changes to secret zeroization test logic</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-49abfea8bf433a24094e1ffadb7f1f5509415bda42b648e25f4d17f4a7f7a171">+12/-25</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>manager.rs</strong><dd><code>Code formatting and import organization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/state/manager.rs

<ul><li>Reorganized import statements to follow alphabetical ordering<br> <li> Reformatted multi-line method calls and await expressions for clarity<br> <li> Split long error handling chains and state transitions across multiple <br>lines<br> <li> No changes to state management functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-b23e5f31a0c6099a8a418a5d125bbf9bf292719c600b02a279975773a09ea6f0">+26/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>proxmox_vm_tests.rs</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/proxmox_vm_tests.rs

<ul><li>Reformatted multi-line conditional expressions and JSON parsing logic<br> <li> Split long parameter insertion chains across multiple lines<br> <li> Improved readability of optional environment variable handling<br> <li> No changes to Proxmox VM test logic</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-d21b515d1e154ec03949ee0154bdc186338a56716b205276841f37ab5a8bf03a">+17/-29</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>provider.rs</strong><dd><code>Code formatting for provider registry module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/provider.rs

<ul><li>Reformatted provider lookup and error handling chains across multiple <br>lines<br> <li> Split long method calls in test assertions for improved readability<br> <li> Improved formatting of registry invocation test cases<br> <li> No changes to provider registry functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-87a3b5aed3e336a5c77fe5562172d359dee46ee7f64e4efc3d7dda83ac6a3292">+33/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>file.rs</strong><dd><code>Code formatting for file module functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/file.rs

<ul><li>Reformatted function signatures with multiple parameters across <br>multiple lines<br> <li> Improved indentation and line breaks in permission and ownership <br>setting functions<br> <li> Split error message formatting for better readability<br> <li> No changes to file module functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-d99cc560ee9acfb9115436d67297db417d17e643db9f6acdd1bf5053bfbc413c">+28/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>windows_integration_tests.rs</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/windows_integration_tests.rs

<ul><li>Reformatted assertion statements and parameter insertion across <br>multiple lines<br> <li> Split long JSON value insertions for improved readability<br> <li> Improved formatting of module classification assertions<br> <li> No changes to Windows integration test logic</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-867038598258cf98e681ee98e7ab77c2f88c4aba3d3798fcb56945a0d1960784">+20/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>db_modules_parity_tests.rs</strong><dd><code>Code formatting and alignment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/db_modules_parity_tests.rs

<ul><li>Reformatted assertion statements for SSL mode alternatives across <br>multiple lines<br> <li> Aligned parameter documentation comments for visual consistency<br> <li> Improved readability of database module parameter lists<br> <li> No changes to database parity test logic</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-4136c63419e2dc859535ee145ef72295662eb936b8d4261e389ac375a0f5cd4d">+29/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>uri_security_test.rs</strong><dd><code>Code formatting and import organization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/uri_security_test.rs

<ul><li>Reorganized import statements to follow alphabetical ordering<br> <li> Reformatted parameter insertion and URL formatting across multiple <br>lines<br> <li> Removed extra blank line for consistency<br> <li> No changes to URI security test logic</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-46a91363050467751a1c0f18397ab4cfacf55029ce32a6cd225434c1cda2a997">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>agent_mode_pilot_tests.rs</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/agent_mode_pilot_tests.rs

<ul><li>Reformatted builder method chaining across multiple lines<br> <li> Split JSON deserialization and parameter parsing for improved <br>readability<br> <li> Improved formatting of multi-line string literals<br> <li> No changes to agent mode pilot test logic</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-d8ea953352c336fd91da29ea5e764bdd0faec8aa7c94730d59cb47b002f58b4c">+5/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Code formatting for regex patterns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/analysis/mod.rs

<ul><li>Reformatted static regex pattern definitions to split across multiple <br>lines<br> <li> Improved indentation and line breaks in lazy regex initialization<br> <li> Enhanced readability of pattern matching helpers<br> <li> No changes to analysis module functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-33d7e049098ea523336d92f302d024c94ab3db07e5bf5520ef1546f298c65c3d">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Code formatting and import organization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/executor/mod.rs

<ul><li>Reorganized public use statements to follow alphabetical ordering<br> <li> Reformatted multi-line task execution method calls across multiple <br>lines<br> <li> Improved indentation of method parameters and arguments<br> <li> No changes to executor functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-a19ea33646ff7837f5d39e725ed6ef4f4c7d7d496185a4f51aba94c677c954b7">+17/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docs_compatibility_sync_tests.rs</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/docs_compatibility_sync_tests.rs

<ul><li>Reformatted function signatures with multiple parameters across <br>multiple lines<br> <li> Split file reading and feature extraction logic for improved <br>readability<br> <li> Improved formatting of assertion statements<br> <li> No changes to documentation compatibility test logic</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-b5a36a077d87f2ff4e789b0d31d1cbbdc081a0d5d752ea6db0da1faabfa74631">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hashing.rs</strong><dd><code>Code formatting for error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/state/hashing.rs

<ul><li>Reformatted file reading error handling across multiple lines<br> <li> Split error construction and mapping for improved readability<br> <li> Improved indentation of nested error creation<br> <li> No changes to state hashing functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-d0bbffbaeb720d5682d4b6da8ad5e70ee4844a2610e671266f3b2257c477316d">+10/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>condition.rs</strong><dd><code>Code formatting for condition expressions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/executor/condition.rs

<ul><li>Reformatted string concatenation and format expressions across <br>multiple lines<br> <li> Improved indentation of multi-line format! macro calls<br> <li> Enhanced readability of condition transformation logic<br> <li> No changes to condition evaluation functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-1498e9622fd59c3db79d460d384774a4a3391cbe4790cc4ec0a12f570cf05c09">+12/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>facts.rs</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/facts.rs

<ul><li>Reformatted multi-line conditional expressions and await calls<br> <li> Split long method chains across multiple lines for clarity<br> <li> Improved indentation of output execution and parsing logic<br> <li> No changes to facts gathering functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-d9751668b6274ee3c9aa9ce30e785ccd4884f13160f2bd098df6bfa8976e8c5a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>unified_templating_engine_tests.rs</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unified_templating_engine_tests.rs

<ul><li>Reformatted render function calls and assertions across multiple lines<br> <li> Split method chaining for improved readability<br> <li> Improved formatting of condition evaluation assertions<br> <li> No changes to templating engine test logic</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-f814afa17f518402b17d1895d1d5fea98b689758a20e457ccc577f63e9ded2eb">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vault.rs</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/commands/vault.rs

<ul><li>Reformatted spinner creation and error handling across multiple lines<br> <li> Split long error message formatting for improved readability<br> <li> Improved indentation of result handling blocks<br> <li> No changes to vault command functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-89bfd2c7810a6cd5c3326c9f47d7b341c45da66702a365ce2f3905deee4409c4">+10/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>native_remote_facts_parity_tests.rs</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/native_remote_facts_parity_tests.rs

<ul><li>Reformatted function signature with parameter across multiple lines<br> <li> Split assertion statements for improved readability<br> <li> Improved formatting of test validation logic<br> <li> No changes to native remote facts test logic</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-f2ddeebe035fe20dee0bed2539d03d2997c0244e6563f419488aeedb3c9e69d5">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/commands/mod.rs

<ul><li>Reformatted CLI parsing and variable extraction across multiple lines<br> <li> Split assertion statements for improved readability<br> <li> Improved formatting of test helper functions<br> <li> No changes to command module functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-38da8705fdf2662e3e19585f900ecaa4856c7edd07d6686cc3a7a8f829fd1653">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>templating_performance_regression_tests.rs</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/templating_performance_regression_tests.rs

<ul><li>Reformatted expression measurement calls across multiple lines<br> <li> Split variable assignments for improved readability<br> <li> Improved formatting of performance test logic<br> <li> No changes to templating performance test functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-1d0979df3ff8536a3fb4ac04267c3de408a8f35205f93b85f997c84eb6b04f3a">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main.rs

<ul><li>Reformatted lock command execution block across multiple lines<br> <li> Improved indentation and readability of command match arm<br> <li> No changes to main function logic</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fc">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vault.rs</strong><dd><code>Code formatting for error messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/secrets/vault.rs

<ul><li>Reformatted error message formatting across multiple lines<br> <li> Split error construction for improved readability<br> <li> Improved indentation of secret key lookup error handling<br> <li> No changes to vault provider functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-026cde9b2ac0d8096d967aa98f92da97c639d3ec956ebcf1fe16c764631aa608">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>awx.rs</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/api/awx.rs

<ul><li>Reformatted assertion statements across multiple lines<br> <li> Split job status conversion assertions for improved readability<br> <li> Improved formatting of test assertions<br> <li> No changes to AWX API functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-9a89d89d992891b0c2985a690cd306c787405bf321fcb5f5efd8a6d8d32e6cd4">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>script.rs</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/script.rs

<ul><li>Reformatted assertion and error message checking across multiple lines<br> <li> Split method chaining for improved readability<br> <li> Improved formatting of test validation logic<br> <li> No changes to script module functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-ad83e21c20ef0df8a39abda1025a4eeccf5cf3f4bec969e213885b1ac6f413c6">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>performance_tests.rs</strong><dd><code>Code formatting fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/performance_tests.rs

<ul><li>Fixed indentation of struct initialization default field<br> <li> Improved formatting consistency in executor configuration<br> <li> No changes to performance test logic</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-7784113375aa5980727aee3c511d8c71fd3607b5475dd106574843ec03dd21f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lock.rs</strong><dd><code>Code formatting for imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/commands/lock.rs

<ul><li>Reformatted import statement across multiple lines<br> <li> Improved readability of lockfile-related imports<br> <li> No changes to lock command functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-b64ef92d3ec286a0ff0573be2e502bfc5ca48356507a1f07adb51e6510773a1b">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parallel_stress_tests.rs</strong><dd><code>Code formatting fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/parallel_stress_tests.rs

<ul><li>Fixed indentation of struct initialization default field<br> <li> Improved formatting consistency in executor configuration<br> <li> No changes to parallel stress test logic</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-532a18eacc7fec89e116d0ec3bb58f5446b626694092543a66a637c36470b559">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Code formatting and import organization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/mod.rs

<ul><li>Reorganized public use statements to follow alphabetical ordering<br> <li> Reformatted provider prelude exports across multiple lines<br> <li> Improved readability of module exports<br> <li> No changes to plugins module functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-81622de67d9d2c5e34d9e7e7e05d0f6185a408d81cefdc2c8f3a6a72a33cc9f8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>postgresql_user.rs</strong><dd><code>Fix command injection in postgresql_user module via shell_escape</code></dd></summary>
<hr>

src/modules/database/postgresql_user.rs

<ul><li>Fixed critical command injection vulnerability by replacing unsafe <br>double-quoted SQL queries with <code>shell_escape()</code> function calls<br> <li> Applied fix across 8 different SQL command constructions (role <br>existence check, user attributes, groups query, user creation, <br>alteration, password change, grant, and drop operations)<br> <li> Added comprehensive security regression test <br><code>test_postgres_user_injection</code> that validates malicious input cannot <br>break out of shell quoting<br> <li> Added inline comments documenting the command injection prevention in <br>each affected location</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/426/files#diff-47ec703d34906a63d8cc8f4dd48c9933bb4da3980eecb73bdbe1073887453d2d">+149/-16</a></td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

