### PR TITLE
feat(security): add enterprise RBAC authorization engine

### DIFF
--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod inventory;
 pub mod lock;
 pub mod provider;
 pub mod provision;
+pub mod rbac;
 pub mod provisioner;
 pub mod run;
 pub mod state;

--- a/src/cli/commands/rbac.rs
+++ b/src/cli/commands/rbac.rs
@@ -1,0 +1,138 @@
+//! RBAC command - Manage role-based access control
+//!
+//! Provides CLI subcommands for checking authorization, listing roles,
+//! and inspecting individual role definitions.
+
+use super::CommandContext;
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use rustible::security::rbac::{Action, AuthzRequest, RbacConfig, RbacEngine};
+
+/// Arguments for the rbac command
+#[derive(Parser, Debug, Clone)]
+pub struct RbacArgs {
+    #[command(subcommand)]
+    pub action: RbacAction,
+}
+
+/// RBAC subcommands
+#[derive(Subcommand, Debug, Clone)]
+pub enum RbacAction {
+    /// Check if a principal is authorized for an action on a resource
+    Check(CheckArgs),
+
+    /// List all configured roles
+    #[command(name = "list-roles")]
+    ListRoles,
+
+    /// Show details of a specific role
+    #[command(name = "show-role")]
+    ShowRole(ShowRoleArgs),
+}
+
+/// Arguments for the check subcommand
+#[derive(Parser, Debug, Clone)]
+pub struct CheckArgs {
+    /// Principal (user or service) to check
+    #[arg(long)]
+    pub principal: String,
+
+    /// Resource identifier to check against
+    #[arg(long)]
+    pub resource: String,
+
+    /// Action to check (read, write, execute, admin)
+    #[arg(long)]
+    pub action: String,
+
+    /// Roles to assign to the principal (comma-separated)
+    #[arg(long, value_delimiter = ',')]
+    pub roles: Vec<String>,
+}
+
+/// Arguments for the show-role subcommand
+#[derive(Parser, Debug, Clone)]
+pub struct ShowRoleArgs {
+    /// Name of the role to display
+    pub name: String,
+}
+
+impl RbacArgs {
+    pub async fn execute(&self, ctx: &mut CommandContext) -> Result<i32> {
+        let config = RbacConfig::with_builtins();
+        let mut engine = RbacEngine::new();
+        engine.load_roles(config.roles.clone());
+
+        match &self.action {
+            RbacAction::Check(args) => {
+                let request = AuthzRequest {
+                    principal: args.principal.clone(),
+                    roles: args.roles.clone(),
+                    resource: args.resource.clone(),
+                    action: Action::from_str(&args.action),
+                };
+
+                let decision = engine.authorize(&request);
+
+                if decision.allowed {
+                    ctx.output.success(&format!(
+                        "ALLOWED: {} may {} on {}",
+                        request.principal, request.action, request.resource
+                    ));
+                } else {
+                    ctx.output.error(&format!(
+                        "DENIED: {} may not {} on {}",
+                        request.principal, request.action, request.resource
+                    ));
+                }
+                ctx.output.info(&format!("Reason: {}", decision.reason));
+                if let Some(role) = &decision.matched_role {
+                    ctx.output.info(&format!("Matched role: {}", role));
+                }
+
+                Ok(if decision.allowed { 0 } else { 1 })
+            }
+
+            RbacAction::ListRoles => {
+                ctx.output.banner("RBAC ROLES");
+                for role in &config.roles {
+                    ctx.output.info(&format!(
+                        "  {:<12} - {} ({} permissions, inherits: [{}])",
+                        role.name,
+                        role.description,
+                        role.permissions.len(),
+                        role.inherits.join(", ")
+                    ));
+                }
+                Ok(0)
+            }
+
+            RbacAction::ShowRole(args) => {
+                if let Some(role) = config.roles.iter().find(|r| r.name == args.name) {
+                    ctx.output.banner(&format!("Role: {}", role.name));
+                    ctx.output.info(&format!("Description: {}", role.description));
+                    if !role.inherits.is_empty() {
+                        ctx.output
+                            .info(&format!("Inherits: {}", role.inherits.join(", ")));
+                    }
+                    ctx.output.section("Permissions:");
+                    for perm in &role.permissions {
+                        let actions: Vec<String> =
+                            perm.actions.iter().map(|a| a.to_string()).collect();
+                        ctx.output.info(&format!(
+                            "  {:?} {} on '{}'",
+                            perm.effect,
+                            actions.join(", "),
+                            perm.resource.pattern
+                        ));
+                    }
+                    Ok(0)
+                } else {
+                    ctx.output
+                        .error(&format!("Role '{}' not found", args.name));
+                    Ok(1)
+                }
+            }
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -153,6 +153,10 @@ pub enum Commands {
     /// Show fleet infrastructure dashboard
     #[command(name = "fleet")]
     Fleet(commands::fleet::FleetArgs),
+
+    /// Role-based access control management
+    #[command(name = "rbac")]
+    Rbac(commands::rbac::RbacArgs),
 }
 
 /// Arguments for agent command

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,7 @@ async fn main() -> Result<()> {
             1
         }
         Commands::Fleet(args) => args.execute(&mut ctx).await?,
+        Commands::Rbac(args) => args.execute(&mut ctx).await?,
     };
 
     std::process::exit(exit_code);

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -74,6 +74,7 @@ pub mod path;
 pub mod rate_limit;
 pub mod secret;
 pub mod template;
+pub mod rbac;
 pub mod validation;
 
 use serde::{Deserialize, Serialize};

--- a/src/security/rbac/engine.rs
+++ b/src/security/rbac/engine.rs
@@ -1,0 +1,253 @@
+//! RBAC authorization engine
+//!
+//! Evaluates authorization requests against loaded roles, resolving
+//! inheritance and enforcing deny-takes-precedence semantics.
+
+use super::model::{AuthzDecision, AuthzRequest, Effect, Role};
+use std::collections::{HashMap, HashSet};
+
+/// The core RBAC authorization engine.
+#[derive(Debug, Clone)]
+pub struct RbacEngine {
+    /// All known roles indexed by name.
+    roles: HashMap<String, Role>,
+}
+
+impl RbacEngine {
+    /// Create an empty engine.
+    pub fn new() -> Self {
+        Self {
+            roles: HashMap::new(),
+        }
+    }
+
+    /// Bulk-load a set of roles, replacing any existing ones with the same name.
+    pub fn load_roles(&mut self, roles: Vec<Role>) {
+        for role in roles {
+            self.roles.insert(role.name.clone(), role);
+        }
+    }
+
+    /// Add a single role.
+    pub fn add_role(&mut self, role: Role) {
+        self.roles.insert(role.name.clone(), role);
+    }
+
+    /// Resolve a list of role names into their `Role` references, following
+    /// inheritance chains. Cycles are detected and avoided.
+    pub fn resolve_roles<'a>(&'a self, role_names: &[String]) -> Vec<&'a Role> {
+        let mut visited = HashSet::new();
+        let mut result = Vec::new();
+        let mut stack: Vec<&str> = role_names.iter().map(|s| s.as_str()).collect();
+
+        while let Some(name) = stack.pop() {
+            if !visited.insert(name.to_string()) {
+                continue;
+            }
+            if let Some(role) = self.roles.get(name) {
+                result.push(role);
+                for parent in &role.inherits {
+                    stack.push(parent.as_str());
+                }
+            }
+        }
+
+        result
+    }
+
+    /// Evaluate an authorization request and return a decision.
+    ///
+    /// Algorithm:
+    /// 1. Resolve all roles (including inherited ones).
+    /// 2. If any resolved permission explicitly *denies* the requested
+    ///    resource+action, the request is denied (deny takes precedence).
+    /// 3. If at least one permission *allows* the requested resource+action
+    ///    and no deny was found, the request is allowed.
+    /// 4. Otherwise, the request is denied by default (implicit deny).
+    pub fn authorize(&self, request: &AuthzRequest) -> AuthzDecision {
+        let resolved = self.resolve_roles(&request.roles);
+
+        if resolved.is_empty() {
+            return AuthzDecision {
+                allowed: false,
+                reason: format!("no roles found for principal '{}'", request.principal),
+                matched_role: None,
+            };
+        }
+
+        // First pass: check for explicit deny.
+        for role in &resolved {
+            for perm in &role.permissions {
+                if perm.effect == Effect::Deny
+                    && perm.resource.matches(&request.resource)
+                    && perm.actions.contains(&request.action)
+                {
+                    return AuthzDecision {
+                        allowed: false,
+                        reason: format!(
+                            "denied by role '{}' on resource '{}' for action '{}'",
+                            role.name, request.resource, request.action
+                        ),
+                        matched_role: Some(role.name.clone()),
+                    };
+                }
+            }
+        }
+
+        // Second pass: check for explicit allow.
+        for role in &resolved {
+            for perm in &role.permissions {
+                if perm.effect == Effect::Allow
+                    && perm.resource.matches(&request.resource)
+                    && perm.actions.contains(&request.action)
+                {
+                    return AuthzDecision {
+                        allowed: true,
+                        reason: format!(
+                            "allowed by role '{}' on resource '{}' for action '{}'",
+                            role.name, request.resource, request.action
+                        ),
+                        matched_role: Some(role.name.clone()),
+                    };
+                }
+            }
+        }
+
+        // Implicit deny.
+        AuthzDecision {
+            allowed: false,
+            reason: format!(
+                "no matching permission for action '{}' on resource '{}'",
+                request.action, request.resource
+            ),
+            matched_role: None,
+        }
+    }
+}
+
+impl Default for RbacEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::security::rbac::model::{Action, Effect, Permission, ResourcePattern};
+
+    fn make_role(name: &str, perms: Vec<Permission>, inherits: Vec<String>) -> Role {
+        Role {
+            name: name.to_string(),
+            permissions: perms,
+            inherits,
+            description: String::new(),
+        }
+    }
+
+    fn allow_perm(pattern: &str, actions: Vec<Action>) -> Permission {
+        Permission {
+            resource: ResourcePattern::new(pattern),
+            actions,
+            effect: Effect::Allow,
+        }
+    }
+
+    fn deny_perm(pattern: &str, actions: Vec<Action>) -> Permission {
+        Permission {
+            resource: ResourcePattern::new(pattern),
+            actions,
+            effect: Effect::Deny,
+        }
+    }
+
+    #[test]
+    fn test_basic_allow() {
+        let mut engine = RbacEngine::new();
+        engine.add_role(make_role(
+            "viewer",
+            vec![allow_perm("*", vec![Action::Read])],
+            vec![],
+        ));
+
+        let decision = engine.authorize(&AuthzRequest {
+            principal: "alice".into(),
+            roles: vec!["viewer".into()],
+            resource: "hosts:web01".into(),
+            action: Action::Read,
+        });
+
+        assert!(decision.allowed);
+        assert_eq!(decision.matched_role.as_deref(), Some("viewer"));
+    }
+
+    #[test]
+    fn test_deny_takes_precedence() {
+        let mut engine = RbacEngine::new();
+        engine.load_roles(vec![
+            make_role(
+                "writer",
+                vec![allow_perm("*", vec![Action::Read, Action::Write])],
+                vec![],
+            ),
+            make_role(
+                "restricted",
+                vec![deny_perm("secrets:*", vec![Action::Write])],
+                vec![],
+            ),
+        ]);
+
+        let decision = engine.authorize(&AuthzRequest {
+            principal: "bob".into(),
+            roles: vec!["writer".into(), "restricted".into()],
+            resource: "secrets:vault".into(),
+            action: Action::Write,
+        });
+
+        assert!(!decision.allowed);
+        assert!(decision.reason.contains("denied"));
+    }
+
+    #[test]
+    fn test_role_inheritance() {
+        let mut engine = RbacEngine::new();
+        engine.load_roles(vec![
+            make_role(
+                "base",
+                vec![allow_perm("*", vec![Action::Read])],
+                vec![],
+            ),
+            make_role(
+                "operator",
+                vec![allow_perm("hosts:*", vec![Action::Execute])],
+                vec!["base".into()],
+            ),
+        ]);
+
+        // Operator should inherit read from base.
+        let decision = engine.authorize(&AuthzRequest {
+            principal: "carol".into(),
+            roles: vec!["operator".into()],
+            resource: "config:main".into(),
+            action: Action::Read,
+        });
+
+        assert!(decision.allowed);
+        assert_eq!(decision.matched_role.as_deref(), Some("base"));
+    }
+
+    #[test]
+    fn test_implicit_deny_for_unknown_role() {
+        let engine = RbacEngine::new();
+
+        let decision = engine.authorize(&AuthzRequest {
+            principal: "eve".into(),
+            roles: vec!["nonexistent".into()],
+            resource: "anything".into(),
+            action: Action::Read,
+        });
+
+        assert!(!decision.allowed);
+        assert!(decision.reason.contains("no roles found"));
+    }
+}

