### PR TITLE
feat(hpc): implement baseline modules

### DIFF
--- a/src/modules/hpc/common.rs
+++ b/src/modules/hpc/common.rs
@@ -1,11 +1,93 @@
 //! HPC common baseline module
 //!
-//! Validates and reports HPC cluster baseline configuration including
-//! system limits, sysctl parameters, required directories, and time sync.
+//! Validates and applies HPC cluster baseline configuration including
+//! system limits, sysctl parameters, required packages, directories,
+//! and tuned profiles.
+//!
+//! # Parameters
+//!
+//! - `limits` (optional): List of `/etc/security/limits.d/` entries
+//! - `sysctl` (optional): Map of sysctl key/value pairs
+//! - `packages` (optional): List of baseline packages to install
+//! - `directories` (optional): List of directories to ensure exist
+//! - `tuned_profile` (optional): Tuned profile name to activate
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::runtime::Handle;
+
+use crate::connection::{Connection, ExecuteOptions};
 use crate::modules::{
-    Module, ModuleClassification, ModuleContext, ModuleOutput, ModuleParams, ModuleResult,
+    Module, ModuleClassification, ModuleContext, ModuleError, ModuleOutput, ModuleParams,
+    ModuleResult, ParamExt, ParallelizationHint,
 };
+
+fn get_exec_options(context: &ModuleContext) -> ExecuteOptions {
+    let mut options = ExecuteOptions::new();
+    if context.r#become {
+        options = options.with_escalation(context.become_user.clone());
+        if let Some(ref method) = context.become_method {
+            options.escalate_method = Some(method.clone());
+        }
+        if let Some(ref password) = context.become_password {
+            options.escalate_password = Some(password.clone());
+        }
+    }
+    options
+}
+
+fn run_cmd(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<(bool, String, String)> {
+    let options = get_exec_options(context);
+    let result = Handle::current()
+        .block_on(async { connection.execute(cmd, Some(options)).await })
+        .map_err(|e| ModuleError::ExecutionFailed(format!("Connection error: {}", e)))?;
+    Ok((result.success, result.stdout, result.stderr))
+}
+
+fn run_cmd_ok(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<String> {
+    let (success, stdout, stderr) = run_cmd(connection, cmd, context)?;
+    if !success {
+        return Err(ModuleError::ExecutionFailed(format!(
+            "Command failed: {}",
+            stderr.trim()
+        )));
+    }
+    Ok(stdout)
+}
+
+/// Detects the OS family from /etc/os-release content.
+fn detect_os_family(os_release: &str) -> Option<&'static str> {
+    for line in os_release.lines() {
+        if line.starts_with("ID_LIKE=") || line.starts_with("ID=") {
+            let val = line
+                .split('=')
+                .nth(1)
+                .unwrap_or("")
+                .trim_matches('"')
+                .to_lowercase();
+            if val.contains("rhel")
+                || val.contains("fedora")
+                || val.contains("centos")
+                || val == "rocky"
+                || val == "almalinux"
+            {
+                return Some("rhel");
+            } else if val.contains("debian") || val.contains("ubuntu") {
+                return Some("debian");
+            }
+        }
+    }
+    None
+}
 
 pub struct HpcBaselineModule;
 
@@ -15,35 +97,207 @@ impl Module for HpcBaselineModule {
     }
 
     fn description(&self) -> &'static str {
-        "Validate and report HPC cluster baseline configuration"
+        "Validate and apply HPC cluster baseline configuration (limits, sysctl, packages, directories, tuned)"
+    }
+
+    fn classification(&self) -> ModuleClassification {
+        ModuleClassification::RemoteCommand
+    }
+
+    fn parallelization_hint(&self) -> ParallelizationHint {
+        ParallelizationHint::HostExclusive
     }
 
     fn execute(
         &self,
-        _params: &ModuleParams,
+        params: &ModuleParams,
         context: &ModuleContext,
     ) -> ModuleResult<ModuleOutput> {
-        if context.check_mode {
-            return Ok(ModuleOutput::ok(
-                "Would validate HPC baseline configuration",
-            ));
+        let connection = context
+            .connection
+            .as_ref()
+            .ok_or_else(|| ModuleError::ExecutionFailed("No connection available".to_string()))?;
+
+        // Detect OS family
+        let os_release_out = run_cmd_ok(connection, "cat /etc/os-release", context)?;
+        let os_family = detect_os_family(&os_release_out).ok_or_else(|| {
+            ModuleError::Unsupported(
+                "Unsupported OS. HPC baseline supports RHEL-family and Debian-family distributions."
+                    .to_string(),
+            )
+        })?;
+
+        let mut changed = false;
+        let mut changes: Vec<String> = Vec::new();
+
+        // --- Limits ---
+        if let Some(limits) = params.get_vec_string("limits")? {
+            if !limits.is_empty() {
+                let content = limits.join("\n");
+                if context.check_mode {
+                    changes.push(format!("Would write {} limit entries", limits.len()));
+                } else {
+                    let (_, existing, _) = run_cmd(
+                        connection,
+                        "cat /etc/security/limits.d/99-hpc.conf 2>/dev/null || true",
+                        context,
+                    )?;
+                    if existing.trim() != content.trim() {
+                        run_cmd_ok(
+                            connection,
+                            &format!(
+                                "printf '%s\\n' '{}' > /etc/security/limits.d/99-hpc.conf",
+                                content.replace('\'', "'\\''")
+                            ),
+                            context,
+                        )?;
+                        changed = true;
+                        changes.push(format!("Wrote {} limit entries", limits.len()));
+                    }
+                }
+            }
         }
 
-        Ok(
-            ModuleOutput::ok("HPC baseline validation: stub - not yet implemented")
-                .with_data("status", serde_json::json!("stub"))
-                .with_data(
-                    "supported_distros",
-                    serde_json::json!(["rocky-9", "alma-9", "ubuntu-22.04"]),
-                ),
-        )
+        // --- Sysctl ---
+        if let Some(sysctl_val) = params.get("sysctl") {
+            if let Some(sysctl_map) = sysctl_val.as_object() {
+                for (key, value) in sysctl_map {
+                    let desired = value.as_str().unwrap_or(&value.to_string()).to_string();
+                    let (_, current, _) = run_cmd(
+                        connection,
+                        &format!("sysctl -n {} 2>/dev/null || true", key),
+                        context,
+                    )?;
+                    if current.trim() != desired.trim() {
+                        if context.check_mode {
+                            changes.push(format!("Would set sysctl {}={}", key, desired));
+                        } else {
+                            run_cmd_ok(
+                                connection,
+                                &format!("sysctl -w {}={}", key, desired),
+                                context,
+                            )?;
+                            // Persist
+                            run_cmd_ok(
+                                connection,
+                                &format!(
+                                    "grep -q '^{}=' /etc/sysctl.d/99-hpc.conf 2>/dev/null && \
+                                     sed -i 's|^{}=.*|{}={}|' /etc/sysctl.d/99-hpc.conf || \
+                                     echo '{}={}' >> /etc/sysctl.d/99-hpc.conf",
+                                    key, key, key, desired, key, desired
+                                ),
+                                context,
+                            )?;
+                            changed = true;
+                            changes.push(format!("Set sysctl {}={}", key, desired));
+                        }
+                    }
+                }
+            }
+        }
+
+        // --- Packages ---
+        if let Some(packages) = params.get_vec_string("packages")? {
+            if !packages.is_empty() {
+                let pkg_cmd = match os_family {
+                    "rhel" => format!("rpm -q {} >/dev/null 2>&1", packages.join(" ")),
+                    _ => format!("dpkg -s {} >/dev/null 2>&1", packages.join(" ")),
+                };
+                let (installed, _, _) = run_cmd(connection, &pkg_cmd, context)?;
+                if !installed {
+                    if context.check_mode {
+                        changes.push(format!("Would install packages: {}", packages.join(", ")));
+                    } else {
+                        let install_cmd = match os_family {
+                            "rhel" => format!("dnf install -y {}", packages.join(" ")),
+                            _ => format!(
+                                "DEBIAN_FRONTEND=noninteractive apt-get install -y {}",
+                                packages.join(" ")
+                            ),
+                        };
+                        run_cmd_ok(connection, &install_cmd, context)?;
+                        changed = true;
+                        changes.push(format!("Installed packages: {}", packages.join(", ")));
+                    }
+                }
+            }
+        }
+
+        // --- Directories ---
+        if let Some(directories) = params.get_vec_string("directories")? {
+            for dir in &directories {
+                let (exists, _, _) = run_cmd(
+                    connection,
+                    &format!("test -d '{}'", dir),
+                    context,
+                )?;
+                if !exists {
+                    if context.check_mode {
+                        changes.push(format!("Would create directory {}", dir));
+                    } else {
+                        run_cmd_ok(connection, &format!("mkdir -p '{}'", dir), context)?;
+                        changed = true;
+                        changes.push(format!("Created directory {}", dir));
+                    }
+                }
+            }
+        }
+
+        // --- Tuned profile ---
+        if let Some(profile) = params.get_string("tuned_profile")? {
+            let (_, current_profile, _) = run_cmd(
+                connection,
+                "tuned-adm active 2>/dev/null | awk '{print $NF}' || true",
+                context,
+            )?;
+            if current_profile.trim() != profile {
+                if context.check_mode {
+                    changes.push(format!("Would activate tuned profile '{}'", profile));
+                } else {
+                    run_cmd_ok(
+                        connection,
+                        &format!("tuned-adm profile '{}'", profile),
+                        context,
+                    )?;
+                    changed = true;
+                    changes.push(format!("Activated tuned profile '{}'", profile));
+                }
+            }
+        }
+
+        if context.check_mode && !changes.is_empty() {
+            return Ok(ModuleOutput::changed(format!(
+                "Would apply {} baseline changes",
+                changes.len()
+            ))
+            .with_data("changes", serde_json::json!(changes))
+            .with_data("os_family", serde_json::json!(os_family)));
+        }
+
+        if changed {
+            Ok(ModuleOutput::changed(format!(
+                "Applied {} baseline changes",
+                changes.len()
+            ))
+            .with_data("changes", serde_json::json!(changes))
+            .with_data("os_family", serde_json::json!(os_family)))
+        } else {
+            Ok(ModuleOutput::ok("HPC baseline configuration is up to date")
+                .with_data("os_family", serde_json::json!(os_family)))
+        }
     }
 
     fn required_params(&self) -> &[&'static str] {
         &[]
     }
 
-    fn classification(&self) -> ModuleClassification {
-        ModuleClassification::LocalLogic
+    fn optional_params(&self) -> HashMap<&'static str, serde_json::Value> {
+        let mut m = HashMap::new();
+        m.insert("limits", serde_json::json!([]));
+        m.insert("sysctl", serde_json::json!({}));
+        m.insert("packages", serde_json::json!([]));
+        m.insert("directories", serde_json::json!([]));
+        m.insert("tuned_profile", serde_json::json!(null));
+        m
     }
 }

