### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection in CommandModule

### DIFF
--- a/src/modules/command.rs
+++ b/src/modules/command.rs
@@ -7,8 +7,9 @@
 //! execution via async connections (SSH, Docker, etc.).
 
 use super::{
-    validate_env_var_name, validate_path_param, Module, ModuleClassification, ModuleContext,
-    ModuleError, ModuleOutput, ModuleParams, ModuleResult, ParamExt,
+    validate_command_args, validate_env_var_name, validate_path_param, Module,
+    ModuleClassification, ModuleContext, ModuleError, ModuleOutput, ModuleParams, ModuleResult,
+    ParamExt,
 };
 use crate::connection::{Connection, ExecuteOptions};
 use crate::utils::{cmd_escape, powershell_escape, shell_escape};
@@ -461,6 +462,14 @@ impl Module for CommandModule {
                 "Either 'cmd' or 'argv' must be provided".to_string(),
             ));
         }
+
+        if let Some(cmd) = params.get_string("cmd")? {
+            validate_command_args(&cmd)?;
+        }
+        if let Some(cmd) = params.get_string("_raw_params")? {
+            validate_command_args(&cmd)?;
+        }
+
         Ok(())
     }
 
@@ -679,5 +688,21 @@ mod security_repro {
             }
             _ => panic!("Expected InvalidParameter error"),
         }
+    }
+}
+
+#[cfg(test)]
+mod security_check {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_command_module_rejects_shell_injection() {
+        let module = CommandModule;
+        let mut params: ModuleParams = HashMap::new();
+        params.insert("cmd".to_string(), serde_json::json!("ls | grep vulnerable"));
+
+        // After fix: This should return Err because validate_command_args is called
+        assert!(module.validate_params(&params).is_err());
     }
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix command injection in CommandModule

🚨 Severity: HIGH
💡 Vulnerability: The `CommandModule` allowed shell metacharacters (e.g., `|`, `;`, `&`) in the `cmd` (string) parameter. While `CommandModule` is intended to execute commands directly without a shell, remote execution via SSH implicitly uses a shell (`sh -c ...`). This allowed attackers to execute arbitrary shell commands (command injection) if they could control the `cmd` parameter, violating the 'no shell' guarantee of the module.
🎯 Impact: Remote Code Execution (RCE) via command injection if user input is passed to `cmd` parameter.
🔧 Fix: Updated `CommandModule::validate_params` to call `validate_command_args` on `cmd` and `_raw_params` inputs. This function rejects strings containing dangerous shell metacharacters. Users requiring shell features should use the `shell` module or pass arguments via `argv`.
✅ Verification: Added regression test `test_command_module_rejects_shell_injection` which asserts that `validate_params` returns an error when shell metacharacters are present.

---
*PR created automatically by Jules for task [15840203935833541764](https://jules.google.com/task/15840203935833541764) started by @dolagoartur*