### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix command injection vulnerability via shell comments

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,7 +31,7 @@
 ## 2024-05-27 - Path Traversal in Systemd Unit Module
 **Vulnerability:** The `systemd_unit` module accepted arbitrary paths for `unit_path` without validation, allowing creation of files outside intended directories via `..` (e.g., `/etc/systemd/system/../../tmp/evil.service`).
 **Learning:** Relying on `Path::join` without inspecting components allows directory traversal if user input contains `..`. System modules often run with elevated privileges, making filesystem boundaries critical.
-**Prevention:** Validate all file paths from user input. Enforce absolute paths where required and explicitly reject paths containing `ParentDir` (`..`) components to prevent directory traversal.
+**Prevention:** Validate all file paths from user input. Enforce absolute paths where required and explicitly reject paths containing `ParentDir` (`..`) components or absolute paths.
 
 ## 2024-05-28 - ZipSlip/Path Traversal in Unarchive Module
 **Vulnerability:** The `unarchive` module was vulnerable to a path traversal attack (ZipSlip) when extracting tar archives. Specifically, it joined the destination directory with the archive entry path without validation before checking for file existence (for the `keep_newer` feature). This allowed an attacker to probe for the existence and modification time of arbitrary files on the system by crafting a tarball with entries like `../etc/passwd`.
@@ -66,3 +66,8 @@
 **Vulnerability:** The `validate_command_args` function used a blacklist approach that missed several dangerous shell metacharacters (`*`, `?`, `{`, `}`, `(`, `)`, `[`, `]`, `\`, `!`). This could allow attackers to bypass validation and inject commands or arguments (e.g., via brace expansion `{echo,pwn}` or globbing) in modules like `script` and `service`.
 **Learning:** Blacklists are inherently fragile for security validation because it is difficult to anticipate all possible dangerous inputs. Shell expansion rules are complex and vary by shell.
 **Prevention:** The blacklist in `validate_command_args` was strengthened to include these missing characters. Where possible, avoid constructing shell commands from untrusted strings; prefer passing arguments arrays to `std::process::Command` directly.
+
+## 2025-06-01 - Command Injection via Comments
+**Vulnerability:** The `validate_command_args` utility did not blacklist the `#` character. This allowed an attacker to inject command arguments (e.g., in `ScriptModule`'s `executable` parameter) that included a shell comment, effectively neutralizing subsequent parts of the constructed command string (such as the target script path or arguments) and allowing the injected executable to run with arbitrary arguments or as a standalone command.
+**Learning:** In shell command construction, even seemingly benign characters like `#` can be weaponized to alter control flow (by truncating execution). Validation must account for all shell metacharacters, including those that don't execute commands directly but modify how the shell parses the line.
+**Prevention:** Added `#` to the blacklist in `validate_command_args`. When constructing shell commands, consider all shell metacharacters including comments.

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -413,6 +413,7 @@ pub fn validate_command_args(args: &str) -> ModuleResult<()> {
         ("!", "history expansion !"),
         ("\\", "shell escaping \\"),
         ("$", "variable expansion $"),
+        ("#", "shell comment #"),
     ];
 
     for (pattern, description) in dangerous_patterns {
@@ -1915,6 +1916,14 @@ mod tests {
         // Extended checks
         assert!(validate_command_args("bash;echo").is_err());
         assert!(validate_command_args("cmd&").is_err());
+    }
+
+    #[test]
+    fn test_validate_command_args_rejects_hash() {
+        // This test asserts that validation FAILS when a hash is present.
+        // Currently, without the fix, this test would fail (because it returns Ok).
+        // The goal is to make this test pass by fixing the code to return Err.
+        assert!(validate_command_args("bash -c 'echo pwned' #").is_err());
     }
 
     #[test]


### PR DESCRIPTION
### **User description**
🚨 Severity: HIGH
💡 Vulnerability: The `validate_command_args` function failed to block the `#` character. This allowed attackers to inject shell comments into command strings (e.g., via the `executable` parameter in the `script` module), effectively truncating the command and neutralizing subsequent arguments (such as the script path or security parameters).
🎯 Impact: An attacker could bypass restrictions and execute arbitrary commands or modify the execution flow of the `script` and `service` modules.
🔧 Fix: Added `#` to the blacklist of dangerous shell characters in `src/modules/mod.rs` and added a regression test.
✅ Verification: Added `test_validate_command_args_rejects_hash` which confirms that strings containing `#` are now rejected.

---
*PR created automatically by Jules for task [11411646019687866570](https://jules.google.com/task/11411646019687866570) started by @dolagoartur*


___

### **PR Type**
Bug fix


___

### **Description**
- Added `#` character to blacklist in `validate_command_args` function

- Prevents command injection via shell comments in script/service modules

- Added regression test `test_validate_command_args_rejects_hash`

- Updated security documentation with vulnerability details


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Input with #"] -->|validate_command_args| B["Blacklist Check"]
  B -->|# now blocked| C["Validation Fails"]
  C -->|Prevents| D["Command Injection"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add hash character to command validation blacklist</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/mod.rs

<ul><li>Added <code>#</code> character to the dangerous patterns blacklist in <br><code>validate_command_args</code><br> <li> Added new regression test <code>test_validate_command_args_rejects_hash</code> to <br>verify hash character rejection<br> <li> Test ensures strings containing <code>#</code> are properly rejected by validation</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/436/files#diff-90d2c2330dd750ac18b6a3a2b13fcb041216ac7e0efef9a2ff729ebf2184f686">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sentinel.md</strong><dd><code>Document command injection vulnerability and prevention</code>&nbsp; &nbsp; </dd></summary>
<hr>

.jules/sentinel.md

<ul><li>Fixed typo in path traversal prevention guidance (added "or absolute <br>paths")<br> <li> Added new vulnerability entry documenting command injection via <br>comments<br> <li> Documented learning that shell metacharacters like <code>#</code> can alter control <br>flow<br> <li> Provided prevention guidance for shell command construction</ul>


</details>


  </td>
  <td><a href="https://github.com/adolago/rustible/pull/436/files#diff-92c8ea7491b8afdf97b053a12e7f4f811041aa6b960c19005077c840ca892922">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