--- a/src/modules/hpc/facts.rs
+++ b/src/modules/hpc/facts.rs
@@ -1,0 +1,333 @@
+//! HPC facts expansion module
+//!
+//! Gathers HPC-specific system facts and returns them as structured data:
+//! - CPU features from `/proc/cpuinfo` flags
+//! - NUMA topology from `/sys/devices/system/node/`
+//! - Hugepages configuration
+//! - GPU inventory via `nvidia-smi` (if present)
+//! - InfiniBand devices via `ibstat`/`lspci` (if present)
+//!
+//! # Parameters
+//!
+//! - `gather` (optional): List of fact categories to gather.
+//!   Values: "cpu", "numa", "hugepages", "gpu", "infiniband"
+//!   Default: all available
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::runtime::Handle;
+
+use crate::connection::{Connection, ExecuteOptions};
+use crate::modules::{
+    Module, ModuleClassification, ModuleContext, ModuleError, ModuleOutput, ModuleParams,
+    ModuleResult, ParamExt,
+};
+
+fn get_exec_options(context: &ModuleContext) -> ExecuteOptions {
+    let mut options = ExecuteOptions::new();
+    if context.r#become {
+        options = options.with_escalation(context.become_user.clone());
+        if let Some(ref method) = context.become_method {
+            options.escalate_method = Some(method.clone());
+        }
+        if let Some(ref password) = context.become_password {
+            options.escalate_password = Some(password.clone());
+        }
+    }
+    options
+}
+
+/// Run a command and return stdout on success, None on failure.
+fn run_cmd_opt(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> Option<String> {
+    let options = get_exec_options(context);
+    match Handle::current().block_on(async { connection.execute(cmd, Some(options)).await }) {
+        Ok(result) if result.success => Some(result.stdout),
+        _ => None,
+    }
+}
+
+pub struct HpcFactsModule;
+
+impl Module for HpcFactsModule {
+    fn name(&self) -> &'static str {
+        "hpc_facts"
+    }
+
+    fn description(&self) -> &'static str {
+        "Gather HPC-specific system facts (CPU features, NUMA, hugepages, GPU, InfiniBand)"
+    }
+
+    fn classification(&self) -> ModuleClassification {
+        ModuleClassification::RemoteCommand
+    }
+
+    fn execute(
+        &self,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let connection = context
+            .connection
+            .as_ref()
+            .ok_or_else(|| ModuleError::ExecutionFailed("No connection available".to_string()))?;
+
+        if context.check_mode {
+            return Ok(ModuleOutput::ok("Would gather HPC facts"));
+        }
+
+        let gather = params.get_vec_string("gather")?;
+        let should_gather = |cat: &str| -> bool {
+            match &gather {
+                Some(cats) => cats.iter().any(|c| c == cat),
+                None => true,
+            }
+        };
+
+        let mut facts = serde_json::Map::new();
+
+        // --- CPU features ---
+        if should_gather("cpu") {
+            if let Some(cpuinfo) = run_cmd_opt(connection, "cat /proc/cpuinfo", context) {
+                let flags: Vec<String> = cpuinfo
+                    .lines()
+                    .find(|l| l.starts_with("flags"))
+                    .map(|l| {
+                        l.split(':')
+                            .nth(1)
+                            .unwrap_or("")
+                            .split_whitespace()
+                            .map(|s| s.to_string())
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                let model_name = cpuinfo
+                    .lines()
+                    .find(|l| l.starts_with("model name"))
+                    .and_then(|l| l.split(':').nth(1))
+                    .map(|s| s.trim().to_string())
+                    .unwrap_or_default();
+
+                let cpu_count = cpuinfo
+                    .lines()
+                    .filter(|l| l.starts_with("processor"))
+                    .count();
+
+                facts.insert(
+                    "cpu".to_string(),
+                    serde_json::json!({
+                        "model": model_name,
+                        "count": cpu_count,
+                        "flags": flags,
+                        "has_avx": flags.contains(&"avx".to_string()),
+                        "has_avx2": flags.contains(&"avx2".to_string()),
+                        "has_avx512f": flags.contains(&"avx512f".to_string()),
+                        "has_sse4_2": flags.contains(&"sse4_2".to_string()),
+                    }),
+                );
+            }
+        }
+
+        // --- NUMA topology ---
+        if should_gather("numa") {
+            if let Some(numa_output) = run_cmd_opt(
+                connection,
+                "ls -d /sys/devices/system/node/node* 2>/dev/null | wc -l",
+                context,
+            ) {
+                let node_count: u32 = numa_output.trim().parse().unwrap_or(0);
+                let mut nodes: Vec<serde_json::Value> = Vec::new();
+
+                for i in 0..node_count {
+                    let cpulist = run_cmd_opt(
+                        connection,
+                        &format!(
+                            "cat /sys/devices/system/node/node{}/cpulist 2>/dev/null",
+                            i
+                        ),
+                        context,
+                    )
+                    .unwrap_or_default();
+                    let meminfo = run_cmd_opt(
+                        connection,
+                        &format!(
+                            "grep MemTotal /sys/devices/system/node/node{}/meminfo 2>/dev/null",
+                            i
+                        ),
+                        context,
+                    )
+                    .unwrap_or_default();
+                    let mem_kb: u64 = meminfo
+                        .split_whitespace()
+                        .nth(3)
+                        .and_then(|s| s.parse().ok())
+                        .unwrap_or(0);
+
+                    nodes.push(serde_json::json!({
+                        "id": i,
+                        "cpulist": cpulist.trim(),
+                        "memory_kb": mem_kb,
+                    }));
+                }
+
+                facts.insert(
+                    "numa".to_string(),
+                    serde_json::json!({
+                        "node_count": node_count,
+                        "nodes": nodes,
+                    }),
+                );
+            }
+        }
+
+        // --- Hugepages ---
+        if should_gather("hugepages") {
+            let hp_total = run_cmd_opt(
+                connection,
+                "cat /proc/sys/vm/nr_hugepages 2>/dev/null",
+                context,
+            )
+            .unwrap_or_default();
+            let hp_free = run_cmd_opt(
+                connection,
+                "cat /proc/meminfo | grep HugePages_Free | awk '{print $2}'",
+                context,
+            )
+            .unwrap_or_default();
+            let hp_size = run_cmd_opt(
+                connection,
+                "cat /proc/meminfo | grep Hugepagesize | awk '{print $2}'",
+                context,
+            )
+            .unwrap_or_default();
+
+            facts.insert(
+                "hugepages".to_string(),
+                serde_json::json!({
+                    "total": hp_total.trim().parse::<u64>().unwrap_or(0),
+                    "free": hp_free.trim().parse::<u64>().unwrap_or(0),
+                    "size_kb": hp_size.trim().parse::<u64>().unwrap_or(0),
+                }),
+            );
+        }
+
+        // --- GPU inventory ---
+        if should_gather("gpu") {
+            let has_nvidia = run_cmd_opt(
+                connection,
+                "which nvidia-smi >/dev/null 2>&1 && echo yes",
+                context,
+            );
+            if has_nvidia.is_some() {
+                if let Some(gpu_csv) = run_cmd_opt(
+                    connection,
+                    "nvidia-smi --query-gpu=index,gpu_name,memory.total,driver_version,gpu_bus_id --format=csv,noheader,nounits 2>/dev/null",
+                    context,
+                ) {
+                    let gpus: Vec<serde_json::Value> = gpu_csv
+                        .lines()
+                        .filter(|l| !l.trim().is_empty())
+                        .map(|line| {
+                            let parts: Vec<&str> =
+                                line.split(',').map(|s| s.trim()).collect();
+                            serde_json::json!({
+                                "index": parts.first().unwrap_or(&""),
+                                "name": parts.get(1).unwrap_or(&""),
+                                "memory_mib": parts.get(2).unwrap_or(&""),
+                                "driver_version": parts.get(3).unwrap_or(&""),
+                                "bus_id": parts.get(4).unwrap_or(&""),
+                            })
+                        })
+                        .collect();
+                    facts.insert(
+                        "gpu".to_string(),
+                        serde_json::json!({
+                            "count": gpus.len(),
+                            "devices": gpus,
+                            "vendor": "nvidia",
+                        }),
+                    );
+                }
+            } else {
+                facts.insert(
+                    "gpu".to_string(),
+                    serde_json::json!({
+                        "count": 0,
+                        "devices": [],
+                        "vendor": null,
+                    }),
+                );
+            }
+        }
+
+        // --- InfiniBand ---
+        if should_gather("infiniband") {
+            let has_ibstat = run_cmd_opt(
+                connection,
+                "which ibstat >/dev/null 2>&1 && echo yes",
+                context,
+            );
+            if has_ibstat.is_some() {
+                let ib_output =
+                    run_cmd_opt(connection, "ibstat -s 2>/dev/null", context)
+                        .unwrap_or_default();
+                let ib_devs: Vec<serde_json::Value> = ib_output
+                    .lines()
+                    .filter(|l| l.contains("CA '"))
+                    .map(|l| {
+                        let name = l
+                            .split('\'')
+                            .nth(1)
+                            .unwrap_or("unknown")
+                            .to_string();
+                        serde_json::json!({"name": name})
+                    })
+                    .collect();
+                facts.insert(
+                    "infiniband".to_string(),
+                    serde_json::json!({
+                        "present": true,
+                        "device_count": ib_devs.len(),
+                        "devices": ib_devs,
+                    }),
+                );
+            } else {
+                // Fallback: check lspci
+                let lspci = run_cmd_opt(
+                    connection,
+                    "lspci 2>/dev/null | grep -i 'infiniband\\|mellanox'",
+                    context,
+                )
+                .unwrap_or_default();
+                let dev_count = lspci.lines().count();
+                facts.insert(
+                    "infiniband".to_string(),
+                    serde_json::json!({
+                        "present": dev_count > 0,
+                        "device_count": dev_count,
+                        "lspci_devices": lspci.lines().map(|l| l.trim()).collect::<Vec<_>>(),
+                    }),
+                );
+            }
+        }
+
+        Ok(
+            ModuleOutput::ok("Gathered HPC facts")
+                .with_data("hpc_facts", serde_json::Value::Object(facts)),
+        )
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &[]
+    }
+
+    fn optional_params(&self) -> HashMap<&'static str, serde_json::Value> {
+        let mut m = HashMap::new();
+        m.insert("gather", serde_json::json!(null));
+        m
+    }
+}

