### PR TITLE
feat(migration): add Warewulf profile import

### DIFF
--- a/src/cli/commands/migrate.rs
+++ b/src/cli/commands/migrate.rs
@@ -1,0 +1,116 @@
+//! Migrate command for importing configuration from external systems.
+//!
+//! Provides subcommands for importing node profiles and inventory data
+//! from HPC cluster management tools into Rustible.
+//!
+//! ## Usage
+//!
+//! ```bash
+//! # Show migration status / help
+//! rustible migrate status
+//!
+//! # Import Warewulf profiles (requires --features hpc)
+//! rustible migrate warewulf-profiles /etc/warewulf/nodes.conf
+//! ```
+
+use clap::{Parser, Subcommand};
+
+/// Arguments for the `migrate` command.
+#[derive(Parser, Debug, Clone)]
+pub struct MigrateArgs {
+    /// Migration subcommand.
+    #[command(subcommand)]
+    pub command: MigrateCommands,
+}
+
+/// Available migration subcommands.
+#[derive(Subcommand, Debug, Clone)]
+pub enum MigrateCommands {
+    /// Show migration framework status and available importers.
+    Status,
+
+    /// Import Warewulf 4 node profiles into Rustible inventory.
+    #[cfg(feature = "hpc")]
+    #[command(name = "warewulf-profiles")]
+    WarewulfProfiles {
+        /// Path to the Warewulf nodes YAML file (e.g. /etc/warewulf/nodes.conf).
+        path: std::path::PathBuf,
+    },
+}
+
+impl MigrateArgs {
+    /// Execute the migrate command.
+    pub async fn execute(
+        &self,
+        ctx: &mut super::CommandContext,
+    ) -> anyhow::Result<i32> {
+        match &self.command {
+            MigrateCommands::Status => {
+                ctx.output.banner("MIGRATION STATUS");
+                ctx.output.info("Available importers:");
+                #[cfg(feature = "hpc")]
+                ctx.output.info("  - warewulf-profiles: Import Warewulf 4 node profiles");
+                #[cfg(not(feature = "hpc"))]
+                ctx.output
+                    .info("  (enable --features hpc for Warewulf importers)");
+                Ok(0)
+            }
+            #[cfg(feature = "hpc")]
+            MigrateCommands::WarewulfProfiles { path } => {
+                ctx.output.banner("WAREWULF PROFILE IMPORT");
+                ctx.output
+                    .info(&format!("Importing from: {}", path.display()));
+
+                if !path.exists() {
+                    ctx.output
+                        .error(&format!("File not found: {}", path.display()));
+                    return Ok(1);
+                }
+
+                match rustible::migration::warewulf::WarewulfProfileImporter::import_from_yaml(path)
+                {
+                    Ok(result) => {
+                        ctx.output.section("Imported Hosts");
+                        for host in &result.hosts {
+                            let ip = host
+                                .ansible_host
+                                .as_deref()
+                                .unwrap_or("(no IP)");
+                            ctx.output.info(&format!(
+                                "  {} -> {} [groups: {}]",
+                                host.name,
+                                ip,
+                                host.groups.join(", ")
+                            ));
+                        }
+
+                        ctx.output.section("Imported Groups");
+                        for group in &result.groups {
+                            ctx.output.info(&format!(
+                                "  {} ({} hosts)",
+                                group.name,
+                                group.hosts.len()
+                            ));
+                        }
+
+                        ctx.output.section("Report");
+                        ctx.output.info(&format!("{}", result.report));
+
+                        if result.report.outcome
+                            == Some(rustible::migration::MigrationOutcome::Failed)
+                        {
+                            Ok(1)
+                        } else {
+                            Ok(0)
+                        }
+                    }
+                    Err(e) => {
+                        ctx.output
+                            .error(&format!("Migration failed: {}", e));
+                        Ok(1)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod fleet;
 pub mod galaxy;
 pub mod inventory;
 pub mod lock;
+pub mod migrate;
 pub mod provider;
 pub mod provision;
 pub mod provisioner;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -153,6 +153,10 @@ pub enum Commands {
     /// Show fleet infrastructure dashboard
     #[command(name = "fleet")]
     Fleet(commands::fleet::FleetArgs),
+
+    /// Migrate configuration from external systems (Warewulf, xCAT, etc.)
+    #[command(name = "migrate")]
+    Migrate(commands::migrate::MigrateArgs),
 }
 
 /// Arguments for agent command

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -883,6 +883,17 @@ pub mod native;
 /// state, secrets, and inventory between tenants in shared environments.
 pub mod tenant;
 
+// ============================================================================
+// Migration Framework
+// ============================================================================
+
+/// Migration framework for importing configuration from external systems.
+///
+/// Provides structured importers for HPC cluster management tools such as
+/// Warewulf and xCAT, mapping their node profiles and inventory data into
+/// Rustible's inventory format with full diagnostic reporting.
+pub mod migration;
+
 /// Agent mode for persistent target execution.
 ///
 /// This module provides an agent that can be deployed to target hosts for

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,7 @@ async fn main() -> Result<()> {
             1
         }
         Commands::Fleet(args) => args.execute(&mut ctx).await?,
+        Commands::Migrate(args) => args.execute(&mut ctx).await?,
     };
 
     std::process::exit(exit_code);

--- a/src/migration/error.rs
+++ b/src/migration/error.rs
@@ -1,0 +1,67 @@
+//! Migration error types.
+//!
+//! Standard error types for migration operations including parsing,
+//! validation, and I/O failures.
+
+use std::path::PathBuf;
+use thiserror::Error;
+
+/// Errors that can occur during migration operations.
+#[derive(Error, Debug)]
+pub enum MigrationError {
+    /// Failed to read a source file.
+    #[error("failed to read migration source '{path}': {message}")]
+    IoError {
+        /// Path to the file that could not be read.
+        path: PathBuf,
+        /// Human-readable description of the failure.
+        message: String,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Failed to parse input data (YAML, JSON, etc.).
+    #[error("failed to parse migration input: {message}")]
+    ParseError {
+        /// Human-readable description of the parse failure.
+        message: String,
+        /// Optional source path where the parse error occurred.
+        source_path: Option<PathBuf>,
+    },
+
+    /// A required field or value was missing from the source data.
+    #[error("missing required field '{field}' in {context}")]
+    MissingField {
+        /// Name of the missing field.
+        field: String,
+        /// Context where the field was expected (e.g. "node definition").
+        context: String,
+    },
+
+    /// A value failed validation constraints.
+    #[error("validation error: {message}")]
+    ValidationError {
+        /// Description of the validation failure.
+        message: String,
+    },
+
+    /// The migration source format is not supported.
+    #[error("unsupported migration source: {format}")]
+    UnsupportedFormat {
+        /// Name or description of the unsupported format.
+        format: String,
+    },
+
+    /// A mapping or transformation failed.
+    #[error("mapping error for '{entity}': {message}")]
+    MappingError {
+        /// The entity being mapped (e.g. "node compute-01").
+        entity: String,
+        /// Description of the mapping failure.
+        message: String,
+    },
+}
+
+/// Result type alias for migration operations.
+pub type MigrationResult<T> = std::result::Result<T, MigrationError>;

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -1,0 +1,23 @@
+//! Migration framework for importing configuration from external systems.
+//!
+//! This module provides a structured approach to migrating inventory, profiles,
+//! and configuration data from HPC cluster management tools (such as Warewulf
+//! and xCAT) into Rustible's inventory format.
+//!
+//! # Modules
+//!
+//! - [`error`] - Standard error types for migration operations.
+//! - [`report`] - Structured reporting with diagnostics, findings, and outcomes.
+//! - [`warewulf`] - Warewulf 4 profile and image import (requires `hpc` feature).
+
+pub mod error;
+pub mod report;
+
+#[cfg(feature = "hpc")]
+pub mod warewulf;
+
+pub use error::{MigrationError, MigrationResult};
+pub use report::{
+    DiagnosticCategory, FindingStatus, MigrationDiagnostic, MigrationFinding, MigrationOutcome,
+    MigrationReport, MigrationSeverity, ReportSummary,
+};

--- a/src/migration/report.rs
+++ b/src/migration/report.rs
@@ -1,0 +1,364 @@
+//! Migration report types.
+//!
+//! Structured reporting for migration operations, including diagnostics,
+//! findings, summaries, and overall outcome assessment.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Severity level for a migration diagnostic or finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MigrationSeverity {
+    /// Informational message; no action required.
+    Info,
+    /// A potential issue that may need attention.
+    Warning,
+    /// A problem that prevents correct migration of a specific item.
+    Error,
+}
+
+impl fmt::Display for MigrationSeverity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Info => write!(f, "info"),
+            Self::Warning => write!(f, "warning"),
+            Self::Error => write!(f, "error"),
+        }
+    }
+}
+
+/// Category of a diagnostic message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticCategory {
+    /// Related to data parsing or format issues.
+    Parsing,
+    /// Related to field mapping or transformation.
+    Mapping,
+    /// Related to validation of migrated data.
+    Validation,
+    /// Related to missing or incomplete data.
+    Completeness,
+    /// Related to compatibility between source and target.
+    Compatibility,
+}
+
+impl fmt::Display for DiagnosticCategory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Parsing => write!(f, "parsing"),
+            Self::Mapping => write!(f, "mapping"),
+            Self::Validation => write!(f, "validation"),
+            Self::Completeness => write!(f, "completeness"),
+            Self::Compatibility => write!(f, "compatibility"),
+        }
+    }
+}
+
+/// Status of a finding (whether it was resolved automatically or requires action).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FindingStatus {
+    /// The issue was resolved automatically during migration.
+    AutoResolved,
+    /// The issue requires manual intervention.
+    NeedsAction,
+    /// The issue was acknowledged but deferred.
+    Deferred,
+}
+
+impl fmt::Display for FindingStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AutoResolved => write!(f, "auto-resolved"),
+            Self::NeedsAction => write!(f, "needs-action"),
+            Self::Deferred => write!(f, "deferred"),
+        }
+    }
+}
+
+/// A single diagnostic message emitted during migration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MigrationDiagnostic {
+    /// Severity of this diagnostic.
+    pub severity: MigrationSeverity,
+    /// Category of this diagnostic.
+    pub category: DiagnosticCategory,
+    /// Human-readable message.
+    pub message: String,
+    /// Optional context (e.g. the entity that triggered the diagnostic).
+    pub context: Option<String>,
+}
+
+impl fmt::Display for MigrationDiagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}] {}: {}", self.severity, self.category, self.message)?;
+        if let Some(ctx) = &self.context {
+            write!(f, " ({})", ctx)?;
+        }
+        Ok(())
+    }
+}
+
+/// A migration finding that summarises an issue and its resolution status.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MigrationFinding {
+    /// Severity of this finding.
+    pub severity: MigrationSeverity,
+    /// Category of this finding.
+    pub category: DiagnosticCategory,
+    /// Resolution status.
+    pub status: FindingStatus,
+    /// Human-readable title.
+    pub title: String,
+    /// Detailed description.
+    pub description: String,
+    /// Optional recommendation for resolution.
+    pub recommendation: Option<String>,
+}
+
+impl fmt::Display for MigrationFinding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[{}] {} ({}): {}",
+            self.severity, self.title, self.status, self.description
+        )
+    }
+}
+
+/// Numeric summary of migration diagnostics.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ReportSummary {
+    /// Total number of entities processed.
+    pub total_entities: usize,
+    /// Number of entities successfully migrated.
+    pub successful: usize,
+    /// Number of entities with warnings.
+    pub with_warnings: usize,
+    /// Number of entities that failed to migrate.
+    pub failed: usize,
+    /// Count of info-level diagnostics.
+    pub info_count: usize,
+    /// Count of warning-level diagnostics.
+    pub warning_count: usize,
+    /// Count of error-level diagnostics.
+    pub error_count: usize,
+}
+
+/// Outcome of a migration operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MigrationOutcome {
+    /// All entities migrated successfully with no issues.
+    Success,
+    /// Migration completed but with warnings that should be reviewed.
+    PartialSuccess,
+    /// Migration completed but error rate exceeds the acceptable threshold.
+    Degraded,
+    /// Migration failed entirely.
+    Failed,
+}
+
+impl fmt::Display for MigrationOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Success => write!(f, "success"),
+            Self::PartialSuccess => write!(f, "partial-success"),
+            Self::Degraded => write!(f, "degraded"),
+            Self::Failed => write!(f, "failed"),
+        }
+    }
+}
+
+/// Full migration report containing diagnostics, findings, summary, and outcome.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MigrationReport {
+    /// Source system description (e.g. "Warewulf 4 profiles").
+    pub source: String,
+    /// Diagnostics emitted during migration.
+    pub diagnostics: Vec<MigrationDiagnostic>,
+    /// High-level findings.
+    pub findings: Vec<MigrationFinding>,
+    /// Computed summary (populated by `compute_summary`).
+    pub summary: Option<ReportSummary>,
+    /// Overall outcome (populated by `compute_outcome`).
+    pub outcome: Option<MigrationOutcome>,
+}
+
+impl MigrationReport {
+    /// Create a new empty report for the given source system.
+    pub fn new(source: impl Into<String>) -> Self {
+        Self {
+            source: source.into(),
+            diagnostics: Vec::new(),
+            findings: Vec::new(),
+            summary: None,
+            outcome: None,
+        }
+    }
+
+    /// Add a finding to the report.
+    pub fn add_finding(&mut self, finding: MigrationFinding) {
+        self.findings.push(finding);
+    }
+
+    /// Add a diagnostic to the report.
+    pub fn add_diagnostic(&mut self, diagnostic: MigrationDiagnostic) {
+        self.diagnostics.push(diagnostic);
+    }
+
+    /// Compute the summary from the current diagnostics and findings.
+    ///
+    /// `total_entities` is the total number of entities that were processed.
+    /// `successful` is the count of entities that migrated without errors.
+    pub fn compute_summary(&mut self, total_entities: usize, successful: usize) {
+        let info_count = self
+            .diagnostics
+            .iter()
+            .filter(|d| d.severity == MigrationSeverity::Info)
+            .count();
+        let warning_count = self
+            .diagnostics
+            .iter()
+            .filter(|d| d.severity == MigrationSeverity::Warning)
+            .count();
+        let error_count = self
+            .diagnostics
+            .iter()
+            .filter(|d| d.severity == MigrationSeverity::Error)
+            .count();
+
+        let failed = total_entities.saturating_sub(successful);
+        let with_warnings = self
+            .findings
+            .iter()
+            .filter(|f| f.severity == MigrationSeverity::Warning)
+            .count();
+
+        self.summary = Some(ReportSummary {
+            total_entities,
+            successful,
+            with_warnings,
+            failed,
+            info_count,
+            warning_count,
+            error_count,
+        });
+    }
+
+    /// Compute the overall outcome based on the summary.
+    ///
+    /// `threshold` is the maximum acceptable error ratio (0.0..=1.0).
+    /// For example, `0.1` means up to 10% errors are tolerated as partial success.
+    pub fn compute_outcome(&mut self, threshold: f64) -> MigrationOutcome {
+        let summary = self.summary.clone().unwrap_or_default();
+
+        let outcome = if summary.total_entities == 0 {
+            MigrationOutcome::Success
+        } else if summary.failed == 0 && summary.warning_count == 0 {
+            MigrationOutcome::Success
+        } else if summary.failed == 0 {
+            MigrationOutcome::PartialSuccess
+        } else {
+            let error_ratio = summary.failed as f64 / summary.total_entities as f64;
+            if error_ratio <= threshold {
+                MigrationOutcome::PartialSuccess
+            } else if summary.successful > 0 {
+                MigrationOutcome::Degraded
+            } else {
+                MigrationOutcome::Failed
+            }
+        };
+
+        self.outcome = Some(outcome);
+        outcome
+    }
+}
+
+impl fmt::Display for MigrationReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Migration Report: {}", self.source)?;
+        writeln!(f, "{}", "=".repeat(60))?;
+
+        if let Some(ref summary) = self.summary {
+            writeln!(f, "Entities: {} total, {} successful, {} failed",
+                summary.total_entities, summary.successful, summary.failed)?;
+            writeln!(f, "Diagnostics: {} info, {} warnings, {} errors",
+                summary.info_count, summary.warning_count, summary.error_count)?;
+        }
+
+        if let Some(outcome) = self.outcome {
+            writeln!(f, "Outcome: {}", outcome)?;
+        }
+
+        if !self.findings.is_empty() {
+            writeln!(f, "\nFindings:")?;
+            for finding in &self.findings {
+                writeln!(f, "  - {}", finding)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_report_empty_is_success() {
+        let mut report = MigrationReport::new("test");
+        report.compute_summary(0, 0);
+        let outcome = report.compute_outcome(0.1);
+        assert_eq!(outcome, MigrationOutcome::Success);
+    }
+
+    #[test]
+    fn test_report_all_successful() {
+        let mut report = MigrationReport::new("test");
+        report.compute_summary(5, 5);
+        let outcome = report.compute_outcome(0.1);
+        assert_eq!(outcome, MigrationOutcome::Success);
+    }
+
+    #[test]
+    fn test_report_with_warnings_is_partial() {
+        let mut report = MigrationReport::new("test");
+        report.add_diagnostic(MigrationDiagnostic {
+            severity: MigrationSeverity::Warning,
+            category: DiagnosticCategory::Mapping,
+            message: "unmapped field".to_string(),
+            context: None,
+        });
+        report.compute_summary(5, 5);
+        let outcome = report.compute_outcome(0.1);
+        assert_eq!(outcome, MigrationOutcome::PartialSuccess);
+    }
+
+    #[test]
+    fn test_report_with_failures_under_threshold() {
+        let mut report = MigrationReport::new("test");
+        report.compute_summary(10, 9);
+        let outcome = report.compute_outcome(0.15);
+        assert_eq!(outcome, MigrationOutcome::PartialSuccess);
+    }
+
+    #[test]
+    fn test_report_with_failures_over_threshold() {
+        let mut report = MigrationReport::new("test");
+        report.compute_summary(10, 5);
+        let outcome = report.compute_outcome(0.1);
+        assert_eq!(outcome, MigrationOutcome::Degraded);
+    }
+
+    #[test]
+    fn test_report_all_failed() {
+        let mut report = MigrationReport::new("test");
+        report.compute_summary(10, 0);
+        let outcome = report.compute_outcome(0.1);
+        assert_eq!(outcome, MigrationOutcome::Failed);
+    }
+}

--- a/src/migration/warewulf/mod.rs
+++ b/src/migration/warewulf/mod.rs
@@ -1,0 +1,11 @@
+//! Warewulf 4 migration support.
+//!
+//! This module provides importers for Warewulf 4 node profiles, mapping them
+//! to Rustible inventory hosts and groups.
+
+pub mod profile;
+
+pub use profile::{
+    ImportedGroup, ImportedHost, ProfileImportResult, WarewulfIpmi, WarewulfKernel,
+    WarewulfNetDev, WarewulfNode, WarewulfProfileImporter,
+};

--- a/src/migration/warewulf/profile.rs
+++ b/src/migration/warewulf/profile.rs
@@ -1,0 +1,624 @@
+//! Warewulf 4 profile importer.
+//!
+//! Parses Warewulf `nodes.conf` / `wwctl node list -y` YAML exports and maps
+//! them into Rustible inventory hosts and groups.
+//!
+//! # Mapping Rules
+//!
+//! | Warewulf field            | Rustible equivalent              |
+//! |---------------------------|----------------------------------|
+//! | Node id / name            | Host `name`                      |
+//! | `net_devs[0].ipaddr`      | `ansible_host` variable          |
+//! | `profiles`                | Group membership                 |
+//! | `tags`                    | Host variables                   |
+//! | `container`               | `warewulf_container` host var    |
+//! | `kernel.version`          | `warewulf_kernel_version` var    |
+//! | `kernel.args`             | `warewulf_kernel_args` var       |
+//! | `ipmi.*`                  | `ipmi_*` host variables          |
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::migration::error::{MigrationError, MigrationResult};
+use crate::migration::report::{
+    DiagnosticCategory, FindingStatus, MigrationDiagnostic, MigrationFinding, MigrationReport,
+    MigrationSeverity,
+};
+
+// ---------------------------------------------------------------------------
+// Warewulf data model
+// ---------------------------------------------------------------------------
+
+/// A single Warewulf node as represented in `nodes.conf` YAML.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WarewulfNode {
+    /// Node identifier (the YAML mapping key).
+    #[serde(default)]
+    pub id: String,
+
+    /// Optional human-readable hostname override.
+    /// When absent the `id` is used as the hostname.
+    #[serde(default)]
+    pub name: Option<String>,
+
+    /// Profiles assigned to this node (used as group membership).
+    #[serde(default)]
+    pub profiles: Vec<String>,
+
+    /// Network devices configured on the node.
+    #[serde(default, alias = "network devices")]
+    pub net_devs: Vec<WarewulfNetDev>,
+
+    /// Kernel configuration.
+    #[serde(default)]
+    pub kernel: Option<WarewulfKernel>,
+
+    /// Container / VNFS image name.
+    #[serde(default)]
+    pub container: Option<String>,
+
+    /// IPMI / BMC configuration.
+    #[serde(default)]
+    pub ipmi: Option<WarewulfIpmi>,
+
+    /// Arbitrary key-value tags.
+    #[serde(default)]
+    pub tags: HashMap<String, String>,
+}
+
+/// A network device definition from Warewulf.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WarewulfNetDev {
+    /// Interface name (e.g. `eth0`).
+    #[serde(default)]
+    pub device: Option<String>,
+
+    /// IPv4 address.
+    #[serde(default, alias = "ipaddr")]
+    pub ipaddr: Option<String>,
+
+    /// Network mask.
+    #[serde(default)]
+    pub netmask: Option<String>,
+
+    /// Hardware (MAC) address.
+    #[serde(default)]
+    pub hwaddr: Option<String>,
+
+    /// Default gateway.
+    #[serde(default)]
+    pub gateway: Option<String>,
+}
+
+/// Kernel settings from Warewulf.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WarewulfKernel {
+    /// Kernel version string.
+    #[serde(default)]
+    pub version: Option<String>,
+
+    /// Kernel boot arguments.
+    #[serde(default)]
+    pub args: Option<String>,
+}
+
+/// IPMI / BMC settings from Warewulf.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WarewulfIpmi {
+    /// IPMI IP address.
+    #[serde(default, alias = "ipaddr")]
+    pub ipaddr: Option<String>,
+
+    /// IPMI username.
+    #[serde(default)]
+    pub username: Option<String>,
+
+    /// IPMI interface type (e.g. `lanplus`).
+    #[serde(default)]
+    pub interface: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Import result types
+// ---------------------------------------------------------------------------
+
+/// A host imported from Warewulf into Rustible inventory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportedHost {
+    /// Hostname (derived from Warewulf node id/name).
+    pub name: String,
+
+    /// The `ansible_host` value (typically the primary IP address).
+    pub ansible_host: Option<String>,
+
+    /// Groups this host belongs to (derived from Warewulf profiles).
+    pub groups: Vec<String>,
+
+    /// Host variables merged from tags, kernel, container, and IPMI fields.
+    pub vars: HashMap<String, serde_yaml::Value>,
+}
+
+/// A group imported from Warewulf profile names.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportedGroup {
+    /// Group name (derived from a Warewulf profile name).
+    pub name: String,
+
+    /// Hostnames belonging to this group.
+    pub hosts: Vec<String>,
+
+    /// Group-level variables (currently empty; can be populated later).
+    pub vars: HashMap<String, serde_yaml::Value>,
+}
+
+/// Result of a Warewulf profile import operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileImportResult {
+    /// Imported hosts.
+    pub hosts: Vec<ImportedHost>,
+
+    /// Imported groups.
+    pub groups: Vec<ImportedGroup>,
+
+    /// Migration report with diagnostics and findings.
+    pub report: MigrationReport,
+}
+
+// ---------------------------------------------------------------------------
+// Importer
+// ---------------------------------------------------------------------------
+
+/// Importer for Warewulf 4 node/profile YAML data.
+///
+/// # Example YAML input
+///
+/// ```yaml
+/// noderange:
+///   compute-01:
+///     profiles:
+///       - default
+///       - compute
+///     net_devs:
+///       - device: eth0
+///         ipaddr: 10.0.0.101
+///         netmask: 255.255.255.0
+///     kernel:
+///       version: 5.14.0-284.el9.x86_64
+///     container: rocky-9
+///     tags:
+///       rack: A01
+///       role: compute
+/// ```
+pub struct WarewulfProfileImporter;
+
+impl WarewulfProfileImporter {
+    /// Import Warewulf nodes from a YAML file on disk.
+    ///
+    /// The YAML is expected to be either:
+    /// - A top-level mapping of `node_id -> WarewulfNode`, or
+    /// - A mapping with a `noderange` key containing the node mapping.
+    pub fn import_from_yaml(path: &Path) -> MigrationResult<ProfileImportResult> {
+        let content = std::fs::read_to_string(path).map_err(|e| MigrationError::IoError {
+            path: path.to_path_buf(),
+            message: "could not read Warewulf YAML file".to_string(),
+            source: e,
+        })?;
+
+        Self::import_from_str(&content)
+    }
+
+    /// Import Warewulf nodes from a YAML string.
+    pub fn import_from_str(yaml: &str) -> MigrationResult<ProfileImportResult> {
+        let raw: serde_yaml::Value =
+            serde_yaml::from_str(yaml).map_err(|e| MigrationError::ParseError {
+                message: format!("invalid YAML: {}", e),
+                source_path: None,
+            })?;
+
+        // Support both top-level mapping and `noderange:` wrapper.
+        let nodes_mapping = if let Some(mapping) = raw.as_mapping() {
+            if let Some(noderange) = mapping.get(&serde_yaml::Value::String("noderange".into())) {
+                noderange
+                    .as_mapping()
+                    .ok_or_else(|| MigrationError::ParseError {
+                        message: "'noderange' must be a mapping".to_string(),
+                        source_path: None,
+                    })?
+                    .clone()
+            } else {
+                mapping.clone()
+            }
+        } else {
+            return Err(MigrationError::ParseError {
+                message: "expected a YAML mapping at the top level".to_string(),
+                source_path: None,
+            });
+        };
+
+        let mut report = MigrationReport::new("Warewulf 4 profiles");
+        let mut hosts: Vec<ImportedHost> = Vec::new();
+        let mut group_map: HashMap<String, Vec<String>> = HashMap::new();
+        let mut successful = 0usize;
+
+        for (key, value) in &nodes_mapping {
+            let node_id = match key.as_str() {
+                Some(id) => id.to_string(),
+                None => {
+                    report.add_diagnostic(MigrationDiagnostic {
+                        severity: MigrationSeverity::Warning,
+                        category: DiagnosticCategory::Parsing,
+                        message: "skipping non-string node key".to_string(),
+                        context: None,
+                    });
+                    continue;
+                }
+            };
+
+            // Skip metadata keys that are not nodes.
+            if node_id == "noderange" || node_id == "warewulf" {
+                continue;
+            }
+
+            match serde_yaml::from_value::<WarewulfNode>(value.clone()) {
+                Ok(mut node) => {
+                    node.id = node_id.clone();
+                    match Self::map_node(&node, &mut report) {
+                        Some(host) => {
+                            // Register host into its profile groups.
+                            for group in &host.groups {
+                                group_map
+                                    .entry(group.clone())
+                                    .or_default()
+                                    .push(host.name.clone());
+                            }
+                            hosts.push(host);
+                            successful += 1;
+                        }
+                        None => {
+                            report.add_diagnostic(MigrationDiagnostic {
+                                severity: MigrationSeverity::Error,
+                                category: DiagnosticCategory::Mapping,
+                                message: format!("failed to map node '{}'", node_id),
+                                context: Some(node_id),
+                            });
+                        }
+                    }
+                }
+                Err(e) => {
+                    report.add_diagnostic(MigrationDiagnostic {
+                        severity: MigrationSeverity::Error,
+                        category: DiagnosticCategory::Parsing,
+                        message: format!("failed to parse node '{}': {}", node_id, e),
+                        context: Some(node_id),
+                    });
+                }
+            }
+        }
+
+        // Build groups from the accumulated map.
+        let groups: Vec<ImportedGroup> = group_map
+            .into_iter()
+            .map(|(name, members)| ImportedGroup {
+                name,
+                hosts: members,
+                vars: HashMap::new(),
+            })
+            .collect();
+
+        let total = hosts.len() + report
+            .diagnostics
+            .iter()
+            .filter(|d| d.severity == MigrationSeverity::Error)
+            .count();
+
+        report.compute_summary(total, successful);
+        report.compute_outcome(0.1);
+
+        Ok(ProfileImportResult {
+            hosts,
+            groups,
+            report,
+        })
+    }
+
+    /// Map a single `WarewulfNode` to an `ImportedHost`.
+    ///
+    /// Returns `None` if the node cannot be meaningfully mapped.
+    fn map_node(node: &WarewulfNode, report: &mut MigrationReport) -> Option<ImportedHost> {
+        let hostname = node
+            .name
+            .as_deref()
+            .unwrap_or(&node.id)
+            .to_string();
+
+        if hostname.is_empty() {
+            return None;
+        }
+
+        let mut vars: HashMap<String, serde_yaml::Value> = HashMap::new();
+
+        // Map primary IP from first network device.
+        let ansible_host = node
+            .net_devs
+            .first()
+            .and_then(|nd| nd.ipaddr.clone());
+
+        if ansible_host.is_none() {
+            report.add_diagnostic(MigrationDiagnostic {
+                severity: MigrationSeverity::Warning,
+                category: DiagnosticCategory::Completeness,
+                message: format!(
+                    "node '{}' has no network device IP; ansible_host will be unset",
+                    hostname
+                ),
+                context: Some(hostname.clone()),
+            });
+        }
+
+        // Map tags to host vars.
+        for (k, v) in &node.tags {
+            vars.insert(k.clone(), serde_yaml::Value::String(v.clone()));
+        }
+
+        // Map container.
+        if let Some(ref container) = node.container {
+            vars.insert(
+                "warewulf_container".to_string(),
+                serde_yaml::Value::String(container.clone()),
+            );
+        }
+
+        // Map kernel settings.
+        if let Some(ref kernel) = node.kernel {
+            if let Some(ref ver) = kernel.version {
+                vars.insert(
+                    "warewulf_kernel_version".to_string(),
+                    serde_yaml::Value::String(ver.clone()),
+                );
+            }
+            if let Some(ref args) = kernel.args {
+                vars.insert(
+                    "warewulf_kernel_args".to_string(),
+                    serde_yaml::Value::String(args.clone()),
+                );
+            }
+        }
+
+        // Map IPMI settings.
+        if let Some(ref ipmi) = node.ipmi {
+            if let Some(ref ip) = ipmi.ipaddr {
+                vars.insert(
+                    "ipmi_address".to_string(),
+                    serde_yaml::Value::String(ip.clone()),
+                );
+            }
+            if let Some(ref user) = ipmi.username {
+                vars.insert(
+                    "ipmi_username".to_string(),
+                    serde_yaml::Value::String(user.clone()),
+                );
+            }
+            if let Some(ref iface) = ipmi.interface {
+                vars.insert(
+                    "ipmi_interface".to_string(),
+                    serde_yaml::Value::String(iface.clone()),
+                );
+            }
+        }
+
+        // Map network device metadata beyond the primary IP.
+        for (i, nd) in node.net_devs.iter().enumerate() {
+            if let Some(ref dev) = nd.device {
+                vars.insert(
+                    format!("warewulf_netdev_{}_device", i),
+                    serde_yaml::Value::String(dev.clone()),
+                );
+            }
+            if let Some(ref mask) = nd.netmask {
+                vars.insert(
+                    format!("warewulf_netdev_{}_netmask", i),
+                    serde_yaml::Value::String(mask.clone()),
+                );
+            }
+            if let Some(ref mac) = nd.hwaddr {
+                vars.insert(
+                    format!("warewulf_netdev_{}_hwaddr", i),
+                    serde_yaml::Value::String(mac.clone()),
+                );
+            }
+            if let Some(ref gw) = nd.gateway {
+                vars.insert(
+                    format!("warewulf_netdev_{}_gateway", i),
+                    serde_yaml::Value::String(gw.clone()),
+                );
+            }
+        }
+
+        // Emit a finding if the node has no profiles.
+        if node.profiles.is_empty() {
+            report.add_finding(MigrationFinding {
+                severity: MigrationSeverity::Info,
+                category: DiagnosticCategory::Completeness,
+                status: FindingStatus::AutoResolved,
+                title: format!("node '{}' has no profiles", hostname),
+                description: "Node will not be assigned to any group".to_string(),
+                recommendation: Some(
+                    "Consider assigning at least one profile/group for organisation".to_string(),
+                ),
+            });
+        }
+
+        Some(ImportedHost {
+            name: hostname,
+            ansible_host,
+            groups: node.profiles.clone(),
+            vars,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migration::report::MigrationOutcome;
+
+    #[test]
+    fn test_import_basic_nodes() {
+        let yaml = r#"
+compute-01:
+  profiles:
+    - default
+    - compute
+  net_devs:
+    - device: eth0
+      ipaddr: "10.0.0.101"
+      netmask: "255.255.255.0"
+      hwaddr: "00:11:22:33:44:55"
+  kernel:
+    version: "5.14.0-284.el9.x86_64"
+    args: "quiet"
+  container: rocky-9
+  tags:
+    rack: A01
+    role: compute
+compute-02:
+  profiles:
+    - default
+    - compute
+  net_devs:
+    - device: eth0
+      ipaddr: "10.0.0.102"
+      netmask: "255.255.255.0"
+  container: rocky-9
+"#;
+
+        let result = WarewulfProfileImporter::import_from_str(yaml).unwrap();
+        assert_eq!(result.hosts.len(), 2);
+
+        let host1 = result.hosts.iter().find(|h| h.name == "compute-01").unwrap();
+        assert_eq!(host1.ansible_host.as_deref(), Some("10.0.0.101"));
+        assert_eq!(host1.groups, vec!["default", "compute"]);
+        assert_eq!(
+            host1.vars.get("warewulf_container"),
+            Some(&serde_yaml::Value::String("rocky-9".to_string()))
+        );
+        assert_eq!(
+            host1.vars.get("warewulf_kernel_version"),
+            Some(&serde_yaml::Value::String(
+                "5.14.0-284.el9.x86_64".to_string()
+            ))
+        );
+        assert_eq!(
+            host1.vars.get("rack"),
+            Some(&serde_yaml::Value::String("A01".to_string()))
+        );
+
+        // Check groups were created.
+        let compute_group = result.groups.iter().find(|g| g.name == "compute").unwrap();
+        assert_eq!(compute_group.hosts.len(), 2);
+        assert!(compute_group.hosts.contains(&"compute-01".to_string()));
+        assert!(compute_group.hosts.contains(&"compute-02".to_string()));
+
+        // Report should show success.
+        assert_eq!(
+            result.report.outcome,
+            Some(MigrationOutcome::Success)
+        );
+    }
+
+    #[test]
+    fn test_import_noderange_wrapper() {
+        let yaml = r#"
+noderange:
+  gpu-node-01:
+    profiles:
+      - gpu
+    net_devs:
+      - device: ib0
+        ipaddr: "10.10.0.1"
+    ipmi:
+      ipaddr: "192.168.1.101"
+      username: admin
+      interface: lanplus
+"#;
+
+        let result = WarewulfProfileImporter::import_from_str(yaml).unwrap();
+        assert_eq!(result.hosts.len(), 1);
+
+        let host = &result.hosts[0];
+        assert_eq!(host.name, "gpu-node-01");
+        assert_eq!(host.ansible_host.as_deref(), Some("10.10.0.1"));
+        assert_eq!(host.groups, vec!["gpu"]);
+        assert_eq!(
+            host.vars.get("ipmi_address"),
+            Some(&serde_yaml::Value::String("192.168.1.101".to_string()))
+        );
+        assert_eq!(
+            host.vars.get("ipmi_username"),
+            Some(&serde_yaml::Value::String("admin".to_string()))
+        );
+        assert_eq!(
+            host.vars.get("ipmi_interface"),
+            Some(&serde_yaml::Value::String("lanplus".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_import_node_without_ip_emits_warning() {
+        let yaml = r#"
+bare-node:
+  profiles:
+    - default
+  net_devs: []
+  tags:
+    location: lab
+"#;
+
+        let result = WarewulfProfileImporter::import_from_str(yaml).unwrap();
+        assert_eq!(result.hosts.len(), 1);
+        assert!(result.hosts[0].ansible_host.is_none());
+
+        // Should have a warning diagnostic about missing IP.
+        let warnings: Vec<_> = result
+            .report
+            .diagnostics
+            .iter()
+            .filter(|d| d.severity == MigrationSeverity::Warning)
+            .collect();
+        assert!(
+            !warnings.is_empty(),
+            "expected a warning about missing network device IP"
+        );
+    }
+
+    #[test]
+    fn test_import_invalid_yaml_returns_error() {
+        let yaml = "not: valid: yaml: [broken";
+        let result = WarewulfProfileImporter::import_from_str(yaml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_import_node_without_profiles_emits_finding() {
+        let yaml = r#"
+lonely-node:
+  net_devs:
+    - ipaddr: "10.0.0.50"
+"#;
+
+        let result = WarewulfProfileImporter::import_from_str(yaml).unwrap();
+        assert_eq!(result.hosts.len(), 1);
+        assert!(result.hosts[0].groups.is_empty());
+
+        // Should have a finding about no profiles.
+        let findings: Vec<_> = result
+            .report
+            .findings
+            .iter()
+            .filter(|f| f.title.contains("no profiles"))
+            .collect();
+        assert!(!findings.is_empty(), "expected finding about missing profiles");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Warewulf profile/node importer mapping nodes to hosts and profiles to groups
- Maps NetDevs->ansible_host, Tags->host vars, Kernel/Container/IPMI->prefixed vars
- Adds `migrate warewulf-profiles` CLI subcommand (requires `hpc` feature)

Closes #544

## Test plan
- [ ] `cargo build` and `cargo build --features hpc` pass
- [ ] Unit tests for multi-node import, missing IP handling, and profile mapping pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)