### PR TITLE
🛡️ Sentinel: Fix command injection vulnerability on unknown OS targets

### DIFF
--- a/src/modules/command.rs
+++ b/src/modules/command.rs
@@ -68,6 +68,10 @@ impl CommandModule {
                 // reasonably well for both cmd.exe and PowerShell, whereas POSIX
                 // single quotes fail completely on cmd.exe.
                 "cmd".to_string()
+            } else if os_family == "unknown" {
+                return Err(ModuleError::InvalidParameter(
+                    "Cannot determine shell type (os_family unknown). Please specify 'shell_type' (e.g., 'cmd', 'powershell', 'posix') or ensure facts are gathered.".to_string(),
+                ));
             } else {
                 "posix".to_string()
             }
@@ -640,5 +644,35 @@ mod tests {
         // Should default to posix escaping (single quotes where needed)
         // 'echo' is safe so it's not quoted. 'hello & calc.exe' is quoted.
         assert_eq!(cmd, "echo 'hello & calc.exe'");
+    }
+}
+
+#[cfg(test)]
+mod security_repro {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_error_on_unknown_os() {
+        let module = CommandModule;
+        let mut params: ModuleParams = HashMap::new();
+        params.insert(
+            "argv".to_string(),
+            serde_json::json!(["echo", "hello & calc.exe"]),
+        );
+
+        // Context with no facts (unknown OS)
+        let context = ModuleContext::default();
+
+        let result = module.get_command_string(&params, &context);
+
+        // Verify that we now error out instead of defaulting to dangerous POSIX escaping
+        assert!(result.is_err());
+        match result {
+            Err(ModuleError::InvalidParameter(msg)) => {
+                assert!(msg.contains("Cannot determine shell type"));
+            }
+            _ => panic!("Expected InvalidParameter error"),
+        }
     }
 }


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix command injection vulnerability on unknown OS targets

🚨 Severity: HIGH
💡 Vulnerability: The `command` module defaulted to POSIX-style shell escaping (single quotes) when the target OS could not be determined (i.e., when `os_family` fact was missing or "unknown"). On Windows hosts using `cmd.exe`, single quotes are treated as literal characters, not strong quotes. This allowed an attacker who could control arguments passed to the `command` module (via `argv`) to inject arbitrary commands (e.g., `& calc.exe`) if the playbook ran against a Windows host without gathering facts.

🎯 Impact: Remote Command Execution (RCE) on Windows targets if facts are not gathered or OS detection fails.

🔧 Fix: Modified `src/modules/command.rs` to fail securely. If `shell_type` is unspecified and `os_family` is unknown, the module now returns an error instructing the user to specify the shell type or gather facts, rather than guessing (wrongly) that it is safe to use POSIX escaping.

✅ Verification:
- Added a regression test `test_error_on_unknown_os` in `src/modules/command.rs`.
- The test simulates an environment with no facts (`ModuleContext::default()`) and verifies that `get_command_string` returns an `InvalidParameter` error instead of a dangerously escaped string.
- Ran `cargo test test_error_on_unknown_os` to confirm the fix.

---
*PR created automatically by Jules for task [276640808688676919](https://jules.google.com/task/276640808688676919) started by @dolagoartur*