### PR TITLE
feat: add HPC feature gates and module namespace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,20 @@ reqwest = []
 experimental = []
 # Distributed execution support
 distributed = []
+# HPC (High Performance Computing) modules
+hpc = ["slurm", "gpu"]
+# Slurm workload manager modules
+slurm = []
+# GPU management modules (NVIDIA, ROCm)
+gpu = []
+# InfiniBand / RDMA / OFED support
+ofed = []
+# Parallel filesystem clients (Lustre, BeeGFS)
+parallel_fs = []
+# OpenStack cloud provider
+openstack = []
+# Bare-metal BMC management via Redfish/IPMI
+redfish = []
 # Background warmup of lazy-initialized components
 startup-warmup = []
 # REST API server
@@ -39,13 +53,15 @@ api = ["dep:axum", "dep:tower-http", "dep:jsonwebtoken", "dep:futures-util"]
 # Infrastructure provisioning (Terraform-like) - requires AWS SDK
 provisioning = ["aws"]
 # Full feature set with ssh2 backend
-full = ["russh", "local", "ssh2-backend", "docker", "kubernetes"]
+full = ["russh", "local", "ssh2-backend", "docker", "kubernetes", "hpc"]
 # Full feature set with all cloud providers
 full-cloud = ["full", "aws", "azure", "gcp"]
 # Full feature set with AWS (requires additional compile time)
 full-aws = ["full", "aws"]
 # Full feature set with provisioning
 full-provisioning = ["full-aws", "provisioning"]
+# Full feature set with all HPC support
+full-hpc = ["full", "hpc", "ofed", "parallel_fs"]
 # Pure Rust build (no C dependencies)
 pure-rust = ["russh", "local"]
 

--- a/src/modules/hpc/common.rs
+++ b/src/modules/hpc/common.rs
@@ -1,0 +1,42 @@
+//! HPC common baseline module
+//!
+//! Validates and reports HPC cluster baseline configuration including
+//! system limits, sysctl parameters, required directories, and time sync.
+
+use crate::modules::{
+    Module, ModuleClassification, ModuleContext, ModuleOutput, ModuleParams, ModuleResult,
+};
+
+pub struct HpcBaselineModule;
+
+impl Module for HpcBaselineModule {
+    fn name(&self) -> &'static str {
+        "hpc_baseline"
+    }
+
+    fn description(&self) -> &'static str {
+        "Validate and report HPC cluster baseline configuration"
+    }
+
+    fn execute(
+        &self,
+        _params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        if context.check_mode {
+            return Ok(ModuleOutput::ok("Would validate HPC baseline configuration"));
+        }
+
+        Ok(ModuleOutput::ok("HPC baseline validation: stub - not yet implemented")
+            .with_data("status", serde_json::json!("stub"))
+            .with_data("supported_distros", serde_json::json!(["rocky-9", "alma-9", "ubuntu-22.04"])))
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &[]
+    }
+
+    fn classification(&self) -> ModuleClassification {
+        ModuleClassification::LocalLogic
+    }
+}

--- a/src/modules/hpc/fs.rs
+++ b/src/modules/hpc/fs.rs
@@ -1,0 +1,65 @@
+//! Parallel filesystem client modules
+//!
+//! Manages Lustre and BeeGFS client installation and mount configuration.
+
+use crate::modules::{
+    Module, ModuleContext, ModuleOutput, ModuleParams, ModuleResult,
+};
+
+pub struct LustreClientModule;
+
+impl Module for LustreClientModule {
+    fn name(&self) -> &'static str {
+        "lustre_client"
+    }
+
+    fn description(&self) -> &'static str {
+        "Manage Lustre filesystem client installation and mounts"
+    }
+
+    fn execute(
+        &self,
+        _params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        if context.check_mode {
+            return Ok(ModuleOutput::ok("Would configure Lustre client"));
+        }
+
+        Ok(ModuleOutput::ok("Lustre client: stub - not yet implemented")
+            .with_data("status", serde_json::json!("stub")))
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &[]
+    }
+}
+
+pub struct BeegfsClientModule;
+
+impl Module for BeegfsClientModule {
+    fn name(&self) -> &'static str {
+        "beegfs_client"
+    }
+
+    fn description(&self) -> &'static str {
+        "Manage BeeGFS filesystem client installation and mounts"
+    }
+
+    fn execute(
+        &self,
+        _params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        if context.check_mode {
+            return Ok(ModuleOutput::ok("Would configure BeeGFS client"));
+        }
+
+        Ok(ModuleOutput::ok("BeeGFS client: stub - not yet implemented")
+            .with_data("status", serde_json::json!("stub")))
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &[]
+    }
+}

