### PR TITLE
🎨 Palette: Improve list-tasks output formatting and JSON support

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,7 @@
 ## 2026-03-05 - [Consistent Interactive Prompts]
 **Learning:** Inconsistent usage of UI themes (like `dialoguer`'s `ColorfulTheme`) and missing semantic icons in password prompts breaks the visual consistency of the CLI. Using standard themes and icons (e.g., 🔐 for secrets) makes the tool feel more polished and trustworthy.
 **Action:** Always use `ColorfulTheme::default()` for `dialoguer` prompts and include appropriate semantic emojis in prompt text to match the rest of the application.
+
+## 2024-03-22 - [Hybrid Output Strategies]
+**Learning:** Commands that support both human-readable text and machine-readable JSON often fail to produce valid JSON if they print text incrementally during execution. Interleaved text breaks the JSON structure.
+**Action:** For commands supporting `--output json`, collect all data into a structured object first, then decide whether to print it as JSON or iterate over it for formatted text output. Avoid immediate `println!` during data gathering.

--- a/src/cli/commands/inventory.rs
+++ b/src/cli/commands/inventory.rs
@@ -5,6 +5,7 @@
 use super::{CommandContext, Runnable};
 use anyhow::{Context, Result};
 use clap::Parser;
+use colored::Colorize;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -46,6 +47,30 @@ pub struct ListTasksArgs {
     /// Include task details
     #[arg(long)]
     pub detailed: bool,
+}
+
+/// Task listing information
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TaskListing {
+    pub name: String,
+    pub module: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub when: Option<String>,
+}
+
+/// Play listing information
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PlayListing {
+    pub name: String,
+    pub tasks: Vec<TaskListing>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub pre_tasks: Vec<TaskListing>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub post_tasks: Vec<TaskListing>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub handlers: Vec<TaskListing>,
 }
 
 /// Host information
@@ -452,127 +477,162 @@ impl ListTasksArgs {
         let content = std::fs::read_to_string(&self.playbook)?;
         let playbook: serde_yaml::Value = serde_yaml::from_str(&content)?;
 
-        ctx.output
-            .section(&format!("Tasks in playbook: {}", self.playbook.display()));
-
-        let mut task_count = 0;
+        let mut play_listings = Vec::new();
+        let mut total_task_count = 0;
 
         // Process plays
         if let Some(plays) = playbook.as_sequence() {
-            for (play_idx, play) in plays.iter().enumerate() {
+            for play in plays {
                 let play_name = play
                     .get("name")
                     .and_then(|n| n.as_str())
-                    .unwrap_or("Unnamed play");
+                    .unwrap_or("Unnamed play")
+                    .to_string();
 
-                ctx.output
-                    .section(&format!("Play #{}: {}", play_idx + 1, play_name));
+                let mut play_listing = PlayListing {
+                    name: play_name,
+                    tasks: Vec::new(),
+                    pre_tasks: Vec::new(),
+                    post_tasks: Vec::new(),
+                    handlers: Vec::new(),
+                };
 
-                // Get tasks
-                if let Some(tasks) = play.get("tasks").and_then(|t| t.as_sequence()) {
-                    for (task_idx, task) in tasks.iter().enumerate() {
-                        let task_name = task
-                            .get("name")
-                            .and_then(|n| n.as_str())
-                            .unwrap_or("Unnamed task");
+                // Helper to process a list of tasks
+                let mut process_task_list = |
+                    tasks_val: Option<&serde_yaml::Value>,
+                    target_list: &mut Vec<TaskListing>,
+                    count_tasks: bool
+                | {
+                    if let Some(tasks) = tasks_val.and_then(|t| t.as_sequence()) {
+                        for task in tasks {
+                            // Get task tags for filtering
+                            let task_tags: Vec<String> = task
+                                .get("tags")
+                                .and_then(|t| {
+                                    if let Some(s) = t.as_str() {
+                                        Some(vec![s.to_string()])
+                                    } else {
+                                        t.as_sequence().map(|seq| {
+                                            seq.iter()
+                                                .filter_map(|v| v.as_str().map(String::from))
+                                                .collect()
+                                        })
+                                    }
+                                })
+                                .unwrap_or_default();
 
-                        // Get task tags for filtering
-                        let task_tags: Vec<String> = task
-                            .get("tags")
-                            .and_then(|t| {
-                                if let Some(s) = t.as_str() {
-                                    Some(vec![s.to_string()])
-                                } else {
-                                    t.as_sequence().map(|seq| {
-                                        seq.iter()
-                                            .filter_map(|v| v.as_str().map(String::from))
-                                            .collect()
-                                    })
+                            // Check skip_tags filter first - skip if any skip_tag matches
+                            if !self.skip_tags.is_empty() {
+                                let should_skip = self.skip_tags.iter().any(|t| task_tags.contains(t));
+                                if should_skip {
+                                    continue;
                                 }
-                            })
-                            .unwrap_or_default();
-
-                        // Check skip_tags filter first - skip if any skip_tag matches
-                        if !self.skip_tags.is_empty() {
-                            let should_skip = self.skip_tags.iter().any(|t| task_tags.contains(t));
-                            if should_skip {
-                                continue;
-                            }
-                        }
-
-                        // Check tags filter - only include if tags match
-                        if !self.tags.is_empty() {
-                            let matches = self.tags.iter().any(|t| task_tags.contains(t));
-                            if !matches {
-                                continue;
-                            }
-                        }
-
-                        task_count += 1;
-
-                        // Detect module
-                        let module = detect_module(task);
-
-                        if self.detailed {
-                            println!("  {:>3}. {} [{}]", task_idx + 1, task_name, module);
-
-                            // Show tags
-                            if let Some(tags) = task.get("tags") {
-                                println!("       Tags: {}", format_value(tags));
                             }
 
-                            // Show when condition
-                            if let Some(when) = task.get("when") {
-                                println!("       When: {}", format_value(when));
+                            // Check tags filter - only include if tags match
+                            if !self.tags.is_empty() {
+                                let matches = self.tags.iter().any(|t| task_tags.contains(t));
+                                if !matches {
+                                    continue;
+                                }
                             }
-                        } else {
-                            println!("  {:>3}. {}", task_idx + 1, task_name);
+
+                            if count_tasks {
+                                total_task_count += 1;
+                            }
+
+                            let task_name = task
+                                .get("name")
+                                .and_then(|n| n.as_str())
+                                .unwrap_or("Unnamed task")
+                                .to_string();
+
+                            let module = detect_module(task).to_string();
+
+                            let tags = if !task_tags.is_empty() {
+                                Some(task_tags)
+                            } else {
+                                None
+                            };
+
+                            let when = task.get("when").map(|w| format_value(w));
+
+                            target_list.push(TaskListing {
+                                name: task_name,
+                                module,
+                                tags,
+                                when,
+                            });
                         }
                     }
-                }
+                };
 
-                // Handle pre_tasks
-                if let Some(tasks) = play.get("pre_tasks").and_then(|t| t.as_sequence()) {
-                    println!("\n  Pre-tasks:");
-                    for (task_idx, task) in tasks.iter().enumerate() {
-                        let task_name = task
-                            .get("name")
-                            .and_then(|n| n.as_str())
-                            .unwrap_or("Unnamed task");
-                        println!("    {:>3}. {}", task_idx + 1, task_name);
-                        task_count += 1;
-                    }
-                }
+                // Process all task lists
+                process_task_list(play.get("tasks"), &mut play_listing.tasks, true);
+                process_task_list(play.get("pre_tasks"), &mut play_listing.pre_tasks, true);
+                process_task_list(play.get("post_tasks"), &mut play_listing.post_tasks, true);
+                // Handlers are not counted in total tasks in original implementation
+                process_task_list(play.get("handlers"), &mut play_listing.handlers, false);
 
-                // Handle post_tasks
-                if let Some(tasks) = play.get("post_tasks").and_then(|t| t.as_sequence()) {
-                    println!("\n  Post-tasks:");
-                    for (task_idx, task) in tasks.iter().enumerate() {
-                        let task_name = task
-                            .get("name")
-                            .and_then(|n| n.as_str())
-                            .unwrap_or("Unnamed task");
-                        println!("    {:>3}. {}", task_idx + 1, task_name);
-                        task_count += 1;
-                    }
-                }
-
-                // Handle handlers
-                if let Some(handlers) = play.get("handlers").and_then(|h| h.as_sequence()) {
-                    println!("\n  Handlers:");
-                    for (handler_idx, handler) in handlers.iter().enumerate() {
-                        let handler_name = handler
-                            .get("name")
-                            .and_then(|n| n.as_str())
-                            .unwrap_or("Unnamed handler");
-                        println!("    {:>3}. {}", handler_idx + 1, handler_name);
-                    }
-                }
+                play_listings.push(play_listing);
             }
         }
 
-        println!("\n{}", "=".repeat(40));
-        println!("Total tasks: {}", task_count);
+        // Output logic
+        if ctx.output.is_json() {
+            println!("{}", serde_json::to_string_pretty(&play_listings)?);
+        } else {
+            ctx.output.section(&format!("Tasks in playbook: {}", self.playbook.display()));
+
+            for (i, play) in play_listings.iter().enumerate() {
+                // Colored header: Play #1: Play Name
+                // We construct the string first to handle the formatting properly
+                println!("\n{} {}: {}",
+                    "Play".blue().bold(),
+                    format!("#{}", i + 1).blue().bold(),
+                    play.name.blue().bold()
+                );
+
+                let print_tasks = |title: &str, tasks: &[TaskListing]| {
+                    if !tasks.is_empty() {
+                        if !title.is_empty() {
+                            println!("\n  {}:", title.yellow());
+                        }
+
+                        for (j, task) in tasks.iter().enumerate() {
+                            // Task output: 1. Task Name [module]
+                            // detailed:
+                            //      Tags: ...
+                            //      When: ...
+
+                            let module_str = format!("[{}]", task.module).cyan().dimmed();
+                            println!("    {:>3}. {} {}",
+                                (j + 1).to_string().bold(),
+                                task.name.white(),
+                                module_str
+                            );
+
+                            if self.detailed {
+                                if let Some(tags) = &task.tags {
+                                    println!("       {}: {}", "Tags".yellow(), format!("{:?}", tags));
+                                }
+                                if let Some(when) = &task.when {
+                                    println!("       {}: {}", "When".yellow(), when);
+                                }
+                            }
+                        }
+                    }
+                };
+
+                print_tasks("", &play.tasks);
+                print_tasks("Pre-tasks", &play.pre_tasks);
+                print_tasks("Post-tasks", &play.post_tasks);
+                print_tasks("Handlers", &play.handlers);
+            }
+
+            println!("\n{}", "=".repeat(40).bright_black());
+            println!("Total tasks: {}", total_task_count.to_string().green().bold());
+        }
 
         Ok(0)
     }
@@ -685,5 +745,27 @@ mod tests {
         assert!(glob_match("web01.example.com", "web*.example.com"));
         assert!(glob_match("db01", "db*"));
         assert!(!glob_match("web01", "db*"));
+    }
+
+    #[test]
+    fn test_play_listing_serialization() {
+        let listing = PlayListing {
+            name: "Test Play".to_string(),
+            tasks: vec![TaskListing {
+                name: "Test Task".to_string(),
+                module: "debug".to_string(),
+                tags: Some(vec!["tag1".to_string()]),
+                when: None,
+            }],
+            pre_tasks: vec![],
+            post_tasks: vec![],
+            handlers: vec![],
+        };
+
+        let json = serde_json::to_string(&listing).unwrap();
+        assert!(json.contains("Test Play"));
+        assert!(json.contains("Test Task"));
+        assert!(json.contains("debug"));
+        assert!(json.contains("tag1"));
     }
 }


### PR DESCRIPTION
Improved the `list-tasks` command to support proper JSON output and enhanced the text output with colors for better readability.

**Changes:**
- Refactored `ListTasksArgs::execute` in `src/cli/commands/inventory.rs` to gather data into `PlayListing` and `TaskListing` structs.
- Added support for `serde_json` output when `ctx.output.is_json()` is true.
- Added `colored` output for human-readable mode, making it easier to distinguish plays, tasks, and modules.
- Added a unit test to verify serialization.

**UX Improvements:**
- **JSON Mode:** Now produces valid JSON instead of a mix of text headers and task lists.
- **Text Mode:** Uses colors to create a visual hierarchy (Blue for Plays, Bold/White for Tasks, Cyan/Dimmed for Modules, Yellow for Tags/Conditions).

**Verification:**
- Verified with manual testing using a dummy playbook.
- ran `cargo test --bin rustible cli::commands::inventory` (all passed).
- Checked for clippy errors in the modified file (none found).

---
*PR created automatically by Jules for task [18357645187385738565](https://jules.google.com/task/18357645187385738565) started by @dolagoartur*