--- a/src/modules/hpc/healthcheck.rs
+++ b/src/modules/hpc/healthcheck.rs
@@ -1,0 +1,254 @@
+//! HPC health check module
+//!
+//! Runs a configurable set of health checks against an HPC node:
+//! - Munge round-trip authentication test
+//! - NFS mount availability
+//! - Service status checks
+//! - Optional GPU validation
+//! - Optional InfiniBand validation
+//!
+//! Returns structured JSON with pass/fail counts.
+//!
+//! # Parameters
+//!
+//! - `checks` (optional): List of checks to run. Default: all applicable.
+//!   Values: "munge", "nfs", "services", "gpu", "infiniband"
+//! - `nfs_mounts` (optional): List of mount points to verify
+//! - `services` (optional): List of systemd services to verify
+//! - `fail_on_error` (optional): Whether to fail the module on any check failure (default: false)
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::runtime::Handle;
+
+use crate::connection::{Connection, ExecuteOptions};
+use crate::modules::{
+    Module, ModuleContext, ModuleError, ModuleOutput, ModuleParams, ModuleResult, ParamExt,
+};
+
+fn get_exec_options(context: &ModuleContext) -> ExecuteOptions {
+    let mut options = ExecuteOptions::new();
+    if context.r#become {
+        options = options.with_escalation(context.become_user.clone());
+        if let Some(ref method) = context.become_method {
+            options.escalate_method = Some(method.clone());
+        }
+        if let Some(ref password) = context.become_password {
+            options.escalate_password = Some(password.clone());
+        }
+    }
+    options
+}
+
+/// Run a command and return (success, stdout, stderr) without failing on errors.
+fn run_cmd_check(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> (bool, String, String) {
+    let options = get_exec_options(context);
+    match Handle::current().block_on(async { connection.execute(cmd, Some(options)).await }) {
+        Ok(result) => (result.success, result.stdout, result.stderr),
+        Err(e) => (false, String::new(), e.to_string()),
+    }
+}
+
+pub struct HpcHealthcheckModule;
+
+impl Module for HpcHealthcheckModule {
+    fn name(&self) -> &'static str {
+        "hpc_healthcheck"
+    }
+
+    fn description(&self) -> &'static str {
+        "Run HPC node health checks (munge, NFS, services, GPU, InfiniBand)"
+    }
+
+    fn execute(
+        &self,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let connection = context
+            .connection
+            .as_ref()
+            .ok_or_else(|| ModuleError::ExecutionFailed("No connection available".to_string()))?;
+
+        if context.check_mode {
+            return Ok(ModuleOutput::ok("Would run HPC health checks"));
+        }
+
+        let enabled_checks = params.get_vec_string("checks")?;
+        let nfs_mounts = params.get_vec_string("nfs_mounts")?.unwrap_or_default();
+        let services = params.get_vec_string("services")?.unwrap_or_default();
+        let fail_on_error = params.get_bool_or("fail_on_error", false);
+
+        let mut results: Vec<serde_json::Value> = Vec::new();
+        let mut passed = 0u32;
+        let mut failed = 0u32;
+
+        let should_run = |check: &str| -> bool {
+            match &enabled_checks {
+                Some(checks) => checks.iter().any(|c| c == check),
+                None => true,
+            }
+        };
+
+        // --- Munge check ---
+        if should_run("munge") {
+            let (ok, _stdout, stderr) =
+                run_cmd_check(connection, "munge -n | unmunge >/dev/null 2>&1", context);
+            let entry = serde_json::json!({
+                "check": "munge",
+                "passed": ok,
+                "detail": if ok { "Munge round-trip succeeded" } else { "Munge round-trip failed" },
+                "stderr": stderr.trim(),
+            });
+            if ok {
+                passed += 1;
+            } else {
+                failed += 1;
+            }
+            results.push(entry);
+        }
+
+        // --- NFS mount checks ---
+        if should_run("nfs") {
+            for mount in &nfs_mounts {
+                let (ok, _, stderr) = run_cmd_check(
+                    connection,
+                    &format!("mountpoint -q '{}'", mount),
+                    context,
+                );
+                let entry = serde_json::json!({
+                    "check": "nfs",
+                    "mount": mount,
+                    "passed": ok,
+                    "detail": if ok {
+                        format!("{} is mounted", mount)
+                    } else {
+                        format!("{} is NOT mounted", mount)
+                    },
+                    "stderr": stderr.trim(),
+                });
+                if ok {
+                    passed += 1;
+                } else {
+                    failed += 1;
+                }
+                results.push(entry);
+            }
+        }
+
+        // --- Service checks ---
+        if should_run("services") {
+            for svc in &services {
+                let (ok, _, stderr) = run_cmd_check(
+                    connection,
+                    &format!("systemctl is-active '{}'", svc),
+                    context,
+                );
+                let entry = serde_json::json!({
+                    "check": "service",
+                    "service": svc,
+                    "passed": ok,
+                    "detail": if ok {
+                        format!("{} is active", svc)
+                    } else {
+                        format!("{} is NOT active", svc)
+                    },
+                    "stderr": stderr.trim(),
+                });
+                if ok {
+                    passed += 1;
+                } else {
+                    failed += 1;
+                }
+                results.push(entry);
+            }
+        }
+
+        // --- GPU check ---
+        if should_run("gpu") {
+            let (nvidia_present, _, _) =
+                run_cmd_check(connection, "which nvidia-smi >/dev/null 2>&1", context);
+            if nvidia_present {
+                let (ok, stdout, stderr) = run_cmd_check(
+                    connection,
+                    "nvidia-smi --query-gpu=gpu_name,memory.total,driver_version --format=csv,noheader 2>&1",
+                    context,
+                );
+                let entry = serde_json::json!({
+                    "check": "gpu",
+                    "passed": ok,
+                    "detail": if ok { stdout.trim().to_string() } else { "nvidia-smi failed".to_string() },
+                    "stderr": stderr.trim(),
+                });
+                if ok {
+                    passed += 1;
+                } else {
+                    failed += 1;
+                }
+                results.push(entry);
+            }
+        }
+
+        // --- InfiniBand check ---
+        if should_run("infiniband") {
+            let (ib_present, _, _) =
+                run_cmd_check(connection, "which ibstat >/dev/null 2>&1", context);
+            if ib_present {
+                let (ok, stdout, stderr) =
+                    run_cmd_check(connection, "ibstat -s 2>&1", context);
+                let entry = serde_json::json!({
+                    "check": "infiniband",
+                    "passed": ok,
+                    "detail": if ok { stdout.trim().to_string() } else { "ibstat failed".to_string() },
+                    "stderr": stderr.trim(),
+                });
+                if ok {
+                    passed += 1;
+                } else {
+                    failed += 1;
+                }
+                results.push(entry);
+            }
+        }
+
+        let summary = serde_json::json!({
+            "checks": results,
+            "passed": passed,
+            "failed": failed,
+            "total": passed + failed,
+        });
+
+        if failed > 0 && fail_on_error {
+            return Err(ModuleError::ExecutionFailed(format!(
+                "HPC health check: {} of {} checks failed",
+                failed,
+                passed + failed
+            )));
+        }
+
+        let msg = format!(
+            "HPC health check: {}/{} passed",
+            passed,
+            passed + failed
+        );
+
+        Ok(ModuleOutput::ok(msg).with_data("healthcheck", summary))
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &[]
+    }
+
+    fn optional_params(&self) -> HashMap<&'static str, serde_json::Value> {
+        let mut m = HashMap::new();
+        m.insert("checks", serde_json::json!(null));
+        m.insert("nfs_mounts", serde_json::json!([]));
+        m.insert("services", serde_json::json!([]));
+        m.insert("fail_on_error", serde_json::json!(false));
+        m
+    }
+}

