### PR TITLE
⚡ Bolt: Optimize template filters `join` and `title`

### DIFF
--- a/benches/template_benchmark.rs
+++ b/benches/template_benchmark.rs
@@ -10,6 +10,7 @@
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use once_cell::sync::Lazy;
+use rustible::template::TemplateEngine;
 use std::collections::HashMap;
 use tera::{Context as TeraContext, Tera};
 
@@ -885,8 +886,55 @@ fn bench_template_memory_patterns(c: &mut Criterion) {
 }
 
 // ============================================================================
+// Filter Optimization Benchmarks
+// ============================================================================
+
+fn bench_filter_join_opt(c: &mut Criterion) {
+    let mut group = c.benchmark_group("filter_join_optimization");
+
+    let engine = TemplateEngine::new();
+    let mut vars = HashMap::new();
+
+    let list: Vec<String> = (0..1000).map(|i| format!("item_{}", i)).collect();
+    vars.insert("list".to_string(), serde_json::to_value(list).unwrap());
+
+    // Pre-compile template
+    let template = "{{ list | join(',') }}";
+
+    group.bench_function("join_1000_items", |b| {
+        b.iter(|| engine.render(black_box(template), black_box(&vars)).unwrap())
+    });
+
+    group.finish();
+}
+
+fn bench_filter_title_opt(c: &mut Criterion) {
+    let mut group = c.benchmark_group("filter_title_optimization");
+
+    let engine = TemplateEngine::new();
+    let mut vars = HashMap::new();
+
+    let text = "hello world ".repeat(1000);
+    vars.insert("text".to_string(), serde_json::to_value(text).unwrap());
+
+    let template = "{{ text | title }}";
+
+    group.bench_function("title_2000_words", |b| {
+        b.iter(|| engine.render(black_box(template), black_box(&vars)).unwrap())
+    });
+
+    group.finish();
+}
+
+// ============================================================================
 // Criterion Groups and Main
 // ============================================================================
+
+criterion_group!(
+    optimization_benches,
+    bench_filter_join_opt,
+    bench_filter_title_opt,
+);
 
 criterion_group!(
     parsing_benches,
@@ -940,4 +988,5 @@ criterion_main!(
     detection_benches,
     comparison_benches,
     memory_benches,
+    optimization_benches,
 );

--- a/src/template.rs
+++ b/src/template.rs
@@ -531,20 +531,28 @@ fn filter_capitalize(value: &str) -> String {
 }
 
 fn filter_title(value: &str) -> String {
-    value
-        .split_whitespace()
-        .map(|word| {
-            let mut chars = word.chars();
-            match chars.next() {
-                None => String::new(),
-                Some(c) => c
-                    .to_uppercase()
-                    .chain(chars.map(|c| c.to_lowercase().next().unwrap_or(c)))
-                    .collect(),
+    let mut result = String::with_capacity(value.len());
+    let mut first_word = true;
+
+    for word in value.split_whitespace() {
+        if !first_word {
+            result.push(' ');
+        }
+        first_word = false;
+
+        let mut chars = word.chars();
+        if let Some(c) = chars.next() {
+            for uc in c.to_uppercase() {
+                result.push(uc);
             }
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
+            for c in chars {
+                for lc in c.to_lowercase() {
+                    result.push(lc);
+                }
+            }
+        }
+    }
+    result
 }
 
 fn filter_trim(value: &str) -> String {
@@ -600,11 +608,17 @@ fn filter_split(value: &str, sep: Option<&str>) -> Vec<String> {
 
 fn filter_join(value: Vec<MiniJinjaValue>, sep: Option<&str>) -> String {
     let sep = sep.unwrap_or("");
-    value
-        .iter()
-        .map(|v| v.to_string())
-        .collect::<Vec<_>>()
-        .join(sep)
+    let mut result = String::new();
+    for (i, v) in value.iter().enumerate() {
+        if i > 0 {
+            result.push_str(sep);
+        }
+        use std::fmt::Write;
+        // Optimization: Write directly to string buffer to avoid allocating
+        // intermediate Strings and Vec<String>
+        write!(result, "{}", v).unwrap();
+    }
+    result
 }
 
 fn filter_int(value: MiniJinjaValue) -> i64 {


### PR DESCRIPTION
💡 **What**: Optimized `filter_join` and `filter_title` in the template engine to minimize memory allocations.

🎯 **Why**: These filters were using inefficient iterator chains involving multiple intermediate `String` and `Vec` allocations.
* `join` was converting every element to String, collecting into a Vec, then joining.
* `title` was splitting into words, mapping each word (allocating String), collecting into Vec, then joining.

📊 **Impact**:
* `filter_join`: **~33% faster**
* `filter_title`: **~65% faster**

🔬 **Measurement**:
Added new benchmarks to `benches/template_benchmark.rs`.
Verified with `cargo bench --bench template_benchmark optimization`.

**Baseline**:
* `join`: ~156 µs
* `title`: ~275 µs

**Optimized**:
* `join`: ~106 µs
* `title`: ~94 µs

---
*PR created automatically by Jules for task [18344254606379427140](https://jules.google.com/task/18344254606379427140) started by @dolagoartur*