--- a/src/modules/hpc/gpu.rs
+++ b/src/modules/hpc/gpu.rs
@@ -1,0 +1,36 @@
+//! GPU management modules
+//!
+//! Manages NVIDIA GPU drivers and configuration.
+
+use crate::modules::{
+    Module, ModuleContext, ModuleOutput, ModuleParams, ModuleResult,
+};
+
+pub struct NvidiaGpuModule;
+
+impl Module for NvidiaGpuModule {
+    fn name(&self) -> &'static str {
+        "nvidia_gpu"
+    }
+
+    fn description(&self) -> &'static str {
+        "Manage NVIDIA GPU driver installation and configuration"
+    }
+
+    fn execute(
+        &self,
+        _params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        if context.check_mode {
+            return Ok(ModuleOutput::ok("Would configure NVIDIA GPU"));
+        }
+
+        Ok(ModuleOutput::ok("NVIDIA GPU management: stub - not yet implemented")
+            .with_data("status", serde_json::json!("stub")))
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &[]
+    }
+}

--- a/src/modules/hpc/lmod.rs
+++ b/src/modules/hpc/lmod.rs
@@ -1,0 +1,36 @@
+//! Lmod / Environment Modules support
+//!
+//! Manages Lmod installation and module path configuration.
+
+use crate::modules::{
+    Module, ModuleContext, ModuleOutput, ModuleParams, ModuleResult,
+};
+
+pub struct LmodModule;
+
+impl Module for LmodModule {
+    fn name(&self) -> &'static str {
+        "lmod"
+    }
+
+    fn description(&self) -> &'static str {
+        "Manage Lmod / Environment Modules installation and configuration"
+    }
+
+    fn execute(
+        &self,
+        _params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        if context.check_mode {
+            return Ok(ModuleOutput::ok("Would configure Lmod"));
+        }
+
+        Ok(ModuleOutput::ok("Lmod configuration: stub - not yet implemented")
+            .with_data("status", serde_json::json!("stub")))
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &[]
+    }
+}

--- a/src/modules/hpc/mod.rs
+++ b/src/modules/hpc/mod.rs
@@ -1,0 +1,66 @@
+//! HPC (High Performance Computing) modules for Rustible
+//!
+//! This module provides configuration management modules specific to HPC
+//! cluster environments. Modules are organized by subsystem:
+//!
+//! - **common**: Cluster baseline configuration (limits, sysctl, directories)
+//! - **slurm**: Slurm workload manager (controller, compute, operations)
+//! - **lmod**: Lmod / Environment Modules software management
+//! - **mpi**: MPI library configuration (OpenMPI, Intel MPI)
+//! - **gpu**: GPU management (NVIDIA drivers, CUDA, ROCm)
+//! - **ofed**: InfiniBand / RDMA / OFED stack management
+//! - **fs**: Parallel filesystem clients (Lustre, BeeGFS)
+//!
+//! # Target Distributions
+//!
+//! HPC modules target these distributions initially:
+//! - Rocky Linux / Alma Linux 9 (RHEL-family)
+//! - Ubuntu 22.04 LTS (Debian-family)
+//!
+//! Modules detect the OS family and fail with clear error messages on
+//! unsupported distributions.
+//!
+//! # Conventions
+//!
+//! All HPC modules follow these conventions:
+//!
+//! ## Idempotency
+//! - Modules check current state before making changes
+//! - Re-running a module with the same parameters produces no changes
+//! - State is detected via command output parsing, not file markers
+//!
+//! ## Check Mode
+//! - All modules support `check_mode` (dry-run)
+//! - In check mode, modules report what *would* change without acting
+//!
+//! ## Structured Output
+//! - Modules return parsed data in `ModuleOutput.data` (not raw stdout)
+//! - Example: Slurm modules return parsed `scontrol` output as JSON
+//!
+//! ## Error Handling
+//! - Unsupported OS → `ModuleError::Unsupported` with clear message
+//! - Missing prerequisites → `ModuleError::ExecutionFailed` with install hint
+
+pub mod common;
+#[cfg(feature = "slurm")]
+pub mod slurm;
+pub mod lmod;
+pub mod mpi;
+#[cfg(feature = "gpu")]
+pub mod gpu;
+#[cfg(feature = "ofed")]
+pub mod ofed;
+#[cfg(feature = "parallel_fs")]
+pub mod fs;
+
+pub use common::HpcBaselineModule;
+#[cfg(feature = "slurm")]
+pub use slurm::{SlurmConfigModule, SlurmOpsModule};
+pub use lmod::LmodModule;
+pub use mpi::MpiModule;
+#[cfg(feature = "gpu")]
+pub use gpu::NvidiaGpuModule;
+#[cfg(feature = "ofed")]
+pub use ofed::RdmaStackModule;
+#[cfg(feature = "parallel_fs")]
+pub use fs::{LustreClientModule, BeegfsClientModule};

