### PR TITLE
feat(audit): add immutable audit log pipeline with hash chain

### DIFF
--- a/src/audit/hashchain.rs
+++ b/src/audit/hashchain.rs
@@ -1,0 +1,195 @@
+//! Hash chain for immutable audit log integrity
+//!
+//! This module implements a cryptographic hash chain using BLAKE3 to ensure
+//! that audit log entries cannot be tampered with. Each entry includes a hash
+//! of the previous entry, forming an immutable chain.
+
+use serde::{Deserialize, Serialize};
+
+/// A single entry in the hash chain.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HashChainEntry {
+    /// Monotonically increasing sequence number
+    pub sequence: u64,
+    /// ISO 8601 timestamp of when the entry was created
+    pub timestamp: String,
+    /// BLAKE3 hash of the event data
+    pub event_hash: String,
+    /// Hash of the previous chain entry (empty string for genesis)
+    pub previous_hash: String,
+    /// Combined chain hash: H(sequence || event_hash || previous_hash)
+    pub chain_hash: String,
+}
+
+/// Internal state for building a hash chain incrementally.
+#[derive(Debug, Clone)]
+pub struct HashChainState {
+    /// Next sequence number to assign
+    next_sequence: u64,
+    /// Chain hash of the most recent entry
+    last_hash: String,
+}
+
+impl HashChainState {
+    /// Create a new hash chain starting from the genesis state.
+    pub fn new() -> Self {
+        Self {
+            next_sequence: 0,
+            last_hash: String::new(),
+        }
+    }
+
+    /// Resume a chain from a known state (e.g. after reading an existing log).
+    pub fn resume(next_sequence: u64, last_hash: String) -> Self {
+        Self {
+            next_sequence,
+            last_hash,
+        }
+    }
+
+    /// Append new event data and return the resulting chain entry.
+    ///
+    /// The chain hash is computed as `BLAKE3(sequence || event_hash || previous_hash)`.
+    pub fn append(&mut self, event_data: &[u8]) -> HashChainEntry {
+        let event_hash = blake3::hash(event_data).to_hex().to_string();
+        let previous_hash = self.last_hash.clone();
+
+        let mut chain_input = Vec::new();
+        chain_input.extend_from_slice(&self.next_sequence.to_le_bytes());
+        chain_input.extend_from_slice(event_hash.as_bytes());
+        chain_input.extend_from_slice(previous_hash.as_bytes());
+        let chain_hash = blake3::hash(&chain_input).to_hex().to_string();
+
+        let timestamp = chrono::Utc::now().to_rfc3339();
+
+        let entry = HashChainEntry {
+            sequence: self.next_sequence,
+            timestamp,
+            event_hash,
+            previous_hash,
+            chain_hash: chain_hash.clone(),
+        };
+
+        self.next_sequence += 1;
+        self.last_hash = chain_hash;
+
+        entry
+    }
+
+    /// Verify that a slice of entries forms a valid chain.
+    ///
+    /// Checks that:
+    /// 1. Sequence numbers are contiguous starting from `entries[0].sequence`.
+    /// 2. Each entry's `previous_hash` matches the preceding entry's `chain_hash`.
+    /// 3. Each entry's `chain_hash` is correctly computed.
+    pub fn verify_chain(entries: &[HashChainEntry]) -> bool {
+        if entries.is_empty() {
+            return true;
+        }
+
+        for (i, entry) in entries.iter().enumerate() {
+            // Verify sequence continuity
+            if entry.sequence != entries[0].sequence + i as u64 {
+                return false;
+            }
+
+            // Verify previous_hash linkage
+            if i == 0 {
+                // Genesis or first entry in the slice -- we cannot verify
+                // backwards further, so we just check the chain_hash.
+            } else {
+                let prev = &entries[i - 1];
+                if entry.previous_hash != prev.chain_hash {
+                    return false;
+                }
+            }
+
+            // Recompute chain_hash
+            let mut chain_input = Vec::new();
+            chain_input.extend_from_slice(&entry.sequence.to_le_bytes());
+            chain_input.extend_from_slice(entry.event_hash.as_bytes());
+            chain_input.extend_from_slice(entry.previous_hash.as_bytes());
+            let expected = blake3::hash(&chain_input).to_hex().to_string();
+
+            if entry.chain_hash != expected {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    /// Get the current sequence number (next to be assigned).
+    pub fn next_sequence(&self) -> u64 {
+        self.next_sequence
+    }
+
+    /// Get the hash of the last entry in the chain.
+    pub fn last_hash(&self) -> &str {
+        &self.last_hash
+    }
+}
+
+impl Default for HashChainState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_append_and_verify() {
+        let mut chain = HashChainState::new();
+
+        let e0 = chain.append(b"event-zero");
+        assert_eq!(e0.sequence, 0);
+        assert!(e0.previous_hash.is_empty());
+
+        let e1 = chain.append(b"event-one");
+        assert_eq!(e1.sequence, 1);
+        assert_eq!(e1.previous_hash, e0.chain_hash);
+
+        let e2 = chain.append(b"event-two");
+        assert_eq!(e2.sequence, 2);
+        assert_eq!(e2.previous_hash, e1.chain_hash);
+
+        assert!(HashChainState::verify_chain(&[e0, e1, e2]));
+    }
+
+    #[test]
+    fn test_tampered_entry_detected() {
+        let mut chain = HashChainState::new();
+        let e0 = chain.append(b"first");
+        let e1 = chain.append(b"second");
+        let e2 = chain.append(b"third");
+
+        // Tamper with the middle entry
+        let mut tampered = e1.clone();
+        tampered.event_hash = "deadbeef".to_string();
+
+        assert!(!HashChainState::verify_chain(&[e0, tampered, e2]));
+    }
+
+    #[test]
+    fn test_empty_chain_is_valid() {
+        assert!(HashChainState::verify_chain(&[]));
+    }
+
+    #[test]
+    fn test_resume_continues_chain() {
+        let mut chain = HashChainState::new();
+        let e0 = chain.append(b"alpha");
+        let e1 = chain.append(b"beta");
+
+        // Resume from the state after e1
+        let mut resumed = HashChainState::resume(chain.next_sequence(), chain.last_hash().to_string());
+        let e2 = resumed.append(b"gamma");
+
+        assert_eq!(e2.sequence, 2);
+        assert_eq!(e2.previous_hash, e1.chain_hash);
+        assert!(HashChainState::verify_chain(&[e0, e1, e2]));
+    }
+}

--- a/src/audit/immutable.rs
+++ b/src/audit/immutable.rs
@@ -1,0 +1,216 @@
+//! Immutable audit storage with hash-chain integrity
+//!
+//! This module provides an append-only audit store that combines hash-chain
+//! verification with persistent storage. The `AuditStorage` trait abstracts
+//! the storage backend, and `FileAuditStorage` provides a JSON-lines file
+//! implementation.
+
+use super::hashchain::{HashChainEntry, HashChainState};
+use async_trait::async_trait;
+use std::io;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+/// Errors specific to immutable audit storage operations.
+#[derive(Error, Debug)]
+pub enum ImmutableAuditError {
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("chain verification failed")]
+    VerificationFailed,
+}
+
+/// Result type alias for immutable audit operations.
+pub type ImmutableAuditResult<T> = std::result::Result<T, ImmutableAuditError>;
+
+/// Trait for append-only audit storage backends.
+#[async_trait]
+pub trait AuditStorage: Send + Sync {
+    /// Append a hash-chain entry to the storage.
+    async fn append(&self, entry: &HashChainEntry) -> ImmutableAuditResult<()>;
+
+    /// Read all entries from the storage.
+    async fn read_all(&self) -> ImmutableAuditResult<Vec<HashChainEntry>>;
+
+    /// Verify the integrity of the stored chain.
+    async fn verify(&self) -> ImmutableAuditResult<bool> {
+        let entries = self.read_all().await?;
+        Ok(HashChainState::verify_chain(&entries))
+    }
+}
+
+/// File-based append-only audit storage using JSON lines format.
+///
+/// Each `HashChainEntry` is serialized as a single JSON line appended to the file.
+/// The file is opened in append mode to prevent accidental overwrites.
+#[derive(Debug, Clone)]
+pub struct FileAuditStorage {
+    path: PathBuf,
+}
+
+impl FileAuditStorage {
+    /// Create a new file-based audit storage at the given path.
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    /// Get the path to the backing file.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[async_trait]
+impl AuditStorage for FileAuditStorage {
+    async fn append(&self, entry: &HashChainEntry) -> ImmutableAuditResult<()> {
+        use std::fs::OpenOptions;
+        use std::io::Write;
+
+        let mut line = serde_json::to_string(entry)?;
+        line.push('\n');
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+
+        file.write_all(line.as_bytes())?;
+        file.flush()?;
+        Ok(())
+    }
+
+    async fn read_all(&self) -> ImmutableAuditResult<Vec<HashChainEntry>> {
+        if !self.path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let content = std::fs::read_to_string(&self.path)?;
+        let mut entries = Vec::new();
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let entry: HashChainEntry = serde_json::from_str(trimmed)?;
+            entries.push(entry);
+        }
+        Ok(entries)
+    }
+}
+
+/// High-level immutable audit store combining hash-chain state with storage.
+///
+/// This struct maintains an in-memory `HashChainState` and writes every new
+/// event to the underlying `AuditStorage` backend.
+pub struct ImmutableAuditStore {
+    chain: HashChainState,
+    storage: Box<dyn AuditStorage>,
+}
+
+impl ImmutableAuditStore {
+    /// Create a new store with the given storage backend.
+    pub fn new(storage: Box<dyn AuditStorage>) -> Self {
+        Self {
+            chain: HashChainState::new(),
+            storage,
+        }
+    }
+
+    /// Create a store and replay existing entries to rebuild chain state.
+    pub async fn open(storage: Box<dyn AuditStorage>) -> ImmutableAuditResult<Self> {
+        let entries = storage.read_all().await?;
+        let chain = if entries.is_empty() {
+            HashChainState::new()
+        } else {
+            let last = entries.last().unwrap();
+            HashChainState::resume(last.sequence + 1, last.chain_hash.clone())
+        };
+        Ok(Self { chain, storage })
+    }
+
+    /// Record a new audit event (as raw bytes) into the chain and persist it.
+    pub async fn record(&mut self, event_data: &[u8]) -> ImmutableAuditResult<HashChainEntry> {
+        let entry = self.chain.append(event_data);
+        self.storage.append(&entry).await?;
+        Ok(entry)
+    }
+
+    /// Verify the entire stored chain.
+    pub async fn verify(&self) -> ImmutableAuditResult<bool> {
+        self.storage.verify().await
+    }
+
+    /// Get the current sequence number.
+    pub fn next_sequence(&self) -> u64 {
+        self.chain.next_sequence()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[tokio::test]
+    async fn test_file_storage_round_trip() {
+        let tmp = NamedTempFile::new().unwrap();
+        let storage = FileAuditStorage::new(tmp.path());
+
+        let mut chain = HashChainState::new();
+        let e0 = chain.append(b"hello");
+        let e1 = chain.append(b"world");
+
+        storage.append(&e0).await.unwrap();
+        storage.append(&e1).await.unwrap();
+
+        let entries = storage.read_all().await.unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0], e0);
+        assert_eq!(entries[1], e1);
+
+        assert!(storage.verify().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_immutable_store_record_and_verify() {
+        let tmp = NamedTempFile::new().unwrap();
+        let storage = Box::new(FileAuditStorage::new(tmp.path()));
+        let mut store = ImmutableAuditStore::new(storage);
+
+        let e0 = store.record(b"event-a").await.unwrap();
+        assert_eq!(e0.sequence, 0);
+
+        let e1 = store.record(b"event-b").await.unwrap();
+        assert_eq!(e1.sequence, 1);
+
+        assert!(store.verify().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_immutable_store_open_resumes() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+
+        // Write two entries
+        {
+            let storage = Box::new(FileAuditStorage::new(&path));
+            let mut store = ImmutableAuditStore::new(storage);
+            store.record(b"first").await.unwrap();
+            store.record(b"second").await.unwrap();
+        }
+
+        // Re-open and continue
+        let storage = Box::new(FileAuditStorage::new(&path));
+        let mut store = ImmutableAuditStore::open(storage).await.unwrap();
+        assert_eq!(store.next_sequence(), 2);
+
+        let e2 = store.record(b"third").await.unwrap();
+        assert_eq!(e2.sequence, 2);
+
+        assert!(store.verify().await.unwrap());
+    }
+}

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -45,6 +45,10 @@
 
 mod event;
 mod logger;
+pub mod hashchain;
+pub mod immutable;
+pub mod sink;
+pub mod verify;
 
 // Re-export main types
 pub use event::{AuditCategory, AuditEvent, AuditOutcome, AuditSeverity};

--- a/src/audit/sink.rs
+++ b/src/audit/sink.rs
@@ -1,0 +1,275 @@
+//! Audit sink pipeline for fan-out delivery
+//!
+//! Sinks are output destinations for audit entries. A `SinkPipeline` fans out
+//! each entry to multiple sinks, enabling simultaneous delivery to files, HTTP
+//! endpoints, syslog, and other backends.
+
+use super::hashchain::HashChainEntry;
+use async_trait::async_trait;
+use std::path::PathBuf;
+use thiserror::Error;
+
+/// Errors from audit sink operations.
+#[derive(Error, Debug)]
+pub enum SinkError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("HTTP sink error: {0}")]
+    Http(String),
+
+    #[error("syslog sink error: {0}")]
+    Syslog(String),
+
+    #[error("pipeline error: {failures} of {total} sinks failed")]
+    Pipeline { failures: usize, total: usize },
+}
+
+/// Result type for sink operations.
+pub type SinkResult<T> = std::result::Result<T, SinkError>;
+
+/// Trait for audit entry output destinations.
+#[async_trait]
+pub trait AuditSink: Send + Sync {
+    /// Send a hash-chain entry to this sink.
+    async fn send(&self, entry: &HashChainEntry) -> SinkResult<()>;
+
+    /// Human-readable name for this sink (used in error messages).
+    fn name(&self) -> &str;
+}
+
+// ---------------------------------------------------------------------------
+// FileSink
+// ---------------------------------------------------------------------------
+
+/// Sink that appends JSON-lines entries to a local file.
+#[derive(Debug, Clone)]
+pub struct FileSink {
+    path: PathBuf,
+}
+
+impl FileSink {
+    /// Create a file sink targeting the given path.
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+}
+
+#[async_trait]
+impl AuditSink for FileSink {
+    async fn send(&self, entry: &HashChainEntry) -> SinkResult<()> {
+        use std::fs::OpenOptions;
+        use std::io::Write;
+
+        let mut line = serde_json::to_string(entry)?;
+        line.push('\n');
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        file.write_all(line.as_bytes())?;
+        file.flush()?;
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "file"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HttpSink (stub)
+// ---------------------------------------------------------------------------
+
+/// Stub sink for forwarding audit entries to an HTTP endpoint.
+///
+/// A real implementation would use `reqwest` to POST entries. This stub
+/// simply records that a send was attempted.
+#[derive(Debug, Clone)]
+pub struct HttpSink {
+    endpoint: String,
+}
+
+impl HttpSink {
+    /// Create a new HTTP sink pointing at the given URL.
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+        }
+    }
+
+    /// Get the configured endpoint URL.
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+#[async_trait]
+impl AuditSink for HttpSink {
+    async fn send(&self, _entry: &HashChainEntry) -> SinkResult<()> {
+        // Stub: in production this would POST the entry as JSON.
+        tracing::debug!(endpoint = %self.endpoint, "HttpSink send (stub)");
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "http"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SyslogSink (stub)
+// ---------------------------------------------------------------------------
+
+/// Stub sink for forwarding audit entries to the system syslog.
+#[derive(Debug, Clone)]
+pub struct SyslogSink {
+    facility: String,
+}
+
+impl SyslogSink {
+    /// Create a syslog sink with the given facility name.
+    pub fn new(facility: impl Into<String>) -> Self {
+        Self {
+            facility: facility.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl AuditSink for SyslogSink {
+    async fn send(&self, _entry: &HashChainEntry) -> SinkResult<()> {
+        // Stub: in production this would write to syslog.
+        tracing::debug!(facility = %self.facility, "SyslogSink send (stub)");
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "syslog"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SinkPipeline
+// ---------------------------------------------------------------------------
+
+/// Pipeline that fans out audit entries to multiple sinks.
+///
+/// By default the pipeline is **fail-open**: if some sinks fail the entry is
+/// still considered delivered as long as at least one succeeds. Set
+/// `require_all` to `true` to require every sink to succeed.
+pub struct SinkPipeline {
+    sinks: Vec<Box<dyn AuditSink>>,
+    require_all: bool,
+}
+
+impl SinkPipeline {
+    /// Create an empty pipeline.
+    pub fn new() -> Self {
+        Self {
+            sinks: Vec::new(),
+            require_all: false,
+        }
+    }
+
+    /// Add a sink to the pipeline.
+    pub fn add_sink(&mut self, sink: Box<dyn AuditSink>) {
+        self.sinks.push(sink);
+    }
+
+    /// Set whether all sinks must succeed for `send` to return `Ok`.
+    pub fn set_require_all(&mut self, require_all: bool) {
+        self.require_all = require_all;
+    }
+
+    /// Send an entry to all sinks. Returns an error only when the failure
+    /// policy is violated.
+    pub async fn send(&self, entry: &HashChainEntry) -> SinkResult<()> {
+        let total = self.sinks.len();
+        let mut failures = 0usize;
+
+        for sink in &self.sinks {
+            if let Err(e) = sink.send(entry).await {
+                tracing::warn!(sink = sink.name(), error = %e, "audit sink delivery failed");
+                failures += 1;
+            }
+        }
+
+        if self.require_all && failures > 0 {
+            return Err(SinkError::Pipeline { failures, total });
+        }
+
+        // Fail-open: as long as not *all* sinks failed we are OK.
+        if failures == total && total > 0 {
+            return Err(SinkError::Pipeline { failures, total });
+        }
+
+        Ok(())
+    }
+
+    /// Get the number of configured sinks.
+    pub fn sink_count(&self) -> usize {
+        self.sinks.len()
+    }
+}
+
+impl Default for SinkPipeline {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[tokio::test]
+    async fn test_file_sink_writes_entry() {
+        let tmp = NamedTempFile::new().unwrap();
+        let sink = FileSink::new(tmp.path());
+
+        let entry = HashChainEntry {
+            sequence: 0,
+            timestamp: "2025-01-01T00:00:00Z".to_string(),
+            event_hash: "abc123".to_string(),
+            previous_hash: String::new(),
+            chain_hash: "def456".to_string(),
+        };
+
+        sink.send(&entry).await.unwrap();
+
+        let content = std::fs::read_to_string(tmp.path()).unwrap();
+        assert!(content.contains("abc123"));
+        assert!(content.contains("def456"));
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_fan_out() {
+        let tmp1 = NamedTempFile::new().unwrap();
+        let tmp2 = NamedTempFile::new().unwrap();
+
+        let mut pipeline = SinkPipeline::new();
+        pipeline.add_sink(Box::new(FileSink::new(tmp1.path())));
+        pipeline.add_sink(Box::new(FileSink::new(tmp2.path())));
+
+        let entry = HashChainEntry {
+            sequence: 0,
+            timestamp: "2025-01-01T00:00:00Z".to_string(),
+            event_hash: "aaa".to_string(),
+            previous_hash: String::new(),
+            chain_hash: "bbb".to_string(),
+        };
+
+        pipeline.send(&entry).await.unwrap();
+
+        let c1 = std::fs::read_to_string(tmp1.path()).unwrap();
+        let c2 = std::fs::read_to_string(tmp2.path()).unwrap();
+        assert!(c1.contains("aaa"));
+        assert!(c2.contains("aaa"));
+    }
+}

--- a/src/audit/verify.rs
+++ b/src/audit/verify.rs
@@ -1,0 +1,161 @@
+//! Offline audit log verification
+//!
+//! This module provides standalone verification of audit log files without
+//! needing the rest of the audit subsystem to be running. It reads a
+//! JSON-lines file and checks hash-chain integrity.
+
+use super::hashchain::HashChainEntry;
+use std::path::Path;
+
+/// Report returned by the audit verifier.
+#[derive(Debug, Clone)]
+pub struct VerificationReport {
+    /// Whether the entire chain is valid.
+    pub valid: bool,
+    /// Number of entries that were checked.
+    pub entries_checked: usize,
+    /// Sequence number of the first invalid entry, if any.
+    pub first_invalid: Option<u64>,
+}
+
+impl std::fmt::Display for VerificationReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.valid {
+            write!(
+                f,
+                "VALID: all {} entries verified",
+                self.entries_checked
+            )
+        } else {
+            write!(
+                f,
+                "INVALID: first bad entry at sequence {} ({} entries checked)",
+                self.first_invalid.unwrap_or(0),
+                self.entries_checked
+            )
+        }
+    }
+}
+
+/// Verifier for offline audit log files.
+pub struct AuditVerifier;
+
+impl AuditVerifier {
+    /// Verify a JSON-lines audit log file at the given path.
+    ///
+    /// Returns a `VerificationReport` with the result. IO and parse errors
+    /// are returned as `Err`.
+    pub fn verify_file(path: &Path) -> std::io::Result<VerificationReport> {
+        let content = std::fs::read_to_string(path)?;
+        let mut entries: Vec<HashChainEntry> = Vec::new();
+
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let entry: HashChainEntry = serde_json::from_str(trimmed).map_err(|e| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, e)
+            })?;
+            entries.push(entry);
+        }
+
+        if entries.is_empty() {
+            return Ok(VerificationReport {
+                valid: true,
+                entries_checked: 0,
+                first_invalid: None,
+            });
+        }
+
+        // Walk the chain entry by entry to find the first invalid one
+        let entries_checked = entries.len();
+        for (i, entry) in entries.iter().enumerate() {
+            // Check sequence continuity
+            if entry.sequence != entries[0].sequence + i as u64 {
+                return Ok(VerificationReport {
+                    valid: false,
+                    entries_checked,
+                    first_invalid: Some(entry.sequence),
+                });
+            }
+
+            // Check previous_hash linkage (skip for first entry)
+            if i > 0 {
+                let prev = &entries[i - 1];
+                if entry.previous_hash != prev.chain_hash {
+                    return Ok(VerificationReport {
+                        valid: false,
+                        entries_checked,
+                        first_invalid: Some(entry.sequence),
+                    });
+                }
+            }
+
+            // Recompute and verify chain_hash
+            let mut chain_input = Vec::new();
+            chain_input.extend_from_slice(&entry.sequence.to_le_bytes());
+            chain_input.extend_from_slice(entry.event_hash.as_bytes());
+            chain_input.extend_from_slice(entry.previous_hash.as_bytes());
+            let expected = blake3::hash(&chain_input).to_hex().to_string();
+
+            if entry.chain_hash != expected {
+                return Ok(VerificationReport {
+                    valid: false,
+                    entries_checked,
+                    first_invalid: Some(entry.sequence),
+                });
+            }
+        }
+
+        Ok(VerificationReport {
+            valid: true,
+            entries_checked,
+            first_invalid: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::hashchain::HashChainState as Chain;
+    use tempfile::NamedTempFile;
+
+    fn write_entries(path: &Path, entries: &[HashChainEntry]) {
+        use std::io::Write;
+        let mut f = std::fs::File::create(path).unwrap();
+        for e in entries {
+            let line = serde_json::to_string(e).unwrap();
+            writeln!(f, "{}", line).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_verify_valid_file() {
+        let tmp = NamedTempFile::new().unwrap();
+        let mut chain = Chain::new();
+        let entries: Vec<_> = (0..5).map(|i| chain.append(format!("evt-{i}").as_bytes())).collect();
+        write_entries(tmp.path(), &entries);
+
+        let report = AuditVerifier::verify_file(tmp.path()).unwrap();
+        assert!(report.valid);
+        assert_eq!(report.entries_checked, 5);
+        assert!(report.first_invalid.is_none());
+    }
+
+    #[test]
+    fn test_verify_tampered_file() {
+        let tmp = NamedTempFile::new().unwrap();
+        let mut chain = Chain::new();
+        let mut entries: Vec<_> = (0..3).map(|i| chain.append(format!("evt-{i}").as_bytes())).collect();
+
+        // Tamper with the second entry
+        entries[1].event_hash = "tampered".to_string();
+        write_entries(tmp.path(), &entries);
+
+        let report = AuditVerifier::verify_file(tmp.path()).unwrap();
+        assert!(!report.valid);
+        assert_eq!(report.first_invalid, Some(1));
+    }
+}

--- a/src/cli/commands/audit.rs
+++ b/src/cli/commands/audit.rs
@@ -1,0 +1,87 @@
+//! CLI command for audit log operations
+//!
+//! Provides subcommands for verifying and inspecting the immutable audit log.
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+
+use super::CommandContext;
+
+/// Arguments for the `audit` command.
+#[derive(Parser, Debug, Clone)]
+pub struct AuditArgs {
+    /// Audit subcommand
+    #[command(subcommand)]
+    pub command: AuditCommands,
+}
+
+/// Available audit subcommands.
+#[derive(Subcommand, Debug, Clone)]
+pub enum AuditCommands {
+    /// Verify integrity of an audit log file
+    Verify(VerifyArgs),
+
+    /// Show audit system status and configuration
+    Status,
+}
+
+/// Arguments for the `audit verify` subcommand.
+#[derive(Parser, Debug, Clone)]
+pub struct VerifyArgs {
+    /// Path to the audit log file to verify
+    #[arg(long = "log-file")]
+    pub log_file: PathBuf,
+}
+
+impl AuditArgs {
+    /// Execute the audit command.
+    pub async fn execute(&self, ctx: &mut CommandContext) -> Result<i32> {
+        match &self.command {
+            AuditCommands::Verify(args) => execute_verify(args, ctx).await,
+            AuditCommands::Status => execute_status(ctx).await,
+        }
+    }
+}
+
+/// Verify the integrity of an audit log file.
+async fn execute_verify(args: &VerifyArgs, ctx: &mut CommandContext) -> Result<i32> {
+    ctx.output.banner("AUDIT LOG VERIFICATION");
+    ctx.output
+        .info(&format!("Verifying: {}", args.log_file.display()));
+
+    if !args.log_file.exists() {
+        ctx.output
+            .error(&format!("Audit log file not found: {}", args.log_file.display()));
+        return Ok(1);
+    }
+
+    let report = rustible::audit::verify::AuditVerifier::verify_file(&args.log_file)
+        .map_err(|e| anyhow::anyhow!("Failed to read audit log: {}", e))?;
+
+    if report.valid {
+        ctx.output.success(&format!(
+            "Audit log is VALID ({} entries verified)",
+            report.entries_checked
+        ));
+        Ok(0)
+    } else {
+        ctx.output.error(&format!(
+            "Audit log is INVALID: first bad entry at sequence {} ({} entries checked)",
+            report.first_invalid.unwrap_or(0),
+            report.entries_checked
+        ));
+        Ok(1)
+    }
+}
+
+/// Display audit system status.
+async fn execute_status(ctx: &mut CommandContext) -> Result<i32> {
+    ctx.output.banner("AUDIT SYSTEM STATUS");
+    ctx.output.info("Immutable audit log pipeline: enabled");
+    ctx.output.info("Hash algorithm: BLAKE3");
+    ctx.output.info("Storage backend: file (JSON-lines, append-only)");
+    ctx.output
+        .info("Sink pipeline: file, http (stub), syslog (stub)");
+    Ok(0)
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! This module contains all the subcommand implementations.
 
+pub mod audit;
 pub mod check;
 pub mod drift;
 pub mod fleet;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -153,6 +153,10 @@ pub enum Commands {
     /// Show fleet infrastructure dashboard
     #[command(name = "fleet")]
     Fleet(commands::fleet::FleetArgs),
+
+    /// Audit log operations (verify, status)
+    #[command(name = "audit")]
+    Audit(commands::audit::AuditArgs),
 }
 
 /// Arguments for agent command

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,7 @@ async fn main() -> Result<()> {
             1
         }
         Commands::Fleet(args) => args.execute(&mut ctx).await?,
+        Commands::Audit(args) => args.execute(&mut ctx).await?,
     };
 
     std::process::exit(exit_code);


### PR DESCRIPTION
## Summary
- Adds blake3-based hash chain for tamper-evident audit log entries
- Implements append-only file storage with chain integrity verification
- Adds sink pipeline with fan-out to file/HTTP/syslog backends
- Adds `audit verify` and `audit status` CLI subcommands

Closes #537

## Test plan
- [ ] `cargo build` passes
- [ ] Hash chain append, verify, and tamper detection tests pass
- [ ] Immutable store round-trip and resume tests pass
- [ ] Sink pipeline fan-out tests pass
- [ ] `rustible audit --help` shows verify/status subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)