--- a/src/modules/hpc/mod.rs
+++ b/src/modules/hpc/mod.rs
@@ -4,6 +4,10 @@
 //! cluster environments. Modules are organized by subsystem:
 //!
 //! - **common**: Cluster baseline configuration (limits, sysctl, directories)
+//! - **munge**: MUNGE authentication (Slurm prerequisite)
+//! - **nfs**: NFS server and client management
+//! - **healthcheck**: HPC node health validation
+//! - **facts**: HPC-specific fact gathering (CPU, NUMA, GPU, IB)
 //! - **slurm**: Slurm workload manager (controller, compute, operations)
 //! - **lmod**: Lmod / Environment Modules software management
 //! - **mpi**: MPI library configuration (OpenMPI, Intel MPI)
@@ -42,24 +46,32 @@
 //! - Missing prerequisites → `ModuleError::ExecutionFailed` with install hint
 
 pub mod common;
+pub mod facts;
 #[cfg(feature = "parallel_fs")]
 pub mod fs;
 #[cfg(feature = "gpu")]
 pub mod gpu;
+pub mod healthcheck;
 pub mod lmod;
 pub mod mpi;
+pub mod munge;
+pub mod nfs;
 #[cfg(feature = "ofed")]
 pub mod ofed;
 #[cfg(feature = "slurm")]
 pub mod slurm;
 
 pub use common::HpcBaselineModule;