--- a/src/modules/hpc/mpi.rs
+++ b/src/modules/hpc/mpi.rs
@@ -1,0 +1,39 @@
+//! MPI configuration module
+//!
+//! Manages MPI library installation and configuration (OpenMPI, Intel MPI).
+
+use crate::modules::{
+    Module, ModuleContext, ModuleOutput, ModuleParams, ModuleResult, ParamExt,
+};
+
+pub struct MpiModule;
+
+impl Module for MpiModule {
+    fn name(&self) -> &'static str {
+        "mpi_config"
+    }
+
+    fn description(&self) -> &'static str {
+        "Configure MPI libraries (OpenMPI, Intel MPI)"
+    }
+
+    fn execute(
+        &self,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let flavor = params.get_string("flavor")?.unwrap_or_else(|| "openmpi".to_string());
+
+        if context.check_mode {
+            return Ok(ModuleOutput::ok(format!("Would configure MPI ({})", flavor)));
+        }
+
+        Ok(ModuleOutput::ok(format!("MPI config ({}): stub - not yet implemented", flavor))
+            .with_data("status", serde_json::json!("stub"))
+            .with_data("flavor", serde_json::json!(flavor)))
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &[]
+    }
+}

--- a/src/modules/hpc/ofed.rs
+++ b/src/modules/hpc/ofed.rs
@@ -1,0 +1,36 @@
+//! OFED / RDMA / InfiniBand stack module
+//!
+//! Manages RDMA userland packages and kernel module configuration.
+
+use crate::modules::{
+    Module, ModuleContext, ModuleOutput, ModuleParams, ModuleResult,
+};
+
+pub struct RdmaStackModule;
+
+impl Module for RdmaStackModule {
+    fn name(&self) -> &'static str {
+        "rdma_stack"
+    }
+
+    fn description(&self) -> &'static str {
+        "Manage RDMA / InfiniBand / OFED userland stack"
+    }
+
+    fn execute(
+        &self,
+        _params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        if context.check_mode {
+            return Ok(ModuleOutput::ok("Would configure RDMA stack"));
+        }
+
+        Ok(ModuleOutput::ok("RDMA stack configuration: stub - not yet implemented")
+            .with_data("status", serde_json::json!("stub")))
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &[]
+    }
+}

--- a/src/modules/hpc/slurm.rs
+++ b/src/modules/hpc/slurm.rs
@@ -1,0 +1,70 @@
+//! Slurm workload manager modules
+//!
+//! Provides configuration and operations modules for Slurm:
+//! - `slurm_config`: Manage slurm.conf, cgroup.conf, gres.conf
+//! - `slurm_ops`: Cluster operations (reconfigure, drain, resume)
+
+use crate::modules::{
+    Module, ModuleContext, ModuleOutput, ModuleParams, ModuleResult, ParamExt,
+};
+
+pub struct SlurmConfigModule;
+
+impl Module for SlurmConfigModule {
+    fn name(&self) -> &'static str {
+        "slurm_config"
+    }
+
+    fn description(&self) -> &'static str {
+        "Manage Slurm configuration files (slurm.conf, cgroup.conf, gres.conf)"
+    }
+
+    fn execute(
+        &self,
+        _params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        if context.check_mode {
+            return Ok(ModuleOutput::ok("Would configure Slurm"));
+        }
+
+        Ok(ModuleOutput::ok("Slurm configuration: stub - not yet implemented")
+            .with_data("status", serde_json::json!("stub")))
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &[]
+    }
+}
+
+pub struct SlurmOpsModule;
+
+impl Module for SlurmOpsModule {
+    fn name(&self) -> &'static str {
+        "slurm_ops"
+    }
+
+    fn description(&self) -> &'static str {
+        "Slurm cluster operations (reconfigure, drain/resume nodes)"
+    }
+
+    fn execute(
+        &self,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let action = params.get_string("action")?.unwrap_or_default();
+
+        if context.check_mode {
+            return Ok(ModuleOutput::ok(format!("Would perform Slurm action: {}", action)));
+        }
+
+        Ok(ModuleOutput::ok(format!("Slurm ops '{}': stub - not yet implemented", action))
+            .with_data("status", serde_json::json!("stub"))
+            .with_data("action", serde_json::json!(action)))
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &["action"]
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -25,6 +25,7 @@ pub mod firewalld;
 pub mod git;
 pub mod group;
 pub mod hostname;
+pub mod hpc;
 pub mod include_vars;
 pub mod k8s;
 pub mod known_hosts;
@@ -720,6 +721,8 @@ pub enum ModuleCategory {
     Security,
     /// Windows-specific modules
     Windows,
+    /// HPC (High Performance Computing) modules
+    Hpc,
 }
 
 impl fmt::Display for ModuleCategory {
@@ -738,6 +741,7 @@ impl fmt::Display for ModuleCategory {
             ModuleCategory::Facts => write!(f, "facts"),
             ModuleCategory::Security => write!(f, "security"),
             ModuleCategory::Windows => write!(f, "windows"),
+            ModuleCategory::Hpc => write!(f, "hpc"),
         }
     }
 }
