### PR TITLE
🎨 Palette: Add semantic emojis to interactive menus

### DIFF
--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -105,7 +105,10 @@ impl InteractiveSession {
             return Ok(None);
         }
 
-        let items: Vec<String> = playbooks.iter().map(|p| p.display().to_string()).collect();
+        let items: Vec<String> = playbooks
+            .iter()
+            .map(|p| format!("📖 {}", p.display()))
+            .collect();
 
         let selection = Select::with_theme(&self.theme)
             .with_prompt("Select a playbook")
@@ -132,7 +135,7 @@ impl InteractiveSession {
 
         let mut items: Vec<String> = inventories
             .iter()
-            .map(|p| p.display().to_string())
+            .map(|p| format!("📋 {}", p.display()))
             .collect();
         items.push("✏️ Enter custom path...".to_string());
         items.push("🏠 Use localhost (no inventory)".to_string());
@@ -172,9 +175,11 @@ impl InteractiveSession {
             return Ok(vec![]);
         }
 
+        let items: Vec<String> = available_tags.iter().map(|t| format!("🏷️ {}", t)).collect();
+
         let selections = MultiSelect::with_theme(&self.theme)
             .with_prompt("Select tags to run (space to select, enter to confirm)")
-            .items(available_tags)
+            .items(&items)
             .interact_on(&self.term)?;
 
         Ok(selections


### PR DESCRIPTION
🎨 **Palette Improvement: Semantic Emojis in Interactive Menus**

**💡 What:**
Added semantic emoji prefixes to dynamic lists in the interactive CLI mode:
*   `📖` for Playbooks
*   `📋` for Inventory files
*   `🏷️` for Tags

**🎯 Why:**
Pure text lists in terminals can be dense and hard to scan. By adding consistent visual anchors (emojis), we improve scannability and align the sub-menus with the main menu's aesthetic, creating a more cohesive and delightful user experience.

**📸 Visuals:**
*   **Playbooks:** `📖 playbooks/site.yml`
*   **Inventory:** `📋 inventory/hosts.yml`
*   **Tags:** `🏷️ deploy`

**♿ Accessibility:**
Emojis are decorative but semantic; they don't interfere with screen readers (which read the emoji name, e.g., "open book playbooks/site.yml"), providing context. Spacing ensures clear separation from text.

---
*PR created automatically by Jules for task [2306417428814061696](https://jules.google.com/task/2306417428814061696) started by @dolagoartur*