+pub use facts::HpcFactsModule;
 #[cfg(feature = "parallel_fs")]
 pub use fs::{BeegfsClientModule, LustreClientModule};
 #[cfg(feature = "gpu")]
 pub use gpu::NvidiaGpuModule;
+pub use healthcheck::HpcHealthcheckModule;
 pub use lmod::LmodModule;
 pub use mpi::MpiModule;
+pub use munge::MungeModule;
+pub use nfs::{NfsClientModule, NfsServerModule};
 #[cfg(feature = "ofed")]
 pub use ofed::RdmaStackModule;
 #[cfg(feature = "slurm")]

--- a/src/modules/hpc/munge.rs
+++ b/src/modules/hpc/munge.rs
@@ -1,0 +1,334 @@
+//! Munge authentication module (Slurm prerequisite)
+//!
+//! Manages MUNGE (MUNGE Uid 'N' Gid Emporium) authentication service
+//! installation, key distribution, and service management.
+//!
+//! # Parameters
+//!
+//! - `state` (optional): "present" (default) or "absent"
+//! - `key_source` (optional): Path to munge.key on the control node
+//! - `key_content` (optional): Base64-encoded munge key content
+//! - `munge_user` (optional): User to own munge files (default: "munge")
+//! - `munge_group` (optional): Group to own munge files (default: "munge")
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::runtime::Handle;
+
+use crate::connection::{Connection, ExecuteOptions};
+use crate::modules::{
+    Module, ModuleContext, ModuleError, ModuleOutput, ModuleParams, ModuleResult, ParamExt,
+    ParallelizationHint,
+};
+
+fn get_exec_options(context: &ModuleContext) -> ExecuteOptions {
+    let mut options = ExecuteOptions::new();
+    if context.r#become {
+        options = options.with_escalation(context.become_user.clone());
+        if let Some(ref method) = context.become_method {
+            options.escalate_method = Some(method.clone());
+        }
+        if let Some(ref password) = context.become_password {
+            options.escalate_password = Some(password.clone());
+        }
+    }
+    options
+}
+
+fn run_cmd(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<(bool, String, String)> {
+    let options = get_exec_options(context);
+    let result = Handle::current()
+        .block_on(async { connection.execute(cmd, Some(options)).await })
+        .map_err(|e| ModuleError::ExecutionFailed(format!("Connection error: {}", e)))?;
+    Ok((result.success, result.stdout, result.stderr))
+}
+
+fn run_cmd_ok(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<String> {
+    let (success, stdout, stderr) = run_cmd(connection, cmd, context)?;
+    if !success {
+        return Err(ModuleError::ExecutionFailed(format!(
+            "Command failed: {}",
+            stderr.trim()
+        )));
+    }
+    Ok(stdout)
+}
+
+fn detect_os_family(os_release: &str) -> Option<&'static str> {
+    let id_line = os_release
+        .lines()
+        .find(|l| l.starts_with("ID_LIKE=") || l.starts_with("ID="));
+    match id_line {
+        Some(line) => {
+            let val = line
+                .split('=')
+                .nth(1)
+                .unwrap_or("")
+                .trim_matches('"')
+                .to_lowercase();
+            if val.contains("rhel")
+                || val.contains("fedora")
+                || val.contains("centos")
+                || val == "rocky"
+                || val == "almalinux"
+            {
+                Some("rhel")
+            } else if val.contains("debian") || val.contains("ubuntu") {
+                Some("debian")
+            } else {
+                None
+            }
+        }
+        None => None,
+    }
+}
+
+pub struct MungeModule;
+
+impl MungeModule {
+    fn handle_absent(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        os_family: &str,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let check_cmd = match os_family {
+            "rhel" => "rpm -q munge >/dev/null 2>&1",
+            _ => "dpkg -s munge >/dev/null 2>&1",
+        };
+        let (installed, _, _) = run_cmd(connection, check_cmd, context)?;
+
+        if !installed {
+            return Ok(ModuleOutput::ok("Munge is not installed"));
+        }
+
+        if context.check_mode {
+            return Ok(ModuleOutput::changed("Would remove munge"));
+        }
+
+        // Stop and disable service (ignore errors if service doesn't exist)
+        let _ = run_cmd(connection, "systemctl stop munge.service", context);
+        let _ = run_cmd(connection, "systemctl disable munge.service", context);
+
+        // Remove packages
+        let remove_cmd = match os_family {
+            "rhel" => "dnf remove -y munge munge-libs munge-devel",
+            _ => "DEBIAN_FRONTEND=noninteractive apt-get remove -y munge libmunge2 libmunge-dev",
+        };
+        run_cmd_ok(connection, remove_cmd, context)?;
+
+        Ok(ModuleOutput::changed("Removed munge"))
+    }
+}
+
+impl Module for MungeModule {
+    fn name(&self) -> &'static str {
+        "munge"
+    }
+
+    fn description(&self) -> &'static str {
+        "Manage MUNGE authentication service for HPC clusters"
+    }
+
+    fn parallelization_hint(&self) -> ParallelizationHint {
+        ParallelizationHint::HostExclusive
+    }
+
+    fn execute(
+        &self,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let connection = context
+            .connection
+            .as_ref()
+            .ok_or_else(|| ModuleError::ExecutionFailed("No connection available".to_string()))?;
+
+        let state = params
+            .get_string("state")?
+            .unwrap_or_else(|| "present".to_string());
+        let munge_user = params
+            .get_string("munge_user")?
+            .unwrap_or_else(|| "munge".to_string());
+        let munge_group = params
+            .get_string("munge_group")?
+            .unwrap_or_else(|| "munge".to_string());
+
+        let os_stdout = run_cmd_ok(connection, "cat /etc/os-release", context)?;
+        let os_family = detect_os_family(&os_stdout).ok_or_else(|| {
+            ModuleError::Unsupported(
+                "Unsupported OS. Munge module supports RHEL-family and Debian-family.".to_string(),
+            )
+        })?;
+
+        if state == "absent" {
+            return self.handle_absent(connection, os_family, context);
+        }
+
+        let mut changed = false;
+        let mut changes: Vec<String> = Vec::new();
+
+        // Install munge packages
+        let check_cmd = match os_family {
+            "rhel" => "rpm -q munge munge-libs >/dev/null 2>&1",
+            _ => "dpkg -s munge libmunge2 >/dev/null 2>&1",
+        };
+        let (installed, _, _) = run_cmd(connection, check_cmd, context)?;
+
+        if !installed {
+            if context.check_mode {
+                changes.push("Would install munge packages".to_string());
+            } else {
+                let install_cmd = match os_family {
+                    "rhel" => "dnf install -y munge munge-libs munge-devel",
+                    _ => "DEBIAN_FRONTEND=noninteractive apt-get install -y munge libmunge2 libmunge-dev",
+                };
+                run_cmd_ok(connection, install_cmd, context)?;
+                changed = true;
+                changes.push("Installed munge packages".to_string());
+            }
+        }
+
+        // Ensure directories exist with correct permissions
+        if !context.check_mode {
+            run_cmd_ok(
+                connection,
+                &format!(
+                    "mkdir -p /etc/munge /var/log/munge /var/lib/munge /run/munge && \
+                     chown {user}:{group} /etc/munge /var/log/munge /var/lib/munge /run/munge && \
+                     chmod 0700 /etc/munge /var/log/munge /var/lib/munge && \
+                     chmod 0755 /run/munge",
+                    user = munge_user,
+                    group = munge_group
+                ),
+                context,
+            )?;
+        }
+
+        // Distribute munge key
+        let key_content = params.get_string("key_content")?;
+        let key_source = params.get_string("key_source")?;
+
+        if key_content.is_some() || key_source.is_some() {
+            let key_written = if let Some(ref content) = key_content {
+                if context.check_mode {
+                    changes.push("Would distribute munge key".to_string());
+                    false
+                } else {
+                    run_cmd_ok(
+                        connection,
+                        &format!(
+                            "echo '{}' | base64 -d > /etc/munge/munge.key",
+                            content
+                        ),
+                        context,
+                    )?;
+                    true
+                }
+            } else if let Some(ref source) = key_source {
+                if context.check_mode {
+                    changes.push(format!("Would copy munge key from {}", source));
+                    false
+                } else {
+                    run_cmd_ok(
+                        connection,
+                        &format!("cp '{}' /etc/munge/munge.key", source),
+                        context,
+                    )?;
+                    true
+                }
+            } else {
+                false
+            };
+
+            if key_written {
+                run_cmd_ok(
+                    connection,
+                    &format!(
+                        "chown {}:{} /etc/munge/munge.key && chmod 0400 /etc/munge/munge.key",
+                        munge_user, munge_group
+                    ),
+                    context,
+                )?;
+                changed = true;
+                changes.push("Distributed munge key".to_string());
+            }
+        } else {
+            // Check if key exists, generate if not
+            let (key_exists, _, _) =
+                run_cmd(connection, "test -f /etc/munge/munge.key", context)?;
+            if !key_exists {
+                if context.check_mode {
+                    changes.push("Would generate new munge key".to_string());
+                } else {
+                    run_cmd_ok(connection, "mungekey --create --force", context)?;
+                    run_cmd_ok(
+                        connection,
+                        &format!(
+                            "chown {}:{} /etc/munge/munge.key && chmod 0400 /etc/munge/munge.key",
+                            munge_user, munge_group
+                        ),
+                        context,
+                    )?;
+                    changed = true;
+                    changes.push("Generated new munge key".to_string());
+                }
+            }
+        }
+
+        // Enable and start munge service
+        let (service_active, _, _) =
+            run_cmd(connection, "systemctl is-active munge.service", context)?;
+        let (service_enabled, _, _) =
+            run_cmd(connection, "systemctl is-enabled munge.service", context)?;
+
+        if !service_enabled || !service_active {
+            if context.check_mode {
+                changes.push("Would enable and start munge.service".to_string());
+            } else {
+                run_cmd_ok(connection, "systemctl enable --now munge.service", context)?;
+                changed = true;
+                changes.push("Enabled and started munge.service".to_string());
+            }
+        }
+
+        if context.check_mode && !changes.is_empty() {
+            return Ok(ModuleOutput::changed(format!(
+                "Would apply {} munge changes",
+                changes.len()
+            ))
+            .with_data("changes", serde_json::json!(changes)));
+        }
+
+        if changed {
+            Ok(
+                ModuleOutput::changed(format!("Applied {} munge changes", changes.len()))
+                    .with_data("changes", serde_json::json!(changes)),
+            )
+        } else {
+            Ok(ModuleOutput::ok("Munge is configured and running"))
+        }
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &[]
+    }
+
+    fn optional_params(&self) -> HashMap<&'static str, serde_json::Value> {
+        let mut m = HashMap::new();
+        m.insert("state", serde_json::json!("present"));
+        m.insert("key_source", serde_json::json!(null));
+        m.insert("key_content", serde_json::json!(null));
+        m.insert("munge_user", serde_json::json!("munge"));
+        m.insert("munge_group", serde_json::json!("munge"));
+        m
+    }
+}