--- a/src/security/rbac/mod.rs
+++ b/src/security/rbac/mod.rs
@@ -1,0 +1,12 @@
+//! Role-Based Access Control (RBAC) for Rustible
+//!
+//! Provides enterprise-grade authorization with role hierarchies,
+//! resource pattern matching, and deny-takes-precedence semantics.
+
+pub mod engine;
+pub mod model;
+pub mod store;
+
+pub use engine::RbacEngine;
+pub use model::{Action, AuthzDecision, AuthzRequest, Effect, Permission, ResourcePattern, Role};
+pub use store::RbacConfig;

--- a/src/security/rbac/model.rs
+++ b/src/security/rbac/model.rs
@@ -1,0 +1,186 @@
+//! RBAC data model types
+//!
+//! Defines roles, permissions, resource patterns, and authorization
+//! request/decision structures.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// A named role containing a set of permissions and optional inheritance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Role {
+    /// Unique role name (e.g. "admin", "operator").
+    pub name: String,
+    /// Permissions granted (or denied) by this role.
+    pub permissions: Vec<Permission>,
+    /// Names of parent roles whose permissions are inherited.
+    #[serde(default)]
+    pub inherits: Vec<String>,
+    /// Human-readable description of the role.
+    #[serde(default)]
+    pub description: String,
+}
+
+/// A single permission entry that maps a resource pattern + actions to an effect.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Permission {
+    /// The resource pattern this permission applies to.
+    pub resource: ResourcePattern,
+    /// The actions covered by this permission.
+    pub actions: Vec<Action>,
+    /// Whether to allow or deny.
+    pub effect: Effect,
+}
+
+/// A glob-like pattern for matching resource identifiers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResourcePattern {
+    /// The pattern string. Supports `*` as a wildcard prefix/suffix.
+    pub pattern: String,
+}
+
+impl ResourcePattern {
+    /// Create a new resource pattern.
+    pub fn new(pattern: impl Into<String>) -> Self {
+        Self {
+            pattern: pattern.into(),
+        }
+    }
+
+    /// Check whether the given resource string matches this pattern.
+    ///
+    /// Matching rules:
+    /// - `"*"` matches everything.
+    /// - A pattern ending with `*` matches any resource that starts with the
+    ///   prefix (e.g. `"hosts:*"` matches `"hosts:web01"`).
+    /// - A pattern starting with `*` matches any resource that ends with the
+    ///   suffix (e.g. `"*:read"` matches `"config:read"`).
+    /// - Otherwise, exact match is required.
+    pub fn matches(&self, resource: &str) -> bool {
+        if self.pattern == "*" {
+            return true;
+        }
+        if self.pattern.ends_with('*') {
+            let prefix = &self.pattern[..self.pattern.len() - 1];
+            return resource.starts_with(prefix);
+        }
+        if self.pattern.starts_with('*') {
+            let suffix = &self.pattern[1..];
+            return resource.ends_with(suffix);
+        }
+        self.pattern == resource
+    }
+}
+
+/// An action that can be performed on a resource.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Action {
+    /// Read / view access.
+    Read,
+    /// Write / modify access.
+    Write,
+    /// Execute / run access.
+    Execute,
+    /// Full administrative access.
+    Admin,
+    /// A custom action defined by the user.
+    Custom(String),
+}
+
+impl fmt::Display for Action {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Action::Read => write!(f, "read"),
+            Action::Write => write!(f, "write"),
+            Action::Execute => write!(f, "execute"),
+            Action::Admin => write!(f, "admin"),
+            Action::Custom(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl Action {
+    /// Parse an action from a string.
+    pub fn from_str(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "read" => Action::Read,
+            "write" => Action::Write,
+            "execute" => Action::Execute,
+            "admin" => Action::Admin,
+            other => Action::Custom(other.to_string()),
+        }
+    }
+}
+
+/// Whether a permission grants or denies access.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Effect {
+    /// Grant access.
+    Allow,
+    /// Deny access (takes precedence over Allow).
+    Deny,
+}
+
+/// An authorization request submitted to the RBAC engine.
+#[derive(Debug, Clone)]
+pub struct AuthzRequest {
+    /// The principal (user or service) requesting access.
+    pub principal: String,
+    /// Roles assigned to the principal.
+    pub roles: Vec<String>,
+    /// The target resource identifier.
+    pub resource: String,
+    /// The action being requested.
+    pub action: Action,
+}
+
+/// The decision returned by the RBAC engine.
+#[derive(Debug, Clone)]
+pub struct AuthzDecision {
+    /// Whether access is allowed.
+    pub allowed: bool,
+    /// Human-readable explanation.
+    pub reason: String,
+    /// The role that matched (if any).
+    pub matched_role: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resource_pattern_matching() {
+        let wildcard = ResourcePattern::new("*");
+        assert!(wildcard.matches("anything"));
+        assert!(wildcard.matches(""));
+
+        let prefix = ResourcePattern::new("hosts:*");
+        assert!(prefix.matches("hosts:web01"));
+        assert!(prefix.matches("hosts:"));
+        assert!(!prefix.matches("config:web01"));
+
+        let suffix = ResourcePattern::new("*:read");
+        assert!(suffix.matches("config:read"));
+        assert!(!suffix.matches("config:write"));
+
+        let exact = ResourcePattern::new("playbooks:deploy");
+        assert!(exact.matches("playbooks:deploy"));
+        assert!(!exact.matches("playbooks:deploy2"));
+    }
+
+    #[test]
+    fn test_action_display_and_parse() {
+        assert_eq!(Action::Read.to_string(), "read");
+        assert_eq!(Action::Write.to_string(), "write");
+        assert_eq!(Action::Execute.to_string(), "execute");
+        assert_eq!(Action::Admin.to_string(), "admin");
+        assert_eq!(Action::Custom("deploy".into()).to_string(), "deploy");
+
+        assert_eq!(Action::from_str("READ"), Action::Read);
+        assert_eq!(Action::from_str("Write"), Action::Write);
+        assert_eq!(Action::from_str("deploy"), Action::Custom("deploy".into()));
+    }
+}