@@ -1654,6 +1658,45 @@ impl ModuleRegistry {
                 cloud::GcpComputeFirewallModule,
                 cloud::GcpComputeNetworkModule,
                 cloud::GcpServiceAccountModule,
+            ],
+        );
+
+        // HPC modules (always register baseline; feature-gated modules below)
+        register_modules!(registry,
+            Hpc: [
+                hpc::HpcBaselineModule,
+                hpc::LmodModule,
+                hpc::MpiModule,
+            ],
+        );
+
+        #[cfg(feature = "slurm")]
+        register_modules!(registry,
+            Hpc: [
+                hpc::SlurmConfigModule,
+                hpc::SlurmOpsModule,
+            ],
+        );
+
+        #[cfg(feature = "gpu")]
+        register_modules!(registry,
+            Hpc: [
+                hpc::NvidiaGpuModule,
+            ],
+        );
+
+        #[cfg(feature = "ofed")]
+        register_modules!(registry,
+            Hpc: [
+                hpc::RdmaStackModule,
+            ],
+        );
+
+        #[cfg(feature = "parallel_fs")]
+        register_modules!(registry,
+            Hpc: [
+                hpc::LustreClientModule,
+                hpc::BeegfsClientModule,
             ],
         );
 


### PR DESCRIPTION
## Summary

Add Cargo feature gates and `src/modules/hpc/` namespace for HPC cluster management modules.

### Feature Flags

| Feature | Description | Dependencies |
|---------|-------------|-------------|
| `hpc` | Meta-feature | `slurm` + `gpu` |
| `slurm` | Slurm workload manager modules | — |
| `gpu` | GPU management (NVIDIA/ROCm) | — |
| `ofed` | InfiniBand / RDMA / OFED | — |
| `parallel_fs` | Lustre / BeeGFS clients | — |
| `openstack` | OpenStack provider (future) | — |
| `redfish` | Bare-metal BMC (future) | — |
| `full-hpc` | Full + all HPC features | `full` + `hpc` + `ofed` + `parallel_fs` |

### Module Namespace

```
src/modules/hpc/
├── mod.rs          # Module root with feature-gated re-exports
├── common.rs       # hpc_baseline (always enabled)
├── slurm.rs        # slurm_config, slurm_ops (feature: slurm)
├── lmod.rs         # lmod (always enabled)
├── mpi.rs          # mpi_config (always enabled)
├── gpu.rs          # nvidia_gpu (feature: gpu)
├── ofed.rs         # rdma_stack (feature: ofed)
└── fs.rs           # lustre_client, beegfs_client (feature: parallel_fs)
```

All modules are stubs implementing the `Module` trait with check_mode support. They are registered in `ModuleRegistry::with_builtins()` under the new `Hpc` category.

### Conventions (documented in mod.rs)
- Idempotency via state inspection, not file markers
- All modules support `check_mode`
- Structured output in `ModuleOutput.data`
- Target distros: Rocky/Alma 9 + Ubuntu 22.04

### Verification
```
cargo check                                         # default features ✓
cargo check --features "hpc,ofed,parallel_fs"        # all HPC features ✓
cargo test --lib -- modules                         # 751 passed ✓
```

Note: `full` feature has pre-existing Docker module compilation errors unrelated to this PR.

Closes #472