### PR TITLE
feat(migration): add xCAT object model import

### DIFF
--- a/src/cli/commands/migrate.rs
+++ b/src/cli/commands/migrate.rs
@@ -1,0 +1,190 @@
+//! Migrate command for importing infrastructure data from external tools.
+//!
+//! Provides subcommands for each supported migration source.
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+#[cfg(feature = "hpc")]
+use std::path::PathBuf;
+
+use super::CommandContext;
+
+/// Arguments for the migrate command.
+#[derive(Parser, Debug, Clone)]
+pub struct MigrateArgs {
+    /// Migration subcommand to execute.
+    #[command(subcommand)]
+    pub command: MigrateCommand,
+}
+
+/// Available migration subcommands.
+#[derive(Subcommand, Debug, Clone)]
+pub enum MigrateCommand {
+    /// Show available migration sources and their status.
+    Status,
+
+    /// Import xCAT object definitions (nodes, groups) into Rustible inventory.
+    #[cfg(feature = "hpc")]
+    #[command(name = "xcat-objects")]
+    XcatObjects(XcatObjectsArgs),
+}
+
+/// Arguments for the xcat-objects migration subcommand.
+#[cfg(feature = "hpc")]
+#[derive(Parser, Debug, Clone)]
+pub struct XcatObjectsArgs {
+    /// Path to a file containing `lsdef -l` output.
+    pub input: PathBuf,
+
+    /// Perform a dry-run without writing any output files.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Emit output as JSON instead of human-readable text.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl MigrateArgs {
+    /// Execute the selected migration subcommand.
+    pub async fn execute(&self, ctx: &mut CommandContext) -> Result<i32> {
+        match &self.command {
+            MigrateCommand::Status => execute_status(ctx).await,
+            #[cfg(feature = "hpc")]
+            MigrateCommand::XcatObjects(args) => execute_xcat_objects(args, ctx).await,
+        }
+    }
+}
+
+/// Display available migration sources.
+async fn execute_status(ctx: &mut CommandContext) -> Result<i32> {
+    ctx.output.banner("MIGRATION STATUS");
+    ctx.output.section("Available Migration Sources");
+
+    #[cfg(feature = "hpc")]
+    {
+        println!("  xcat-objects   Import xCAT node/group definitions (lsdef output)");
+    }
+
+    #[cfg(not(feature = "hpc"))]
+    {
+        println!("  (no migration sources available with current features)");
+        println!();
+        println!("  Enable the 'hpc' feature for xCAT migration support.");
+    }
+
+    Ok(0)
+}
+
+/// Execute the xCAT objects import.
+#[cfg(feature = "hpc")]
+async fn execute_xcat_objects(args: &XcatObjectsArgs, ctx: &mut CommandContext) -> Result<i32> {
+    use rustible::migration::xcat::objects::XcatObjectImporter;
+
+    ctx.output.banner("XCAT OBJECT IMPORT");
+
+    // Read input file
+    if !args.input.exists() {
+        ctx.output.error(&format!(
+            "Input file not found: {}",
+            args.input.display()
+        ));
+        return Ok(1);
+    }
+
+    let content = std::fs::read_to_string(&args.input)?;
+    ctx.output.info(&format!(
+        "Parsing xCAT lsdef output from: {}",
+        args.input.display()
+    ));
+
+    let importer = XcatObjectImporter::new();
+
+    // Parse the lsdef output
+    let objects = match importer.parse_lsdef(&content) {
+        Ok(objs) => objs,
+        Err(e) => {
+            ctx.output.error(&format!("Failed to parse input: {}", e));
+            return Ok(1);
+        }
+    };
+
+    ctx.output
+        .info(&format!("Parsed {} xCAT object(s)", objects.len()));
+
+    // Import into inventory structures
+    let result = importer.import(&objects);
+    let summary = result.report.compute_summary();
+
+    if args.json {
+        let output = serde_json::json!({
+            "hosts": result.hosts.len(),
+            "groups": result.groups.len(),
+            "host_names": result.hosts.iter().map(|h| &h.name).collect::<Vec<_>>(),
+            "group_names": result.groups.iter().map(|g| &g.name).collect::<Vec<_>>(),
+            "findings": summary.total_findings,
+            "errors": summary.errors,
+            "warnings": summary.warnings,
+            "dry_run": args.dry_run,
+        });
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        ctx.output.section("Import Results");
+        println!("  Hosts imported:  {}", result.hosts.len());
+        println!("  Groups derived:  {}", result.groups.len());
+
+        if !result.hosts.is_empty() {
+            ctx.output.section("Hosts");
+            for host in &result.hosts {
+                let addr = host.ansible_host.as_deref().unwrap_or("-");
+                let groups: Vec<&str> = host.groups.iter().map(|s| s.as_str()).collect();
+                println!(
+                    "  {:<25} {:<18} groups=[{}]",
+                    host.name,
+                    addr,
+                    groups.join(", ")
+                );
+            }
+        }
+
+        if !result.groups.is_empty() {
+            ctx.output.section("Groups");
+            for group in &result.groups {
+                println!(
+                    "  {:<25} ({} host(s))",
+                    group.name,
+                    group.hosts.len()
+                );
+            }
+        }
+
+        if summary.total_findings > 0 {
+            ctx.output.section("Diagnostics");
+            println!(
+                "  {} error(s), {} warning(s), {} info",
+                summary.errors, summary.warnings, summary.info
+            );
+            for finding in &result.report.findings {
+                let icon = match finding.severity {
+                    rustible::migration::MigrationSeverity::Error => "ERROR",
+                    rustible::migration::MigrationSeverity::Warning => "WARN ",
+                    rustible::migration::MigrationSeverity::Info => "INFO ",
+                };
+                println!("  [{}] {}: {}", icon, finding.id, finding.title);
+            }
+        }
+
+        if args.dry_run {
+            println!();
+            ctx.output
+                .warning("Dry-run mode: no output files were written.");
+        }
+    }
+
+    if summary.errors > 0 {
+        Ok(1)
+    } else {
+        Ok(0)
+    }
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod fleet;
 pub mod galaxy;
 pub mod inventory;
 pub mod lock;
+pub mod migrate;
 pub mod provider;
 pub mod provision;
 pub mod provisioner;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -153,6 +153,10 @@ pub enum Commands {
     /// Show fleet infrastructure dashboard
     #[command(name = "fleet")]
     Fleet(commands::fleet::FleetArgs),
+
+    /// Migrate infrastructure data from external tools
+    #[command(name = "migrate")]
+    Migrate(commands::migrate::MigrateArgs),
 }
 
 /// Arguments for agent command

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -907,6 +907,16 @@ pub mod tenant;
 pub mod agent;
 
 // ============================================================================
+// Migration Framework
+// ============================================================================
+
+/// Migration framework for importing infrastructure from external tools.
+///
+/// Provides structured parsers and mappers for converting configuration
+/// data from other systems (xCAT, Warewulf, etc.) into Rustible inventory.
+pub mod migration;
+
+// ============================================================================
 // Version Information
 // ============================================================================
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,7 @@ async fn main() -> Result<()> {
             1
         }
         Commands::Fleet(args) => args.execute(&mut ctx).await?,
+        Commands::Migrate(args) => args.execute(&mut ctx).await?,
     };
 
     std::process::exit(exit_code);