--- a/src/modules/hpc/nfs.rs
+++ b/src/modules/hpc/nfs.rs
@@ -1,0 +1,490 @@
+//! NFS shared storage modules
+//!
+//! Provides NFS server and client management for HPC clusters.
+//!
+//! # Modules
+//!
+//! - `nfs_server`: Manage NFS exports via `/etc/exports`
+//! - `nfs_client`: Manage NFS client mounts via fstab
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::runtime::Handle;
+
+use crate::connection::{Connection, ExecuteOptions};
+use crate::modules::{
+    Module, ModuleContext, ModuleError, ModuleOutput, ModuleParams, ModuleResult, ParamExt,
+    ParallelizationHint,
+};
+
+fn get_exec_options(context: &ModuleContext) -> ExecuteOptions {
+    let mut options = ExecuteOptions::new();
+    if context.r#become {
+        options = options.with_escalation(context.become_user.clone());
+        if let Some(ref method) = context.become_method {
+            options.escalate_method = Some(method.clone());
+        }
+        if let Some(ref password) = context.become_password {
+            options.escalate_password = Some(password.clone());
+        }
+    }
+    options
+}
+
+fn run_cmd(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<(bool, String, String)> {
+    let options = get_exec_options(context);
+    let result = Handle::current()
+        .block_on(async { connection.execute(cmd, Some(options)).await })
+        .map_err(|e| ModuleError::ExecutionFailed(format!("Connection error: {}", e)))?;
+    Ok((result.success, result.stdout, result.stderr))
+}
+
+fn run_cmd_ok(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<String> {
+    let (success, stdout, stderr) = run_cmd(connection, cmd, context)?;
+    if !success {
+        return Err(ModuleError::ExecutionFailed(format!(
+            "Command failed: {}",
+            stderr.trim()
+        )));
+    }
+    Ok(stdout)
+}
+
+fn detect_os_family(os_release: &str) -> Option<&'static str> {
+    let id_line = os_release
+        .lines()
+        .find(|l| l.starts_with("ID_LIKE=") || l.starts_with("ID="));
+    match id_line {
+        Some(line) => {
+            let val = line
+                .split('=')
+                .nth(1)
+                .unwrap_or("")
+                .trim_matches('"')
+                .to_lowercase();
+            if val.contains("rhel")
+                || val.contains("fedora")
+                || val.contains("centos")
+                || val == "rocky"
+                || val == "almalinux"
+            {
+                Some("rhel")
+            } else if val.contains("debian") || val.contains("ubuntu") {
+                Some("debian")
+            } else {
+                None
+            }
+        }
+        None => None,
+    }
+}
+
+// ---- NFS Server Module ----
+
+pub struct NfsServerModule;
+
+impl Module for NfsServerModule {
+    fn name(&self) -> &'static str {
+        "nfs_server"
+    }
+
+    fn description(&self) -> &'static str {
+        "Manage NFS server exports for HPC shared storage"
+    }
+
+    fn parallelization_hint(&self) -> ParallelizationHint {
+        ParallelizationHint::HostExclusive
+    }
+
+    fn execute(
+        &self,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let connection = context
+            .connection
+            .as_ref()
+            .ok_or_else(|| ModuleError::ExecutionFailed("No connection available".to_string()))?;
+
+        let os_stdout = run_cmd_ok(connection, "cat /etc/os-release", context)?;
+        let os_family = detect_os_family(&os_stdout).ok_or_else(|| {
+            ModuleError::Unsupported("Unsupported OS for NFS server module".to_string())
+        })?;
+
+        let state = params
+            .get_string("state")?
+            .unwrap_or_else(|| "present".to_string());
+
+        let mut changed = false;
+        let mut changes: Vec<String> = Vec::new();
+
+        // Determine package and service names
+        let nfs_pkg = match os_family {
+            "rhel" => "nfs-utils",
+            _ => "nfs-kernel-server",
+        };
+        let nfs_svc = match os_family {
+            "rhel" => "nfs-server.service",
+            _ => "nfs-kernel-server.service",
+        };
+
+        // Check if installed
+        let check_cmd = match os_family {
+            "rhel" => format!("rpm -q {} >/dev/null 2>&1", nfs_pkg),
+            _ => format!("dpkg -s {} >/dev/null 2>&1", nfs_pkg),
+        };
+        let (installed, _, _) = run_cmd(connection, &check_cmd, context)?;
+
+        if state == "absent" {
+            if !installed {
+                return Ok(ModuleOutput::ok("NFS server is not installed"));
+            }
+            if context.check_mode {
+                return Ok(ModuleOutput::changed("Would remove NFS server"));
+            }
+            let _ = run_cmd(connection, &format!("systemctl stop {}", nfs_svc), context);
+            let _ = run_cmd(connection, &format!("systemctl disable {}", nfs_svc), context);
+            let remove_cmd = match os_family {
+                "rhel" => format!("dnf remove -y {}", nfs_pkg),
+                _ => format!("DEBIAN_FRONTEND=noninteractive apt-get remove -y {}", nfs_pkg),
+            };
+            run_cmd_ok(connection, &remove_cmd, context)?;
+            return Ok(ModuleOutput::changed("Removed NFS server"));
+        }
+
+        // Install NFS server packages
+        if !installed {
+            if context.check_mode {
+                changes.push(format!("Would install {}", nfs_pkg));
+            } else {
+                let install_cmd = match os_family {
+                    "rhel" => format!("dnf install -y {}", nfs_pkg),
+                    _ => format!(
+                        "DEBIAN_FRONTEND=noninteractive apt-get install -y {}",
+                        nfs_pkg
+                    ),
+                };
+                run_cmd_ok(connection, &install_cmd, context)?;
+                changed = true;
+                changes.push(format!("Installed {}", nfs_pkg));
+            }
+        }
+
+        // Manage exports
+        if let Some(exports) = params.get_vec_string("exports")? {
+            if !exports.is_empty() {
+                let desired = exports.join("\n") + "\n";
+                let (_, current, _) = run_cmd(
+                    connection,
+                    "cat /etc/exports 2>/dev/null || true",
+                    context,
+                )?;
+
+                if current.trim() != desired.trim() {
+                    if context.check_mode {
+                        changes.push(format!(
+                            "Would update /etc/exports with {} entries",
+                            exports.len()
+                        ));
+                    } else {
+                        run_cmd_ok(
+                            connection,
+                            &format!(
+                                "printf '%s\\n' '{}' > /etc/exports",
+                                desired.trim().replace('\'', "'\\''")
+                            ),
+                            context,
+                        )?;
+                        run_cmd_ok(connection, "exportfs -ra", context)?;
+                        changed = true;
+                        changes.push(format!(
+                            "Updated /etc/exports with {} entries",
+                            exports.len()
+                        ));
+                    }
+                }
+            }
+        }
+
+        // Enable NFS service
+        let (active, _, _) = run_cmd(
+            connection,
+            &format!("systemctl is-active {}", nfs_svc),
+            context,
+        )?;
+        if !active {
+            if context.check_mode {
+                changes.push(format!("Would enable and start {}", nfs_svc));
+            } else {
+                run_cmd_ok(
+                    connection,
+                    &format!("systemctl enable --now {}", nfs_svc),
+                    context,
+                )?;
+                changed = true;
+                changes.push(format!("Enabled and started {}", nfs_svc));
+            }
+        }
+
+        if context.check_mode && !changes.is_empty() {
+            return Ok(ModuleOutput::changed(format!(
+                "Would apply {} NFS server changes",
+                changes.len()
+            ))
+            .with_data("changes", serde_json::json!(changes)));
+        }
+
+        if changed {
+            Ok(
+                ModuleOutput::changed(format!("Applied {} NFS server changes", changes.len()))
+                    .with_data("changes", serde_json::json!(changes)),
+            )
+        } else {
+            Ok(ModuleOutput::ok("NFS server is configured"))
+        }
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &[]
+    }
+
+    fn optional_params(&self) -> HashMap<&'static str, serde_json::Value> {
+        let mut m = HashMap::new();
+        m.insert("state", serde_json::json!("present"));
+        m.insert("exports", serde_json::json!([]));
+        m
+    }
+}
+
+// ---- NFS Client Module ----
+
+pub struct NfsClientModule;
+
+impl Module for NfsClientModule {
+    fn name(&self) -> &'static str {
+        "nfs_client"
+    }
+
+    fn description(&self) -> &'static str {
+        "Manage NFS client mounts for HPC shared storage"
+    }
+
+    fn parallelization_hint(&self) -> ParallelizationHint {
+        ParallelizationHint::HostExclusive
+    }
+
+    fn execute(
+        &self,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let connection = context
+            .connection
+            .as_ref()
+            .ok_or_else(|| ModuleError::ExecutionFailed("No connection available".to_string()))?;
+
+        let os_stdout = run_cmd_ok(connection, "cat /etc/os-release", context)?;
+        let os_family = detect_os_family(&os_stdout).ok_or_else(|| {
+            ModuleError::Unsupported("Unsupported OS for NFS client module".to_string())
+        })?;
+
+        let state = params
+            .get_string("state")?
+            .unwrap_or_else(|| "mounted".to_string());
+        let server = params.get_string_required("server")?;
+        let export_path = params.get_string_required("export")?;
+        let mount_point = params.get_string_required("mount_point")?;
+        let mount_options = params
+            .get_string("mount_options")?
+            .unwrap_or_else(|| "defaults,hard,intr".to_string());
+
+        let mut changed = false;
+        let mut changes: Vec<String> = Vec::new();
+
+        // Install NFS client packages
+        let nfs_pkg = match os_family {
+            "rhel" => "nfs-utils",
+            _ => "nfs-common",
+        };
+        let check_cmd = match os_family {
+            "rhel" => format!("rpm -q {} >/dev/null 2>&1", nfs_pkg),
+            _ => format!("dpkg -s {} >/dev/null 2>&1", nfs_pkg),
+        };
+        let (installed, _, _) = run_cmd(connection, &check_cmd, context)?;
+
+        if !installed {
+            if context.check_mode {
+                changes.push(format!("Would install {}", nfs_pkg));
+            } else {
+                let install_cmd = match os_family {
+                    "rhel" => format!("dnf install -y {}", nfs_pkg),
+                    _ => format!(
+                        "DEBIAN_FRONTEND=noninteractive apt-get install -y {}",
+                        nfs_pkg
+                    ),
+                };
+                run_cmd_ok(connection, &install_cmd, context)?;
+                changed = true;
+                changes.push(format!("Installed {}", nfs_pkg));
+            }
+        }
+
+        let _fstab_entry = format!(
+            "{}:{} {} nfs {} 0 0",
+            server, export_path, mount_point, mount_options
+        );
+
+        match state.as_str() {
+            "mounted" => {
+                // Ensure mount point directory exists
+                let (dir_exists, _, _) = run_cmd(
+                    connection,
+                    &format!("test -d '{}'", mount_point),
+                    context,
+                )?;
+                if !dir_exists {
+                    if !context.check_mode {
+                        run_cmd_ok(
+                            connection,
+                            &format!("mkdir -p '{}'", mount_point),
+                            context,
+                        )?;
+                    }
+                    changed = true;
+                    changes.push(format!("Created mount point {}", mount_point));
+                }
+
+                // Check if fstab entry exists
+                let (in_fstab, _, _) = run_cmd(
+                    connection,
+                    &format!("grep -qF '{}:{}' /etc/fstab", server, export_path),
+                    context,
+                )?;
+
+                if !in_fstab {
+                    if context.check_mode {
+                        changes.push(format!("Would add fstab entry for {}", mount_point));
+                    } else {
+                        run_cmd_ok(
+                            connection,
+                            &format!("echo '{}' >> /etc/fstab", _fstab_entry),
+                            context,
+                        )?;
+                        changed = true;
+                        changes.push(format!("Added fstab entry for {}", mount_point));
+                    }
+                }
+
+                // Mount if not already mounted
+                let (is_mounted, _, _) = run_cmd(
+                    connection,
+                    &format!("mountpoint -q '{}'", mount_point),
+                    context,
+                )?;
+
+                if !is_mounted {
+                    if context.check_mode {
+                        changes.push(format!("Would mount {}", mount_point));
+                    } else {
+                        run_cmd_ok(
+                            connection,
+                            &format!("mount '{}'", mount_point),
+                            context,
+                        )?;
+                        changed = true;
+                        changes.push(format!("Mounted {}", mount_point));
+                    }
+                }
+            }
+            "unmounted" | "absent" => {
+                let (is_mounted, _, _) = run_cmd(
+                    connection,
+                    &format!("mountpoint -q '{}'", mount_point),
+                    context,
+                )?;
+
+                if is_mounted {
+                    if context.check_mode {
+                        changes.push(format!("Would unmount {}", mount_point));
+                    } else {
+                        run_cmd_ok(
+                            connection,
+                            &format!("umount '{}'", mount_point),
+                            context,
+                        )?;
+                        changed = true;
+                        changes.push(format!("Unmounted {}", mount_point));
+                    }
+                }
+
+                if state == "absent" {
+                    // Remove fstab entry
+                    let (in_fstab, _, _) = run_cmd(
+                        connection,
+                        &format!("grep -qF '{}:{}' /etc/fstab", server, export_path),
+                        context,
+                    )?;
+
+                    if in_fstab {
+                        if context.check_mode {
+                            changes.push("Would remove fstab entry".to_string());
+                        } else {
+                            run_cmd_ok(
+                                connection,
+                                &format!(
+                                    "sed -i '\\|{}:{}|d' /etc/fstab",
+                                    server, export_path
+                                ),
+                                context,
+                            )?;
+                            changed = true;
+                            changes.push("Removed fstab entry".to_string());
+                        }
+                    }
+                }
+            }
+            _ => {
+                return Err(ModuleError::InvalidParameter(format!(
+                    "Invalid state '{}'. Must be 'mounted', 'unmounted', or 'absent'",
+                    state
+                )));
+            }
+        }
+
+        if context.check_mode && !changes.is_empty() {
+            return Ok(ModuleOutput::changed(format!(
+                "Would apply {} NFS client changes",
+                changes.len()
+            ))
+            .with_data("changes", serde_json::json!(changes)));
+        }
+
+        if changed {
+            Ok(
+                ModuleOutput::changed(format!("Applied {} NFS client changes", changes.len()))
+                    .with_data("changes", serde_json::json!(changes)),
+            )
+        } else {
+            Ok(ModuleOutput::ok("NFS client mount is configured"))
+        }
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &["server", "export", "mount_point"]
+    }
+
+    fn optional_params(&self) -> HashMap<&'static str, serde_json::Value> {
+        let mut m = HashMap::new();
+        m.insert("state", serde_json::json!("mounted"));
+        m.insert("mount_options", serde_json::json!("defaults,hard,intr"));
+        m
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1665,6 +1665,11 @@ impl ModuleRegistry {
         register_modules!(registry,
             Hpc: [
                 hpc::HpcBaselineModule,
+                hpc::MungeModule,
+                hpc::NfsServerModule,
+                hpc::NfsClientModule,
+                hpc::HpcHealthcheckModule,
+                hpc::HpcFactsModule,
                 hpc::LmodModule,
                 hpc::MpiModule,
             ],


### PR DESCRIPTION
## Summary

- Replace `hpc_baseline` stub with full implementation (limits, sysctl, packages, directories, tuned profiles)
- Add `munge` module for MUNGE authentication service management with key distribution
- Add `nfs_server` and `nfs_client` modules for NFS shared storage
- Add `hpc_healthcheck` module for configurable node health validation
- Add `hpc_facts` module for HPC-specific fact gathering (CPU, NUMA, hugepages, GPU, InfiniBand)
- All modules support check_mode, privilege escalation, and idempotent operation

Closes #487, Closes #490, Closes #491, Closes #470, Closes #467

## Test plan

- [x] `cargo build --features hpc,slurm,gpu,ofed,parallel_fs` compiles cleanly
- [x] `cargo clippy` passes with no HPC-related warnings
- [ ] Module registration verified in `ModuleRegistry::with_builtins()`
- [ ] Each module's `check_mode` path returns correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)