--- a/src/security/rbac/store.rs
+++ b/src/security/rbac/store.rs
@@ -1,0 +1,132 @@
+//! RBAC configuration storage and built-in role definitions
+//!
+//! Provides serialization-friendly configuration and a set of
+//! sensible default roles for common enterprise use cases.
+
+use super::model::{Action, Effect, Permission, ResourcePattern, Role};
+use serde::{Deserialize, Serialize};
+
+/// Top-level RBAC configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RbacConfig {
+    /// All configured roles.
+    pub roles: Vec<Role>,
+}
+
+impl RbacConfig {
+    /// Create a configuration pre-populated with built-in roles.
+    ///
+    /// Built-in roles:
+    /// - **admin**: full access to all resources and actions.
+    /// - **operator**: read, write, and execute on all resources.
+    /// - **viewer**: read-only access to all resources.
+    /// - **auditor**: read-only access to audit-related resources.
+    pub fn with_builtins() -> Self {
+        let admin = Role {
+            name: "admin".into(),
+            permissions: vec![Permission {
+                resource: ResourcePattern::new("*"),
+                actions: vec![Action::Read, Action::Write, Action::Execute, Action::Admin],
+                effect: Effect::Allow,
+            }],
+            inherits: vec![],
+            description: "Full administrative access to all resources".into(),
+        };
+
+        let operator = Role {
+            name: "operator".into(),
+            permissions: vec![Permission {
+                resource: ResourcePattern::new("*"),
+                actions: vec![Action::Read, Action::Write, Action::Execute],
+                effect: Effect::Allow,
+            }],
+            inherits: vec![],
+            description: "Operational access: read, write, and execute".into(),
+        };
+
+        let viewer = Role {
+            name: "viewer".into(),
+            permissions: vec![Permission {
+                resource: ResourcePattern::new("*"),
+                actions: vec![Action::Read],
+                effect: Effect::Allow,
+            }],
+            inherits: vec![],
+            description: "Read-only access to all resources".into(),
+        };
+
+        let auditor = Role {
+            name: "auditor".into(),
+            permissions: vec![Permission {
+                resource: ResourcePattern::new("audit:*"),
+                actions: vec![Action::Read],
+                effect: Effect::Allow,
+            }],
+            inherits: vec![],
+            description: "Read-only access to audit resources".into(),
+        };
+
+        Self {
+            roles: vec![admin, operator, viewer, auditor],
+        }
+    }
+
+    /// Parse an `RbacConfig` from a YAML string.
+    pub fn from_yaml(content: &str) -> Result<Self, serde_yaml::Error> {
+        serde_yaml::from_str(content)
+    }
+}
+
+impl Default for RbacConfig {
+    fn default() -> Self {
+        Self::with_builtins()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_builtins_contain_expected_roles() {
+        let config = RbacConfig::with_builtins();
+        let names: Vec<&str> = config.roles.iter().map(|r| r.name.as_str()).collect();
+
+        assert!(names.contains(&"admin"));
+        assert!(names.contains(&"operator"));
+        assert!(names.contains(&"viewer"));
+        assert!(names.contains(&"auditor"));
+        assert_eq!(config.roles.len(), 4);
+    }
+
+    #[test]
+    fn test_from_yaml_roundtrip() {
+        let config = RbacConfig::with_builtins();
+        let yaml = serde_yaml::to_string(&config).expect("serialize");
+        let parsed = RbacConfig::from_yaml(&yaml).expect("deserialize");
+
+        assert_eq!(parsed.roles.len(), config.roles.len());
+        assert_eq!(parsed.roles[0].name, "admin");
+    }
+
+    #[test]
+    fn test_from_yaml_custom_roles() {
+        let yaml = r#"
+roles:
+  - name: deployer
+    description: Can deploy playbooks
+    permissions:
+      - resource:
+          pattern: "playbooks:*"
+        actions:
+          - read
+          - execute
+        effect: allow
+    inherits: []
+"#;
+        let config = RbacConfig::from_yaml(yaml).expect("parse custom yaml");
+        assert_eq!(config.roles.len(), 1);
+        assert_eq!(config.roles[0].name, "deployer");
+        assert_eq!(config.roles[0].permissions[0].actions.len(), 2);
+    }
+}


### PR DESCRIPTION
## Summary
- Implements role-based access control (RBAC) with hierarchical role inheritance
- Adds `RbacEngine` with built-in roles: admin, operator, viewer, auditor
- Supports resource pattern matching with glob-style wildcards
- Includes `rbac check`, `rbac list-roles`, `rbac show-role` CLI commands

## Test plan
- [ ] `cargo build` compiles successfully
- [ ] `cargo test --test rbac_tests` passes
- [ ] `rustible rbac --help` shows available subcommands
- [ ] Role inheritance resolves correctly (admin > operator > viewer)
- [ ] Resource pattern matching works with wildcards

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)