### PR TITLE
⚡ Bolt: Optimized Template Context Serialization

### DIFF
--- a/src/modules/template.rs
+++ b/src/modules/template.rs
@@ -10,46 +10,80 @@ use super::{
 use crate::connection::TransferOptions;
 use crate::template::TEMPLATE_ENGINE;
 use crate::utils::shell_escape;
+use serde::ser::{Serialize, Serializer, SerializeMap};
+use std::collections::{BTreeSet, HashMap};
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+/// Context wrapper that merges vars, facts, and extra_vars without cloning
+struct MergedContext<'a> {
+    vars: &'a HashMap<String, serde_json::Value>,
+    facts: &'a HashMap<String, serde_json::Value>,
+    extra_vars: Option<&'a serde_json::Value>,
+}
+
+impl<'a> Serialize for MergedContext<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Use BTreeSet for deterministic order of keys
+        let mut keys: BTreeSet<&str> = BTreeSet::new();
+
+        if let Some(serde_json::Value::Object(obj)) = self.extra_vars {
+            keys.extend(obj.keys().map(|s| s.as_str()));
+        }
+
+        // Always include ansible_facts key
+        keys.insert("ansible_facts");
+
+        // Add facts keys
+        keys.extend(self.facts.keys().map(|s| s.as_str()));
+
+        // Add vars keys
+        keys.extend(self.vars.keys().map(|s| s.as_str()));
+
+        let mut map = serializer.serialize_map(Some(keys.len()))?;
+
+        for key in keys {
+            // Priority 1: Extra vars
+            if let Some(serde_json::Value::Object(obj)) = self.extra_vars {
+                if let Some(val) = obj.get(key) {
+                    map.serialize_entry(key, val)?;
+                    continue;
+                }
+            }
+
+            // Priority 2: Facts
+            if key == "ansible_facts" {
+                // Special case: the ansible_facts key itself maps to the whole facts map
+                map.serialize_entry(key, self.facts)?;
+                continue;
+            }
+
+            if let Some(val) = self.facts.get(key) {
+                map.serialize_entry(key, val)?;
+                continue;
+            }
+
+            // Priority 3: Vars
+            if let Some(val) = self.vars.get(key) {
+                map.serialize_entry(key, val)?;
+                continue;
+            }
+        }
+
+        map.end()
+    }
+}
+
 /// Module for rendering templates
 pub struct TemplateModule;
 
 impl TemplateModule {
-    fn build_context(
-        context: &ModuleContext,
-        extra_vars: Option<&serde_json::Value>,
-    ) -> serde_json::Value {
-        let mut ctx_map = serde_json::Map::new();
-
-        // Add variables
-        for (key, value) in &context.vars {
-            ctx_map.insert(key.clone(), value.clone());
-        }
-
-        // Add facts
-        ctx_map.insert(
-            "ansible_facts".to_string(),
-            serde_json::json!(&context.facts),
-        );
-        for (key, value) in &context.facts {
-            ctx_map.insert(key.clone(), value.clone());
-        }
-
-        // Add extra variables if provided
-        if let Some(serde_json::Value::Object(vars)) = extra_vars {
-            for (key, value) in vars {
-                ctx_map.insert(key.clone(), value.clone());
-            }
-        }
-
-        serde_json::Value::Object(ctx_map)
-    }
-
     #[allow(clippy::too_many_arguments)]
     async fn execute_remote(
         conn: Arc<dyn crate::connection::Connection + Send + Sync>,
@@ -183,16 +217,6 @@ impl TemplateModule {
         }
 
         Ok(output)
-    }
-
-    fn render_template(
-        template_content: &str,
-        context: &serde_json::Value,
-    ) -> ModuleResult<String> {
-        // Use the shared global TemplateEngine
-        TEMPLATE_ENGINE
-            .render_with_json(template_content, context)
-            .map_err(|e| ModuleError::TemplateError(format!("Failed to render template: {}", e)))
     }
 
     fn create_backup(dest: &Path, backup_suffix: &str) -> ModuleResult<Option<String>> {
@@ -414,9 +438,17 @@ impl Module for TemplateModule {
         };
         let _src_path = Path::new(&src_name);
 
-        // Build context and render
-        let ctx = Self::build_context(context, extra_vars);
-        let rendered = Self::render_template(&template_content, &ctx)?;
+        // Build context and render using zero-allocation strategy
+        let ctx = MergedContext {
+            vars: &context.vars,
+            facts: &context.facts,
+            extra_vars,
+        };
+
+        // Use render_serialize to avoid cloning context into intermediate Value
+        let rendered = TEMPLATE_ENGINE
+            .render_serialize(&template_content, &ctx)
+            .map_err(|e| ModuleError::TemplateError(format!("Failed to render template: {}", e)))?;
 
         // Check if we have a connection for remote execution
         if let Some(ref conn) = context.connection {

--- a/src/template.rs
+++ b/src/template.rs
@@ -307,6 +307,14 @@ impl TemplateEngine {
         self.render_cached(template, context)
     }
 
+    /// Render a template string with any Serializable context
+    ///
+    /// This allows rendering with custom structs or optimized context wrappers
+    /// without converting to serde_json::Value first.
+    pub fn render_serialize<S: serde::Serialize>(&self, template: &str, vars: &S) -> Result<String> {
+        self.render_cached(template, vars)
+    }
+
     /// Render a JSON value, templating any strings within it
     ///
     /// Recursively templates all string values in the JSON structure.


### PR DESCRIPTION
### **User description**
⚡ Bolt: Optimized Template Context Serialization

💡 What:
Replaced the `build_context` function in `src/modules/template.rs`, which was deeply cloning `vars`, `facts`, and `extra_vars` into a new `serde_json::Value`, with a `MergedContext` struct. This struct holds references to the existing maps and implements `serde::Serialize` to merge them on-the-fly during serialization.

🎯 Why:
Creating a new `serde_json::Map` for every template rendering involves allocating memory for every key and value. When `ansible_facts` contains extensive system information, this operation becomes expensive (both in CPU and memory) and runs for every template task.

📊 Impact:
- Eliminates O(N) deep clones of context variables per template execution.
- Reduces memory pressure by avoiding intermediate JSON object construction.
- Expected to speed up template rendering significantly in playbooks with large fact sets.

🔬 Measurement:
Verified with `cargo test --lib modules::template` to ensure:
- Variable precedence is preserved (`extra_vars` overrides `facts`, `facts` override `vars`).
- `ansible_facts` key is correctly populated.
- Basic template rendering, loops, and conditionals function as expected.
Verified `template` engine tests pass to ensure no regression in the engine itself.

---
*PR created automatically by Jules for task [10249682647001888441](https://jules.google.com/task/10249682647001888441) started by @dolagoartur*


___

### **PR Type**
Enhancement


___

### **Description**
- Replaced deep cloning with zero-copy `MergedContext` struct for template context serialization

- Implements custom `serde::Serialize` to merge vars, facts, and extra_vars on-the-fly

- Added `render_serialize` method to `TemplateEngine` for generic serializable contexts

- Eliminates O(N) memory allocations and deep clones per template rendering


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Template Module"] -->|"build_context"| B["Deep Clone vars/facts/extra_vars"]
  B --> C["serde_json::Value"]
  C --> D["render_with_json"]
  D --> E["Rendered Output"]
  
  F["Template Module"] -->|"MergedContext"| G["Reference-based Struct"]
  G --> H["render_serialize"]
  H --> E
  
  style B fill:#ff9999
  style G fill:#99ff99
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>template.rs</strong><dd><code>Replace deep cloning with reference-based MergedContext</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/modules/template.rs

<ul><li>Introduced <code>MergedContext<'a></code> struct that holds references to vars, facts, <br>and extra_vars<br> <li> Implemented custom <code>serde::Serialize</code> for <code>MergedContext</code> with <br>deterministic key ordering via <code>BTreeSet</code><br> <li> Enforces correct precedence logic: extra_vars > facts > vars, with <br>special handling for <code>ansible_facts</code> key<br> <li> Removed <code>build_context</code> function that performed expensive deep cloning<br> <li> Removed <code>render_template</code> helper function and integrated rendering <br>directly into module execution<br> <li> Updated template rendering call to use <br><code>TEMPLATE_ENGINE.render_serialize()</code> with the new <code>MergedContext</code></ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/434/files#diff-9bcc0c5b8fc326a0b519b499122f1e55e4b4c74ba0d50a50b0b6df8e40593da9">+69/-37</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>template.rs</strong><dd><code>Add generic serializable context rendering method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/template.rs

<ul><li>Added new <code>render_serialize</code> public method to <code>TemplateEngine</code> that <br>accepts any <code>serde::Serialize</code> type<br> <li> Method delegates to existing <code>render_cached</code> infrastructure for <br>consistency<br> <li> Enables rendering with custom context wrappers without intermediate <br>JSON conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/434/files#diff-94a2be1bc04f2828bc51dc8bfbdc5593caf509f2c6f435755275f71c2d4de379">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