--- a/src/migration/error.rs
+++ b/src/migration/error.rs
@@ -1,0 +1,43 @@
+//! Error types for the migration framework.
+
+use thiserror::Error;
+
+/// Errors that can occur during a migration operation.
+#[derive(Debug, Error)]
+pub enum MigrationError {
+    /// The specified migration source file or directory was not found.
+    #[error("migration source not found: {0}")]
+    SourceNotFound(String),
+
+    /// Failed to parse the source data format.
+    #[error("parse error: {0}")]
+    ParseError(String),
+
+    /// A field in the source data is not supported by the target model.
+    #[error("unsupported field '{field}' in object '{object}'")]
+    UnsupportedField {
+        /// The object that contains the unsupported field.
+        object: String,
+        /// The field name that is not supported.
+        field: String,
+    },
+
+    /// Validation of the migrated data failed.
+    #[error("validation failed: {0}")]
+    ValidationFailed(String),
+
+    /// An I/O error occurred during migration.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// A JSON serialization/deserialization error.
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// A YAML serialization/deserialization error.
+    #[error("YAML error: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+}
+
+/// Convenience type alias for migration results.
+pub type MigrationResult<T> = std::result::Result<T, MigrationError>;

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -1,0 +1,20 @@
+//! Migration framework for importing infrastructure from external tools.
+//!
+//! This module provides a structured approach to migrating configuration
+//! data from other infrastructure management systems into Rustible's
+//! inventory format. Each source system has its own submodule with
+//! parsers and mappers.
+//!
+//! # Supported Sources
+//!
+//! - **xCAT** (feature `hpc`): Import node definitions, groups, and
+//!   network objects from xCAT's `lsdef` output.
+
+pub mod error;
+pub mod report;
+
+#[cfg(feature = "hpc")]
+pub mod xcat;
+
+pub use error::{MigrationError, MigrationResult};
+pub use report::{MigrationDiagnostic, MigrationFinding, MigrationReport, MigrationSeverity};

--- a/src/migration/report.rs
+++ b/src/migration/report.rs
@@ -1,0 +1,230 @@
+//! Migration reporting and diagnostics.
+//!
+//! Provides structured reporting for migration operations including
+//! per-object diagnostics, severity classification, and outcome
+//! computation based on configurable thresholds.
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+/// Severity level of a migration diagnostic or finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MigrationSeverity {
+    /// Informational message, no action required.
+    Info,
+    /// A potential issue that may need attention.
+    Warning,
+    /// An error that prevented correct migration of an object.
+    Error,
+}
+
+/// Category of a diagnostic finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticCategory {
+    /// Related to data parsing.
+    Parsing,
+    /// Related to field mapping between source and target.
+    FieldMapping,
+    /// Related to data validation.
+    Validation,
+    /// Related to an unsupported feature or object type.
+    Unsupported,
+}
+
+/// Status of a finding (whether it was resolved or remains open).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FindingStatus {
+    /// The finding is still open / unresolved.
+    Open,
+    /// The finding has been resolved or accepted.
+    Resolved,
+}
+
+/// A single diagnostic message attached to a migration operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MigrationDiagnostic {
+    /// Severity of the diagnostic.
+    pub severity: MigrationSeverity,
+    /// Category of the diagnostic.
+    pub category: DiagnosticCategory,
+    /// Human-readable description.
+    pub message: String,
+    /// The source object this diagnostic relates to, if any.
+    pub source_object: Option<String>,
+}
+
+/// A top-level finding that summarises one or more diagnostics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MigrationFinding {
+    /// Unique identifier within the report.
+    pub id: String,
+    /// Severity of the finding.
+    pub severity: MigrationSeverity,
+    /// Status of the finding.
+    pub status: FindingStatus,
+    /// Short title.
+    pub title: String,
+    /// Detailed description.
+    pub description: String,
+    /// Category of the finding.
+    pub category: DiagnosticCategory,
+    /// Related diagnostics.
+    pub diagnostics: Vec<MigrationDiagnostic>,
+}
+
+/// Summary statistics for a migration report.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReportSummary {
+    /// Total number of findings.
+    pub total_findings: usize,
+    /// Number of error-level findings.
+    pub errors: usize,
+    /// Number of warning-level findings.
+    pub warnings: usize,
+    /// Number of info-level findings.
+    pub info: usize,
+}
+
+/// Overall outcome of a migration operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MigrationOutcome {
+    /// Migration succeeded with no issues.
+    Success,
+    /// Migration completed but some findings exceed the threshold.
+    Degraded,
+    /// Migration failed due to too many errors.
+    Failed,
+}
+
+/// A complete migration report containing all findings and metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MigrationReport {
+    /// ISO-8601 timestamp of when the report was created.
+    pub created_at: String,
+    /// Human-readable label for the migration source.
+    pub source_label: String,
+    /// Ordered list of findings.
+    pub findings: Vec<MigrationFinding>,
+}
+
+impl MigrationReport {
+    /// Create a new empty report for the given source.
+    pub fn new(source_label: impl Into<String>) -> Self {
+        Self {
+            created_at: Utc::now().to_rfc3339(),
+            source_label: source_label.into(),
+            findings: Vec::new(),
+        }
+    }
+
+    /// Append a finding to the report.
+    pub fn add_finding(&mut self, finding: MigrationFinding) {
+        self.findings.push(finding);
+    }
+
+    /// Compute summary statistics from the current findings.
+    pub fn compute_summary(&self) -> ReportSummary {
+        let mut errors = 0usize;
+        let mut warnings = 0usize;
+        let mut info = 0usize;
+
+        for f in &self.findings {
+            match f.severity {
+                MigrationSeverity::Error => errors += 1,
+                MigrationSeverity::Warning => warnings += 1,
+                MigrationSeverity::Info => info += 1,
+            }
+        }
+
+        ReportSummary {
+            total_findings: self.findings.len(),
+            errors,
+            warnings,
+            info,
+        }
+    }
+
+    /// Compute the overall outcome based on the number of errors
+    /// relative to the given `threshold`.
+    ///
+    /// - 0 errors => `Success`
+    /// - errors <= threshold => `Degraded`
+    /// - errors > threshold => `Failed`
+    pub fn compute_outcome(&self, threshold: usize) -> MigrationOutcome {
+        let summary = self.compute_summary();
+        if summary.errors == 0 {
+            MigrationOutcome::Success
+        } else if summary.errors <= threshold {
+            MigrationOutcome::Degraded
+        } else {
+            MigrationOutcome::Failed
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_report_is_success() {
+        let report = MigrationReport::new("test");
+        assert_eq!(report.compute_outcome(5), MigrationOutcome::Success);
+        let summary = report.compute_summary();
+        assert_eq!(summary.total_findings, 0);
+        assert_eq!(summary.errors, 0);
+    }
+
+    #[test]
+    fn test_report_with_warnings_is_success() {
+        let mut report = MigrationReport::new("test");
+        report.add_finding(MigrationFinding {
+            id: "W001".into(),
+            severity: MigrationSeverity::Warning,
+            status: FindingStatus::Open,
+            title: "minor issue".into(),
+            description: "something".into(),
+            category: DiagnosticCategory::FieldMapping,
+            diagnostics: vec![],
+        });
+        assert_eq!(report.compute_outcome(5), MigrationOutcome::Success);
+    }
+
+    #[test]
+    fn test_report_errors_below_threshold_is_degraded() {
+        let mut report = MigrationReport::new("test");
+        report.add_finding(MigrationFinding {
+            id: "E001".into(),
+            severity: MigrationSeverity::Error,
+            status: FindingStatus::Open,
+            title: "error".into(),
+            description: "something broke".into(),
+            category: DiagnosticCategory::Validation,
+            diagnostics: vec![],
+        });
+        assert_eq!(report.compute_outcome(5), MigrationOutcome::Degraded);
+    }
+
+    #[test]
+    fn test_report_errors_above_threshold_is_failed() {
+        let mut report = MigrationReport::new("test");
+        for i in 0..6 {
+            report.add_finding(MigrationFinding {
+                id: format!("E{:03}", i),
+                severity: MigrationSeverity::Error,
+                status: FindingStatus::Open,
+                title: "error".into(),
+                description: "fail".into(),
+                category: DiagnosticCategory::Parsing,
+                diagnostics: vec![],
+            });
+        }
+        assert_eq!(report.compute_outcome(5), MigrationOutcome::Failed);
+        let summary = report.compute_summary();
+        assert_eq!(summary.errors, 6);
+    }
+}

--- a/src/migration/xcat/mod.rs
+++ b/src/migration/xcat/mod.rs
@@ -1,0 +1,7 @@
+//! xCAT migration support.
+//!
+//! Provides parsers and mappers for importing xCAT object definitions
+//! (produced by `lsdef -t node -l`, `lsdef -t group -l`, etc.) into
+//! Rustible inventory structures.
+
+pub mod objects;

--- a/src/migration/xcat/objects.rs
+++ b/src/migration/xcat/objects.rs
@@ -1,0 +1,503 @@
+//! xCAT object definition parser and importer.
+//!
+//! Parses the output of `lsdef -l` (long listing) which produces
+//! key=value attribute listings per object, and maps them into
+//! Rustible [`Host`] and [`Group`] structures.
+//!
+//! # xCAT `lsdef` format
+//!
+//! ```text
+//! Object name: node01
+//!     arch=x86_64
+//!     groups=compute,rack1
+//!     ip=10.0.0.101
+//!     mac=aa:bb:cc:dd:ee:01
+//!     bmc=10.0.1.101
+//!     os=rhels8.5
+//!     status=booted
+//! ```
+
+use std::collections::{HashMap, HashSet};
+
+use crate::inventory::{Group, Host};
+use crate::migration::error::MigrationResult;
+use crate::migration::report::{
+    DiagnosticCategory, FindingStatus, MigrationDiagnostic, MigrationFinding, MigrationReport,
+    MigrationSeverity,
+};
+
+/// The type of an xCAT object as determined from context or the
+/// `objtype` attribute.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum XcatObjectType {
+    /// A compute or management node.
+    Node,
+    /// A logical group of nodes.
+    Group,
+    /// A network definition.
+    Network,
+    /// An OS image definition.
+    Osimage,
+    /// A policy rule.
+    Policy,
+}
+
+impl XcatObjectType {
+    /// Try to parse an object type from a string value.
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "node" => Some(Self::Node),
+            "group" => Some(Self::Group),
+            "network" => Some(Self::Network),
+            "osimage" => Some(Self::Osimage),
+            "policy" => Some(Self::Policy),
+            _ => None,
+        }
+    }
+}
+
+/// A parsed xCAT object with its raw attributes.
+#[derive(Debug, Clone)]
+pub struct XcatObject {
+    /// Object name as reported by `lsdef`.
+    pub name: String,
+    /// Object type, if determinable.
+    pub object_type: Option<XcatObjectType>,
+    /// Raw key=value attributes.
+    pub attributes: HashMap<String, String>,
+}
+
+/// Result of importing a collection of xCAT objects.
+#[derive(Debug, Clone)]
+pub struct ObjectImportResult {
+    /// Successfully mapped hosts.
+    pub hosts: Vec<Host>,
+    /// Derived groups (from the `groups` attribute on nodes).
+    pub groups: Vec<Group>,
+    /// Migration report with diagnostics.
+    pub report: MigrationReport,
+}
+
+/// Importer that converts xCAT `lsdef` output into Rustible inventory.
+pub struct XcatObjectImporter {
+    /// Default object type to assume when `objtype` is not present.
+    default_type: Option<XcatObjectType>,
+}
+
+impl XcatObjectImporter {
+    /// Create a new importer with no default type assumption.
+    pub fn new() -> Self {
+        Self { default_type: None }
+    }
+
+    /// Create a new importer that assumes all objects are the given type
+    /// unless an explicit `objtype` attribute overrides it.
+    pub fn with_default_type(object_type: XcatObjectType) -> Self {
+        Self {
+            default_type: Some(object_type),
+        }
+    }
+
+    /// Parse raw `lsdef -l` output into a list of [`XcatObject`]s.
+    pub fn parse_lsdef(&self, input: &str) -> MigrationResult<Vec<XcatObject>> {
+        let mut objects = Vec::new();
+        let mut current_name: Option<String> = None;
+        let mut current_attrs: HashMap<String, String> = HashMap::new();
+
+        for line in input.lines() {
+            let trimmed = line.trim();
+
+            // Skip empty lines and comments
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+
+            // Object header: "Object name: <name>"
+            if let Some(rest) = trimmed.strip_prefix("Object name:") {
+                // Flush previous object
+                if let Some(name) = current_name.take() {
+                    let object_type = self.resolve_type(&current_attrs);
+                    objects.push(XcatObject {
+                        name,
+                        object_type,
+                        attributes: std::mem::take(&mut current_attrs),
+                    });
+                }
+                current_name = Some(rest.trim().to_string());
+                continue;
+            }
+
+            // Attribute line: "    key=value"
+            if let Some((key, value)) = trimmed.split_once('=') {
+                let key = key.trim().to_string();
+                let value = value.trim().to_string();
+                current_attrs.insert(key, value);
+            }
+        }
+
+        // Flush last object
+        if let Some(name) = current_name.take() {
+            let object_type = self.resolve_type(&current_attrs);
+            objects.push(XcatObject {
+                name,
+                object_type,
+                attributes: current_attrs,
+            });
+        }
+
+        Ok(objects)
+    }
+
+    /// Import parsed xCAT objects into Rustible inventory structures.
+    pub fn import(&self, objects: &[XcatObject]) -> ObjectImportResult {
+        let mut hosts = Vec::new();
+        let mut group_members: HashMap<String, HashSet<String>> = HashMap::new();
+        let mut report = MigrationReport::new("xCAT lsdef objects");
+        let mut finding_counter = 0usize;
+
+        for obj in objects {
+            let obj_type = obj
+                .object_type
+                .as_ref()
+                .or(self.default_type.as_ref());
+
+            match obj_type {
+                Some(XcatObjectType::Node) => {
+                    let host = self.map_node_to_host(obj);
+                    // Derive groups from the node's groups attribute
+                    if let Some(groups_str) = obj.attributes.get("groups") {
+                        for g in groups_str.split(',') {
+                            let g = g.trim();
+                            if !g.is_empty() {
+                                group_members
+                                    .entry(g.to_string())
+                                    .or_default()
+                                    .insert(obj.name.clone());
+                            }
+                        }
+                    }
+                    hosts.push(host);
+                }
+                Some(XcatObjectType::Group) => {
+                    // xCAT group objects define group-level attributes.
+                    // We track them so they appear in derived groups.
+                    if let Some(members) = obj.attributes.get("members") {
+                        for m in members.split(',') {
+                            let m = m.trim();
+                            if !m.is_empty() {
+                                group_members
+                                    .entry(obj.name.clone())
+                                    .or_default()
+                                    .insert(m.to_string());
+                            }
+                        }
+                    } else {
+                        // Ensure the group exists even without explicit members
+                        group_members.entry(obj.name.clone()).or_default();
+                    }
+                }
+                Some(other_type) => {
+                    finding_counter += 1;
+                    report.add_finding(MigrationFinding {
+                        id: format!("XCAT-{:04}", finding_counter),
+                        severity: MigrationSeverity::Warning,
+                        status: FindingStatus::Open,
+                        title: format!("Unsupported object type: {:?}", other_type),
+                        description: format!(
+                            "Object '{}' has type {:?} which is not mapped to inventory",
+                            obj.name, other_type
+                        ),
+                        category: DiagnosticCategory::Unsupported,
+                        diagnostics: vec![MigrationDiagnostic {
+                            severity: MigrationSeverity::Warning,
+                            category: DiagnosticCategory::Unsupported,
+                            message: format!(
+                                "Skipping {:?} object '{}'",
+                                other_type, obj.name
+                            ),
+                            source_object: Some(obj.name.clone()),
+                        }],
+                    });
+                }
+                None => {
+                    finding_counter += 1;
+                    report.add_finding(MigrationFinding {
+                        id: format!("XCAT-{:04}", finding_counter),
+                        severity: MigrationSeverity::Warning,
+                        status: FindingStatus::Open,
+                        title: "Unknown object type".into(),
+                        description: format!(
+                            "Object '{}' has no determinable type; skipping",
+                            obj.name
+                        ),
+                        category: DiagnosticCategory::Unsupported,
+                        diagnostics: vec![],
+                    });
+                }
+            }
+        }
+
+        // Build Group structs from collected membership data
+        let groups: Vec<Group> = group_members
+            .into_iter()
+            .map(|(name, members)| {
+                let mut group = Group::new(name);
+                for m in members {
+                    group.hosts.insert(m);
+                }
+                group
+            })
+            .collect();
+
+        ObjectImportResult {
+            hosts,
+            groups,
+            report,
+        }
+    }
+
+    /// Map a single xCAT node object to a Rustible [`Host`].
+    fn map_node_to_host(&self, obj: &XcatObject) -> Host {
+        let mut host = Host::new(&obj.name);
+
+        // Map ip -> ansible_host
+        if let Some(ip) = obj.attributes.get("ip") {
+            if !ip.is_empty() {
+                host.ansible_host = Some(ip.clone());
+            }
+        }
+
+        // Map groups -> host.groups
+        if let Some(groups_str) = obj.attributes.get("groups") {
+            for g in groups_str.split(',') {
+                let g = g.trim();
+                if !g.is_empty() {
+                    host.groups.insert(g.to_string());
+                }
+            }
+        }
+
+        // Map interesting xCAT attributes to host vars
+        let var_mappings = [
+            ("mac", "xcat_mac"),
+            ("bmc", "xcat_bmc"),
+            ("os", "xcat_os"),
+            ("arch", "xcat_arch"),
+            ("status", "xcat_status"),
+            ("serial", "xcat_serial"),
+            ("room", "xcat_room"),
+            ("rack", "xcat_rack"),
+            ("unit", "xcat_unit"),
+            ("height", "xcat_height"),
+            ("weight", "xcat_weight"),
+            ("cpucount", "xcat_cpucount"),
+            ("memory", "xcat_memory"),
+            ("disksize", "xcat_disksize"),
+        ];
+
+        for (xcat_key, var_key) in &var_mappings {
+            if let Some(value) = obj.attributes.get(*xcat_key) {
+                if !value.is_empty() {
+                    host.vars.insert(
+                        var_key.to_string(),
+                        serde_yaml::Value::String(value.clone()),
+                    );
+                }
+            }
+        }
+
+        host
+    }
+
+    /// Determine the object type from attributes or the default.
+    fn resolve_type(&self, attrs: &HashMap<String, String>) -> Option<XcatObjectType> {
+        if let Some(objtype) = attrs.get("objtype") {
+            XcatObjectType::from_str_opt(objtype)
+        } else {
+            self.default_type.clone()
+        }
+    }
+}
+
+impl Default for XcatObjectImporter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_LSDEF: &str = r#"
+Object name: node01
+    objtype=node
+    arch=x86_64
+    groups=compute,rack1
+    ip=10.0.0.101
+    mac=aa:bb:cc:dd:ee:01
+    bmc=10.0.1.101
+    os=rhels8.5
+    status=booted
+
+Object name: node02
+    objtype=node
+    arch=x86_64
+    groups=compute,rack2
+    ip=10.0.0.102
+    mac=aa:bb:cc:dd:ee:02
+    bmc=10.0.1.102
+    os=rhels8.5
+    status=booted
+"#;
+
+    #[test]
+    fn test_parse_lsdef_basic() {
+        let importer = XcatObjectImporter::new();
+        let objects = importer.parse_lsdef(SAMPLE_LSDEF).unwrap();
+        assert_eq!(objects.len(), 2);
+        assert_eq!(objects[0].name, "node01");
+        assert_eq!(objects[1].name, "node02");
+        assert_eq!(
+            objects[0].object_type,
+            Some(XcatObjectType::Node)
+        );
+    }
+
+    #[test]
+    fn test_parse_lsdef_attributes() {
+        let importer = XcatObjectImporter::new();
+        let objects = importer.parse_lsdef(SAMPLE_LSDEF).unwrap();
+        let node01 = &objects[0];
+        assert_eq!(node01.attributes.get("arch").map(|s| s.as_str()), Some("x86_64"));
+        assert_eq!(node01.attributes.get("ip").map(|s| s.as_str()), Some("10.0.0.101"));
+        assert_eq!(
+            node01.attributes.get("mac").map(|s| s.as_str()),
+            Some("aa:bb:cc:dd:ee:01")
+        );
+    }
+
+    #[test]
+    fn test_import_nodes_to_hosts() {
+        let importer = XcatObjectImporter::new();
+        let objects = importer.parse_lsdef(SAMPLE_LSDEF).unwrap();
+        let result = importer.import(&objects);
+
+        assert_eq!(result.hosts.len(), 2);
+
+        let host = &result.hosts[0];
+        assert_eq!(host.name, "node01");
+        assert_eq!(host.ansible_host.as_deref(), Some("10.0.0.101"));
+        assert!(host.groups.contains("compute"));
+        assert!(host.groups.contains("rack1"));
+
+        // Check vars mapping
+        assert_eq!(
+            host.vars.get("xcat_mac").and_then(|v| v.as_str()),
+            Some("aa:bb:cc:dd:ee:01")
+        );
+        assert_eq!(
+            host.vars.get("xcat_bmc").and_then(|v| v.as_str()),
+            Some("10.0.1.101")
+        );
+        assert_eq!(
+            host.vars.get("xcat_os").and_then(|v| v.as_str()),
+            Some("rhels8.5")
+        );
+        assert_eq!(
+            host.vars.get("xcat_arch").and_then(|v| v.as_str()),
+            Some("x86_64")
+        );
+    }
+
+    #[test]
+    fn test_import_derives_groups() {
+        let importer = XcatObjectImporter::new();
+        let objects = importer.parse_lsdef(SAMPLE_LSDEF).unwrap();
+        let result = importer.import(&objects);
+
+        // Groups derived: compute, rack1, rack2
+        let group_names: HashSet<String> =
+            result.groups.iter().map(|g| g.name.clone()).collect();
+        assert!(group_names.contains("compute"), "expected 'compute' group");
+        assert!(group_names.contains("rack1"), "expected 'rack1' group");
+        assert!(group_names.contains("rack2"), "expected 'rack2' group");
+
+        // compute group should contain both nodes
+        let compute = result.groups.iter().find(|g| g.name == "compute").unwrap();
+        assert!(compute.hosts.contains("node01"));
+        assert!(compute.hosts.contains("node02"));
+
+        // rack1 should contain only node01
+        let rack1 = result.groups.iter().find(|g| g.name == "rack1").unwrap();
+        assert!(rack1.hosts.contains("node01"));
+        assert!(!rack1.hosts.contains("node02"));
+    }
+
+    #[test]
+    fn test_import_unsupported_type_generates_warning() {
+        let input = r#"
+Object name: testnet
+    objtype=network
+    net=10.0.0.0
+    mask=255.255.255.0
+"#;
+        let importer = XcatObjectImporter::new();
+        let objects = importer.parse_lsdef(input).unwrap();
+        let result = importer.import(&objects);
+
+        assert!(result.hosts.is_empty());
+        assert!(!result.report.findings.is_empty());
+        assert_eq!(
+            result.report.findings[0].severity,
+            MigrationSeverity::Warning
+        );
+    }
+
+    #[test]
+    fn test_import_with_default_type() {
+        let input = r#"
+Object name: gpu01
+    arch=x86_64
+    ip=10.0.0.201
+    groups=gpu
+"#;
+        let importer = XcatObjectImporter::with_default_type(XcatObjectType::Node);
+        let objects = importer.parse_lsdef(input).unwrap();
+        let result = importer.import(&objects);
+
+        assert_eq!(result.hosts.len(), 1);
+        assert_eq!(result.hosts[0].name, "gpu01");
+        assert_eq!(result.hosts[0].ansible_host.as_deref(), Some("10.0.0.201"));
+    }
+
+    #[test]
+    fn test_import_group_object() {
+        let input = r#"
+Object name: compute
+    objtype=group
+    members=node01,node02,node03
+"#;
+        let importer = XcatObjectImporter::new();
+        let objects = importer.parse_lsdef(input).unwrap();
+        let result = importer.import(&objects);
+
+        assert!(result.hosts.is_empty());
+        assert_eq!(result.groups.len(), 1);
+        let group = &result.groups[0];
+        assert_eq!(group.name, "compute");
+        assert!(group.hosts.contains("node01"));
+        assert!(group.hosts.contains("node02"));
+        assert!(group.hosts.contains("node03"));
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let importer = XcatObjectImporter::new();
+        let objects = importer.parse_lsdef("").unwrap();
+        assert!(objects.is_empty());
+        let result = importer.import(&objects);
+        assert!(result.hosts.is_empty());
+        assert!(result.groups.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds xCAT object importer parsing `lsdef -l` output into Rustible inventory structures
- Maps xCAT nodes to hosts (ip->ansible_host, groups, mac/bmc/os/arch->vars) and derives groups
- Adds `migrate xcat-objects` CLI subcommand (requires `hpc` feature)

Closes #546

## Test plan
- [ ] `cargo build` and `cargo build --features hpc` pass
- [ ] Unit tests for lsdef parsing, node mapping, and group derivation pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)