### PR TITLE
feat: native Slurm runtime integration modules

### DIFF
--- a/src/modules/hpc/mod.rs
+++ b/src/modules/hpc/mod.rs
@@ -70,6 +70,14 @@ pub mod power;
 pub mod scheduler_orchestration;
 #[cfg(feature = "slurm")]
 pub mod slurm;
+#[cfg(feature = "slurm")]
+pub mod slurm_account;
+#[cfg(feature = "slurm")]
+pub mod slurm_info;
+#[cfg(feature = "slurm")]
+pub mod slurm_job;
+#[cfg(feature = "slurm")]
+pub mod slurm_queue;
 pub mod toolchain;
 
 pub use boot_profile::BootProfileModule;
@@ -97,4 +105,12 @@ pub use power::HpcPowerModule;
 pub use scheduler_orchestration::SchedulerOrchestrationModule;
 #[cfg(feature = "slurm")]
 pub use slurm::{SlurmConfigModule, SlurmOpsModule};
+#[cfg(feature = "slurm")]
+pub use slurm_account::SlurmAccountModule;
+#[cfg(feature = "slurm")]
+pub use slurm_info::SlurmInfoModule;
+#[cfg(feature = "slurm")]
+pub use slurm_job::SlurmJobModule;
+#[cfg(feature = "slurm")]
+pub use slurm_queue::SlurmQueueModule;
 pub use toolchain::HpcToolchainModule;

--- a/src/modules/hpc/slurm_account.rs
+++ b/src/modules/hpc/slurm_account.rs
@@ -1,0 +1,525 @@
+//! Slurm account management module
+//!
+//! Manage Slurm accounts and user associations via sacctmgr.
+//!
+//! # Parameters
+//!
+//! - `action` (required): "create", "update", "delete", "add_user", or "remove_user"
+//! - `account` (required): Account name
+//! - `user` (optional, required for add_user/remove_user): User name
+//! - `organization` (optional): Organization name
+//! - `description` (optional): Account description
+//! - `parent` (optional): Parent account name
+//! - `max_jobs` (optional): Maximum concurrent jobs
+//! - `max_submit` (optional): Maximum submitted jobs
+//! - `max_wall` (optional): Maximum wall time per job
+//! - `fairshare` (optional): Fairshare value
+//! - `cluster` (optional): Cluster name (defaults to current)
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::runtime::Handle;
+
+use crate::connection::{Connection, ExecuteOptions};
+use crate::modules::{
+    Module, ModuleContext, ModuleError, ModuleOutput, ModuleParams, ModuleResult, ParamExt,
+    ParallelizationHint,
+};
+
+fn get_exec_options(context: &ModuleContext) -> ExecuteOptions {
+    let mut options = ExecuteOptions::new();
+    if context.r#become {
+        options = options.with_escalation(context.become_user.clone());
+        if let Some(ref method) = context.become_method {
+            options.escalate_method = Some(method.clone());
+        }
+        if let Some(ref password) = context.become_password {
+            options.escalate_password = Some(password.clone());
+        }
+    }
+    options
+}
+
+fn run_cmd(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<(bool, String, String)> {
+    let options = get_exec_options(context);
+    let result = Handle::current()
+        .block_on(async { connection.execute(cmd, Some(options)).await })
+        .map_err(|e| ModuleError::ExecutionFailed(format!("Connection error: {}", e)))?;
+    Ok((result.success, result.stdout, result.stderr))
+}
+
+fn run_cmd_ok(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<String> {
+    let (success, stdout, stderr) = run_cmd(connection, cmd, context)?;
+    if !success {
+        return Err(ModuleError::ExecutionFailed(format!(
+            "Command failed: {}",
+            stderr.trim()
+        )));
+    }
+    Ok(stdout)
+}
+
+pub struct SlurmAccountModule;
+
+impl Module for SlurmAccountModule {
+    fn name(&self) -> &'static str {
+        "slurm_account"
+    }
+
+    fn description(&self) -> &'static str {
+        "Manage Slurm accounts and user associations (sacctmgr)"
+    }
+
+    fn parallelization_hint(&self) -> ParallelizationHint {
+        ParallelizationHint::GlobalExclusive
+    }
+
+    fn execute(
+        &self,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let connection = context
+            .connection
+            .as_ref()
+            .ok_or_else(|| ModuleError::ExecutionFailed("No connection available".to_string()))?;
+
+        let action = params.get_string_required("action")?;
+        let account = params.get_string_required("account")?;
+
+        match action.as_str() {
+            "create" => self.action_create(connection, &account, params, context),
+            "update" => self.action_update(connection, &account, params, context),
+            "delete" => self.action_delete(connection, &account, params, context),
+            "add_user" => self.action_add_user(connection, &account, params, context),
+            "remove_user" => self.action_remove_user(connection, &account, params, context),
+            _ => Err(ModuleError::InvalidParameter(format!(
+                "Invalid action '{}'. Must be 'create', 'update', 'delete', 'add_user', or 'remove_user'",
+                action
+            ))),
+        }
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &["action", "account"]
+    }
+
+    fn optional_params(&self) -> HashMap<&'static str, serde_json::Value> {
+        let mut m = HashMap::new();
+        m.insert("user", serde_json::json!(null));
+        m.insert("organization", serde_json::json!(null));
+        m.insert("description", serde_json::json!(null));
+        m.insert("parent", serde_json::json!(null));
+        m.insert("max_jobs", serde_json::json!(null));
+        m.insert("max_submit", serde_json::json!(null));
+        m.insert("max_wall", serde_json::json!(null));
+        m.insert("fairshare", serde_json::json!(null));
+        m.insert("cluster", serde_json::json!(null));
+        m
+    }
+}
+
+impl SlurmAccountModule {
+    /// Check if an account exists.
+    fn account_exists(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        account: &str,
+        context: &ModuleContext,
+    ) -> ModuleResult<bool> {
+        let (ok, stdout, _) = run_cmd(
+            connection,
+            &format!(
+                "sacctmgr --noheader --parsable2 list accounts where name={} format=Account",
+                account
+            ),
+            context,
+        )?;
+        Ok(ok && !stdout.trim().is_empty())
+    }
+
+    /// Check if a user association exists for an account.
+    fn user_association_exists(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        user: &str,
+        account: &str,
+        cluster: Option<&str>,
+        context: &ModuleContext,
+    ) -> ModuleResult<bool> {
+        let mut cmd = format!(
+            "sacctmgr --noheader --parsable2 list associations where user={} account={}",
+            user, account
+        );
+        if let Some(c) = cluster {
+            cmd.push_str(&format!(" cluster={}", c));
+        }
+        cmd.push_str(" format=User,Account");
+        let (ok, stdout, _) = run_cmd(connection, &cmd, context)?;
+        Ok(ok && !stdout.trim().is_empty())
+    }
+
+    fn action_create(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        account: &str,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        // Idempotency check
+        if self.account_exists(connection, account, context)? {
+            return Ok(
+                ModuleOutput::ok(format!("Account '{}' already exists", account))
+                    .with_data("account", serde_json::json!(account)),
+            );
+        }
+
+        if context.check_mode {
+            return Ok(
+                ModuleOutput::changed(format!("Would create account '{}'", account))
+                    .with_data("account", serde_json::json!(account)),
+            );
+        }
+
+        let props = build_account_properties(params)?;
+        let mut cmd = format!("sacctmgr --immediate add account {}", account);
+        if !props.is_empty() {
+            cmd.push(' ');
+            cmd.push_str(&props);
+        }
+        if let Some(cluster) = params.get_string("cluster")? {
+            cmd.push_str(&format!(" cluster={}", cluster));
+        }
+
+        run_cmd_ok(connection, &cmd, context)?;
+
+        Ok(
+            ModuleOutput::changed(format!("Created account '{}'", account))
+                .with_data("account", serde_json::json!(account)),
+        )
+    }
+
+    fn action_update(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        account: &str,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        if !self.account_exists(connection, account, context)? {
+            return Err(ModuleError::ExecutionFailed(format!(
+                "Account '{}' does not exist; cannot update",
+                account
+            )));
+        }
+
+        let props = build_account_properties(params)?;
+        if props.is_empty() {
+            return Ok(
+                ModuleOutput::ok(format!("No properties to update for account '{}'", account))
+                    .with_data("account", serde_json::json!(account)),
+            );
+        }
+
+        if context.check_mode {
+            return Ok(ModuleOutput::changed(format!(
+                "Would update account '{}' with: {}",
+                account, props
+            ))
+            .with_data("account", serde_json::json!(account)));
+        }
+
+        let mut cmd = format!(
+            "sacctmgr --immediate modify account where name={} set {}",
+            account, props
+        );
+        if let Some(cluster) = params.get_string("cluster")? {
+            cmd = format!(
+                "sacctmgr --immediate modify account where name={} cluster={} set {}",
+                account, cluster, props
+            );
+        }
+
+        run_cmd_ok(connection, &cmd, context)?;
+
+        Ok(
+            ModuleOutput::changed(format!("Updated account '{}'", account))
+                .with_data("account", serde_json::json!(account))
+                .with_data("properties", serde_json::json!(props)),
+        )
+    }
+
+    fn action_delete(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        account: &str,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        // Idempotency check
+        if !self.account_exists(connection, account, context)? {
+            return Ok(
+                ModuleOutput::ok(format!("Account '{}' does not exist", account))
+                    .with_data("account", serde_json::json!(account)),
+            );
+        }
+
+        if context.check_mode {
+            return Ok(
+                ModuleOutput::changed(format!("Would delete account '{}'", account))
+                    .with_data("account", serde_json::json!(account)),
+            );
+        }
+
+        let mut cmd = format!("sacctmgr --immediate delete account where name={}", account);
+        if let Some(cluster) = params.get_string("cluster")? {
+            cmd.push_str(&format!(" cluster={}", cluster));
+        }
+
+        run_cmd_ok(connection, &cmd, context)?;
+
+        Ok(
+            ModuleOutput::changed(format!("Deleted account '{}'", account))
+                .with_data("account", serde_json::json!(account)),
+        )
+    }
+
+    fn action_add_user(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        account: &str,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let user = params.get_string_required("user")?;
+        let cluster = params.get_string("cluster")?;
+
+        // Idempotency check
+        if self.user_association_exists(
+            connection,
+            &user,
+            account,
+            cluster.as_deref(),
+            context,
+        )? {
+            return Ok(ModuleOutput::ok(format!(
+                "User '{}' is already associated with account '{}'",
+                user, account
+            ))
+            .with_data("user", serde_json::json!(user))
+            .with_data("account", serde_json::json!(account)));
+        }
+
+        if context.check_mode {
+            return Ok(ModuleOutput::changed(format!(
+                "Would add user '{}' to account '{}'",
+                user, account
+            ))
+            .with_data("user", serde_json::json!(user))
+            .with_data("account", serde_json::json!(account)));
+        }
+
+        let mut cmd = format!(
+            "sacctmgr --immediate add user {} account={}",
+            user, account
+        );
+        if let Some(ref c) = cluster {
+            cmd.push_str(&format!(" cluster={}", c));
+        }
+        // Add optional user-level limits
+        let user_props = build_user_properties(params)?;
+        if !user_props.is_empty() {
+            cmd.push(' ');
+            cmd.push_str(&user_props);
+        }
+
+        run_cmd_ok(connection, &cmd, context)?;
+
+        Ok(ModuleOutput::changed(format!(
+            "Added user '{}' to account '{}'",
+            user, account
+        ))
+        .with_data("user", serde_json::json!(user))
+        .with_data("account", serde_json::json!(account)))
+    }
+
+    fn action_remove_user(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        account: &str,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let user = params.get_string_required("user")?;
+        let cluster = params.get_string("cluster")?;
+
+        // Idempotency check
+        if !self.user_association_exists(
+            connection,
+            &user,
+            account,
+            cluster.as_deref(),
+            context,
+        )? {
+            return Ok(ModuleOutput::ok(format!(
+                "User '{}' is not associated with account '{}'",
+                user, account
+            ))
+            .with_data("user", serde_json::json!(user))
+            .with_data("account", serde_json::json!(account)));
+        }
+
+        if context.check_mode {
+            return Ok(ModuleOutput::changed(format!(
+                "Would remove user '{}' from account '{}'",
+                user, account
+            ))
+            .with_data("user", serde_json::json!(user))
+            .with_data("account", serde_json::json!(account)));
+        }
+
+        let mut cmd = format!(
+            "sacctmgr --immediate delete user where name={} account={}",
+            user, account
+        );
+        if let Some(ref c) = cluster {
+            cmd.push_str(&format!(" cluster={}", c));
+        }
+
+        run_cmd_ok(connection, &cmd, context)?;
+
+        Ok(ModuleOutput::changed(format!(
+            "Removed user '{}' from account '{}'",
+            user, account
+        ))
+        .with_data("user", serde_json::json!(user))
+        .with_data("account", serde_json::json!(account)))
+    }
+}
+
+/// Build sacctmgr account property string from params.
+fn build_account_properties(params: &ModuleParams) -> ModuleResult<String> {
+    let mut props = Vec::new();
+
+    if let Some(org) = params.get_string("organization")? {
+        props.push(format!("Organization={}", org));
+    }
+    if let Some(desc) = params.get_string("description")? {
+        props.push(format!("Description={}", desc));
+    }
+    if let Some(parent) = params.get_string("parent")? {
+        props.push(format!("parent={}", parent));
+    }
+    if let Some(fairshare) = params.get_string("fairshare")? {
+        props.push(format!("fairshare={}", fairshare));
+    }
+    if let Some(max_jobs) = params.get_string("max_jobs")? {
+        props.push(format!("MaxJobs={}", max_jobs));
+    }
+    if let Some(max_submit) = params.get_string("max_submit")? {
+        props.push(format!("MaxSubmitJobs={}", max_submit));
+    }
+    if let Some(max_wall) = params.get_string("max_wall")? {
+        props.push(format!("MaxWall={}", max_wall));
+    }
+
+    Ok(props.join(" "))
+}
+
+/// Build sacctmgr user-level property string.
+fn build_user_properties(params: &ModuleParams) -> ModuleResult<String> {
+    let mut props = Vec::new();
+    if let Some(fairshare) = params.get_string("fairshare")? {
+        props.push(format!("fairshare={}", fairshare));
+    }
+    if let Some(max_jobs) = params.get_string("max_jobs")? {
+        props.push(format!("MaxJobs={}", max_jobs));
+    }
+    if let Some(max_submit) = params.get_string("max_submit")? {
+        props.push(format!("MaxSubmitJobs={}", max_submit));
+    }
+    if let Some(max_wall) = params.get_string("max_wall")? {
+        props.push(format!("MaxWall={}", max_wall));
+    }
+    Ok(props.join(" "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_account_properties_full() {
+        let mut params = ModuleParams::new();
+        params.insert("organization".to_string(), serde_json::json!("Physics"));
+        params.insert(
+            "description".to_string(),
+            serde_json::json!("Physics department"),
+        );
+        params.insert("parent".to_string(), serde_json::json!("root"));
+        params.insert("fairshare".to_string(), serde_json::json!("100"));
+        params.insert("max_jobs".to_string(), serde_json::json!("50"));
+        params.insert("max_submit".to_string(), serde_json::json!("200"));
+        params.insert("max_wall".to_string(), serde_json::json!("7-00:00:00"));
+
+        let props = build_account_properties(&params).unwrap();
+        assert!(props.contains("Organization=Physics"));
+        assert!(props.contains("Description=Physics department"));
+        assert!(props.contains("parent=root"));
+        assert!(props.contains("fairshare=100"));
+        assert!(props.contains("MaxJobs=50"));
+        assert!(props.contains("MaxSubmitJobs=200"));
+        assert!(props.contains("MaxWall=7-00:00:00"));
+    }
+
+    #[test]
+    fn test_build_account_properties_empty() {
+        let params = ModuleParams::new();
+        let props = build_account_properties(&params).unwrap();
+        assert!(props.is_empty());
+    }
+
+    #[test]
+    fn test_build_account_properties_partial() {
+        let mut params = ModuleParams::new();
+        params.insert("organization".to_string(), serde_json::json!("CS"));
+        params.insert("fairshare".to_string(), serde_json::json!("50"));
+
+        let props = build_account_properties(&params).unwrap();
+        assert!(props.contains("Organization=CS"));
+        assert!(props.contains("fairshare=50"));
+        assert!(!props.contains("Description"));
+        assert!(!props.contains("MaxJobs"));
+    }
+
+    #[test]
+    fn test_build_user_properties() {
+        let mut params = ModuleParams::new();
+        params.insert("fairshare".to_string(), serde_json::json!("10"));
+        params.insert("max_jobs".to_string(), serde_json::json!("5"));
+        params.insert("max_submit".to_string(), serde_json::json!("20"));
+        params.insert("max_wall".to_string(), serde_json::json!("1-00:00:00"));
+
+        let props = build_user_properties(&params).unwrap();
+        assert!(props.contains("fairshare=10"));
+        assert!(props.contains("MaxJobs=5"));
+        assert!(props.contains("MaxSubmitJobs=20"));
+        assert!(props.contains("MaxWall=1-00:00:00"));
+    }
+
+    #[test]
+    fn test_build_user_properties_empty() {
+        let params = ModuleParams::new();
+        let props = build_user_properties(&params).unwrap();
+        assert!(props.is_empty());
+    }
+}

--- a/src/modules/hpc/slurm_info.rs
+++ b/src/modules/hpc/slurm_info.rs
@@ -1,0 +1,442 @@
+//! Slurm cluster information gathering module
+//!
+//! Gathers cluster state as structured facts from Slurm commands.
+//!
+//! # Parameters
+//!
+//! - `gather` (required): What to gather — "nodes", "jobs", "partitions", "accounts", "cluster"
+//! - `partition` (optional): Filter by partition name
+//! - `node` (optional): Filter by node name
+//! - `user` (optional): Filter by user name
+//! - `state` (optional): Filter by state (e.g. "idle", "running")
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::runtime::Handle;
+
+use crate::connection::{Connection, ExecuteOptions};
+use crate::modules::{
+    Module, ModuleContext, ModuleError, ModuleOutput, ModuleParams, ModuleResult, ParamExt,
+    ParallelizationHint,
+};
+
+fn get_exec_options(context: &ModuleContext) -> ExecuteOptions {
+    let mut options = ExecuteOptions::new();
+    if context.r#become {
+        options = options.with_escalation(context.become_user.clone());
+        if let Some(ref method) = context.become_method {
+            options.escalate_method = Some(method.clone());
+        }
+        if let Some(ref password) = context.become_password {
+            options.escalate_password = Some(password.clone());
+        }
+    }
+    options
+}
+
+fn run_cmd(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<(bool, String, String)> {
+    let options = get_exec_options(context);
+    let result = Handle::current()
+        .block_on(async { connection.execute(cmd, Some(options)).await })
+        .map_err(|e| ModuleError::ExecutionFailed(format!("Connection error: {}", e)))?;
+    Ok((result.success, result.stdout, result.stderr))
+}
+
+fn run_cmd_ok(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<String> {
+    let (success, stdout, stderr) = run_cmd(connection, cmd, context)?;
+    if !success {
+        return Err(ModuleError::ExecutionFailed(format!(
+            "Command failed: {}",
+            stderr.trim()
+        )));
+    }
+    Ok(stdout)
+}
+
+pub struct SlurmInfoModule;
+
+impl Module for SlurmInfoModule {
+    fn name(&self) -> &'static str {
+        "slurm_info"
+    }
+
+    fn description(&self) -> &'static str {
+        "Gather Slurm cluster state as structured facts (nodes, jobs, partitions, accounts)"
+    }
+
+    fn parallelization_hint(&self) -> ParallelizationHint {
+        ParallelizationHint::FullyParallel
+    }
+
+    fn execute(
+        &self,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let connection = context
+            .connection
+            .as_ref()
+            .ok_or_else(|| ModuleError::ExecutionFailed("No connection available".to_string()))?;
+
+        let gather = params.get_string_required("gather")?;
+
+        match gather.as_str() {
+            "nodes" => self.gather_nodes(connection, params, context),
+            "jobs" => self.gather_jobs(connection, params, context),
+            "partitions" => self.gather_partitions(connection, params, context),
+            "accounts" => self.gather_accounts(connection, params, context),
+            "cluster" => self.gather_cluster(connection, params, context),
+            _ => Err(ModuleError::InvalidParameter(format!(
+                "Invalid gather type '{}'. Must be 'nodes', 'jobs', 'partitions', 'accounts', or 'cluster'",
+                gather
+            ))),
+        }
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &["gather"]
+    }
+
+    fn optional_params(&self) -> HashMap<&'static str, serde_json::Value> {
+        let mut m = HashMap::new();
+        m.insert("partition", serde_json::json!(null));
+        m.insert("node", serde_json::json!(null));
+        m.insert("user", serde_json::json!(null));
+        m.insert("state", serde_json::json!(null));
+        m
+    }
+}
+
+impl SlurmInfoModule {
+    fn gather_nodes(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let mut cmd =
+            "sinfo --noheader -o '%n|%T|%c|%m|%P|%E|%O|%e'".to_string();
+        if let Some(partition) = params.get_string("partition")? {
+            cmd.push_str(&format!(" -p {}", partition));
+        }
+        if let Some(node) = params.get_string("node")? {
+            cmd.push_str(&format!(" -n {}", node));
+        }
+
+        let stdout = run_cmd_ok(connection, &cmd, context)?;
+        let nodes = parse_sinfo_nodes(&stdout);
+
+        Ok(ModuleOutput::ok(format!("Gathered {} node(s)", nodes.len()))
+            .with_data("nodes", serde_json::json!(nodes))
+            .with_data("count", serde_json::json!(nodes.len())))
+    }
+
+    fn gather_jobs(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let mut cmd =
+            "squeue --noheader -o '%i|%j|%u|%T|%P|%D|%C|%l|%M|%R'".to_string();
+        if let Some(partition) = params.get_string("partition")? {
+            cmd.push_str(&format!(" -p {}", partition));
+        }
+        if let Some(user) = params.get_string("user")? {
+            cmd.push_str(&format!(" -u {}", user));
+        }
+        if let Some(state) = params.get_string("state")? {
+            cmd.push_str(&format!(" -t {}", state));
+        }
+
+        let stdout = run_cmd_ok(connection, &cmd, context)?;
+        let jobs = parse_squeue_jobs(&stdout);
+
+        Ok(ModuleOutput::ok(format!("Gathered {} job(s)", jobs.len()))
+            .with_data("jobs", serde_json::json!(jobs))
+            .with_data("count", serde_json::json!(jobs.len())))
+    }
+
+    fn gather_partitions(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let mut cmd =
+            "sinfo --noheader -o '%R|%a|%F|%c|%m|%l|%G'".to_string();
+        if let Some(partition) = params.get_string("partition")? {
+            cmd.push_str(&format!(" -p {}", partition));
+        }
+
+        let stdout = run_cmd_ok(connection, &cmd, context)?;
+        let partitions = parse_sinfo_partitions(&stdout);
+
+        Ok(
+            ModuleOutput::ok(format!("Gathered {} partition(s)", partitions.len()))
+                .with_data("partitions", serde_json::json!(partitions))
+                .with_data("count", serde_json::json!(partitions.len())),
+        )
+    }
+
+    fn gather_accounts(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        _params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let stdout = run_cmd_ok(
+            connection,
+            "sacctmgr --noheader --parsable2 list accounts format=Account,Description,Organization",
+            context,
+        )?;
+        let accounts = parse_sacctmgr_accounts(&stdout);
+
+        Ok(
+            ModuleOutput::ok(format!("Gathered {} account(s)", accounts.len()))
+                .with_data("accounts", serde_json::json!(accounts))
+                .with_data("count", serde_json::json!(accounts.len())),
+        )
+    }
+
+    fn gather_cluster(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        _params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        // Gather aggregated cluster summary from multiple commands
+        let (_, node_out, _) = run_cmd(
+            connection,
+            "sinfo --noheader -o '%T' | sort | uniq -c",
+            context,
+        )?;
+        let (_, job_out, _) = run_cmd(
+            connection,
+            "squeue --noheader -o '%T' | sort | uniq -c",
+            context,
+        )?;
+        let (_, part_out, _) = run_cmd(
+            connection,
+            "sinfo --noheader -o '%R' | sort -u",
+            context,
+        )?;
+
+        let node_states = parse_uniq_counts(&node_out);
+        let job_states = parse_uniq_counts(&job_out);
+        let partitions: Vec<String> = part_out
+            .lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .collect();
+
+        Ok(ModuleOutput::ok("Gathered cluster summary")
+            .with_data("node_states", serde_json::json!(node_states))
+            .with_data("job_states", serde_json::json!(job_states))
+            .with_data("partitions", serde_json::json!(partitions))
+            .with_data("partition_count", serde_json::json!(partitions.len())))
+    }
+}
+
+/// Parse sinfo node output (pipe-delimited).
+/// Format: NodeName|State|CPUs|Memory|Partition|Reason|Load|FreeMem
+fn parse_sinfo_nodes(output: &str) -> Vec<serde_json::Value> {
+    let fields = [
+        "name", "state", "cpus", "memory", "partition", "reason", "load", "free_mem",
+    ];
+    parse_pipe_delimited(output, &fields)
+}
+
+/// Parse squeue job output (pipe-delimited).
+/// Format: JobID|Name|User|State|Partition|Nodes|CPUs|TimeLimit|TimeUsed|Reason
+fn parse_squeue_jobs(output: &str) -> Vec<serde_json::Value> {
+    let fields = [
+        "job_id",
+        "name",
+        "user",
+        "state",
+        "partition",
+        "nodes",
+        "cpus",
+        "time_limit",
+        "time_used",
+        "reason",
+    ];
+    parse_pipe_delimited(output, &fields)
+}
+
+/// Parse sinfo partition output (pipe-delimited).
+/// Format: Partition|Avail|Nodes(A/I/O/T)|CPUs|Memory|TimeLimit|GRES
+fn parse_sinfo_partitions(output: &str) -> Vec<serde_json::Value> {
+    let fields = [
+        "name",
+        "avail",
+        "nodes_aiot",
+        "cpus",
+        "memory",
+        "time_limit",
+        "gres",
+    ];
+    parse_pipe_delimited(output, &fields)
+}
+
+/// Parse sacctmgr account output (pipe-delimited via --parsable2).
+/// Format: Account|Description|Organization
+fn parse_sacctmgr_accounts(output: &str) -> Vec<serde_json::Value> {
+    let fields = ["account", "description", "organization"];
+    parse_pipe_delimited(output, &fields)
+}
+
+/// Generic pipe-delimited output parser.
+fn parse_pipe_delimited(output: &str, fields: &[&str]) -> Vec<serde_json::Value> {
+    output
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| {
+            let parts: Vec<&str> = line.split('|').collect();
+            if parts.len() < fields.len() {
+                return None;
+            }
+            let mut map = serde_json::Map::new();
+            for (i, &field) in fields.iter().enumerate() {
+                map.insert(
+                    field.to_string(),
+                    serde_json::Value::String(parts[i].trim().to_string()),
+                );
+            }
+            Some(serde_json::Value::Object(map))
+        })
+        .collect()
+}
+
+/// Parse `uniq -c` output into a map of value -> count.
+fn parse_uniq_counts(output: &str) -> HashMap<String, i64> {
+    let mut map = HashMap::new();
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Some((count_str, value)) = trimmed.split_once(char::is_whitespace) {
+            if let Ok(count) = count_str.trim().parse::<i64>() {
+                map.insert(value.trim().to_string(), count);
+            }
+        }
+    }
+    map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_sinfo_nodes() {
+        let output = "node01|idle|32|128000|compute|none|0.50|120000\nnode02|allocated|64|256000|gpu|none|45.2|100000\n";
+        let nodes = parse_sinfo_nodes(output);
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(nodes[0]["name"], "node01");
+        assert_eq!(nodes[0]["state"], "idle");
+        assert_eq!(nodes[0]["cpus"], "32");
+        assert_eq!(nodes[0]["memory"], "128000");
+        assert_eq!(nodes[0]["partition"], "compute");
+        assert_eq!(nodes[1]["name"], "node02");
+        assert_eq!(nodes[1]["state"], "allocated");
+        assert_eq!(nodes[1]["cpus"], "64");
+    }
+
+    #[test]
+    fn test_parse_sinfo_nodes_empty() {
+        let nodes = parse_sinfo_nodes("");
+        assert!(nodes.is_empty());
+    }
+
+    #[test]
+    fn test_parse_squeue_jobs() {
+        let output = "12345|my_job|alice|RUNNING|compute|4|128|2-00:00:00|0:05:30|(Resources)\n";
+        let jobs = parse_squeue_jobs(output);
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0]["job_id"], "12345");
+        assert_eq!(jobs[0]["name"], "my_job");
+        assert_eq!(jobs[0]["user"], "alice");
+        assert_eq!(jobs[0]["state"], "RUNNING");
+        assert_eq!(jobs[0]["partition"], "compute");
+        assert_eq!(jobs[0]["nodes"], "4");
+        assert_eq!(jobs[0]["cpus"], "128");
+    }
+
+    #[test]
+    fn test_parse_squeue_jobs_multiple() {
+        let output = "100|job_a|bob|PENDING|gpu|1|8|1:00:00|0:00:00|(Priority)\n200|job_b|carol|RUNNING|compute|2|16|4:00:00|1:30:00|(None)\n";
+        let jobs = parse_squeue_jobs(output);
+        assert_eq!(jobs.len(), 2);
+        assert_eq!(jobs[0]["job_id"], "100");
+        assert_eq!(jobs[1]["job_id"], "200");
+        assert_eq!(jobs[1]["state"], "RUNNING");
+    }
+
+    #[test]
+    fn test_parse_sinfo_partitions() {
+        let output = "compute|up|10/5/0/15|32|128000|infinite|(null)\ngpu|up|2/0/0/2|64|256000|7-00:00:00|gpu:4\n";
+        let parts = parse_sinfo_partitions(output);
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0]["name"], "compute");
+        assert_eq!(parts[0]["avail"], "up");
+        assert_eq!(parts[0]["nodes_aiot"], "10/5/0/15");
+        assert_eq!(parts[1]["name"], "gpu");
+        assert_eq!(parts[1]["gres"], "gpu:4");
+    }
+
+    #[test]
+    fn test_parse_sacctmgr_accounts() {
+        let output = "research|Research group|Physics\nengineering|Engineering team|CS\n";
+        let accounts = parse_sacctmgr_accounts(output);
+        assert_eq!(accounts.len(), 2);
+        assert_eq!(accounts[0]["account"], "research");
+        assert_eq!(accounts[0]["description"], "Research group");
+        assert_eq!(accounts[0]["organization"], "Physics");
+        assert_eq!(accounts[1]["account"], "engineering");
+    }
+
+    #[test]
+    fn test_parse_uniq_counts() {
+        let output = "     10 idle\n      5 allocated\n      2 drained\n";
+        let counts = parse_uniq_counts(output);
+        assert_eq!(counts.get("idle"), Some(&10));
+        assert_eq!(counts.get("allocated"), Some(&5));
+        assert_eq!(counts.get("drained"), Some(&2));
+    }
+
+    #[test]
+    fn test_parse_uniq_counts_empty() {
+        let counts = parse_uniq_counts("");
+        assert!(counts.is_empty());
+    }
+
+    #[test]
+    fn test_parse_pipe_delimited_short_line() {
+        let output = "only_one_field\n";
+        let fields = ["a", "b", "c"];
+        let result = parse_pipe_delimited(output, &fields);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_pipe_delimited_extra_fields() {
+        let output = "a|b|c|d|e\n";
+        let fields = ["f1", "f2", "f3"];
+        let result = parse_pipe_delimited(output, &fields);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0]["f1"], "a");
+        assert_eq!(result[0]["f3"], "c");
+    }
+}

--- a/src/modules/hpc/slurm_job.rs
+++ b/src/modules/hpc/slurm_job.rs
@@ -1,0 +1,544 @@
+//! Slurm job management module
+//!
+//! Submit, cancel, and query Slurm jobs via sbatch/scancel/squeue/sacct.
+//!
+//! # Parameters
+//!
+//! - `action` (required): "submit", "cancel", or "status"
+//! - `script` (optional): Inline job script content (for submit)
+//! - `script_path` (optional): Path to job script file (for submit)
+//! - `job_name` (optional): Job name (--job-name for sbatch, used for idempotency)
+//! - `partition` (optional): Target partition (--partition)
+//! - `nodes` (optional): Number of nodes (--nodes)
+//! - `ntasks` (optional): Number of tasks (--ntasks)
+//! - `time_limit` (optional): Wall time limit (--time)
+//! - `output` (optional): stdout file path (--output)
+//! - `error` (optional): stderr file path (--error)
+//! - `extra_args` (optional): Additional sbatch arguments as a string
+//! - `job_id` (required for cancel/status): Job ID to operate on
+//! - `signal` (optional): Signal to send on cancel (e.g. "SIGTERM")
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::runtime::Handle;
+
+use crate::connection::{Connection, ExecuteOptions};
+use crate::modules::{
+    Module, ModuleContext, ModuleError, ModuleOutput, ModuleParams, ModuleResult, ParamExt,
+    ParallelizationHint,
+};
+
+fn get_exec_options(context: &ModuleContext) -> ExecuteOptions {
+    let mut options = ExecuteOptions::new();
+    if context.r#become {
+        options = options.with_escalation(context.become_user.clone());
+        if let Some(ref method) = context.become_method {
+            options.escalate_method = Some(method.clone());
+        }
+        if let Some(ref password) = context.become_password {
+            options.escalate_password = Some(password.clone());
+        }
+    }
+    options
+}
+
+fn run_cmd(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<(bool, String, String)> {
+    let options = get_exec_options(context);
+    let result = Handle::current()
+        .block_on(async { connection.execute(cmd, Some(options)).await })
+        .map_err(|e| ModuleError::ExecutionFailed(format!("Connection error: {}", e)))?;
+    Ok((result.success, result.stdout, result.stderr))
+}
+
+fn run_cmd_ok(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<String> {
+    let (success, stdout, stderr) = run_cmd(connection, cmd, context)?;
+    if !success {
+        return Err(ModuleError::ExecutionFailed(format!(
+            "Command failed: {}",
+            stderr.trim()
+        )));
+    }
+    Ok(stdout)
+}
+
+pub struct SlurmJobModule;
+
+impl Module for SlurmJobModule {
+    fn name(&self) -> &'static str {
+        "slurm_job"
+    }
+
+    fn description(&self) -> &'static str {
+        "Submit, cancel, and query Slurm jobs (sbatch/scancel/squeue/sacct)"
+    }
+
+    fn parallelization_hint(&self) -> ParallelizationHint {
+        ParallelizationHint::FullyParallel
+    }
+
+    fn execute(
+        &self,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let connection = context
+            .connection
+            .as_ref()
+            .ok_or_else(|| ModuleError::ExecutionFailed("No connection available".to_string()))?;
+
+        let action = params.get_string_required("action")?;
+
+        match action.as_str() {
+            "submit" => self.action_submit(connection, params, context),
+            "cancel" => self.action_cancel(connection, params, context),
+            "status" => self.action_status(connection, params, context),
+            _ => Err(ModuleError::InvalidParameter(format!(
+                "Invalid action '{}'. Must be 'submit', 'cancel', or 'status'",
+                action
+            ))),
+        }
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &["action"]
+    }
+
+    fn optional_params(&self) -> HashMap<&'static str, serde_json::Value> {
+        let mut m = HashMap::new();
+        m.insert("script", serde_json::json!(null));
+        m.insert("script_path", serde_json::json!(null));
+        m.insert("job_name", serde_json::json!(null));
+        m.insert("partition", serde_json::json!(null));
+        m.insert("nodes", serde_json::json!(null));
+        m.insert("ntasks", serde_json::json!(null));
+        m.insert("time_limit", serde_json::json!(null));
+        m.insert("output", serde_json::json!(null));
+        m.insert("error", serde_json::json!(null));
+        m.insert("extra_args", serde_json::json!(null));
+        m.insert("job_id", serde_json::json!(null));
+        m.insert("signal", serde_json::json!(null));
+        m
+    }
+}
+
+impl SlurmJobModule {
+    fn action_submit(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let job_name = params.get_string("job_name")?;
+
+        // Idempotency: check if a job with this name is already pending/running
+        if let Some(ref name) = job_name {
+            let (ok, stdout, _) = run_cmd(
+                connection,
+                &format!(
+                    "squeue --noheader --name={} -o '%i|%T' 2>/dev/null",
+                    name
+                ),
+                context,
+            )?;
+            if ok && !stdout.trim().is_empty() {
+                let active_jobs: Vec<&str> = stdout
+                    .lines()
+                    .filter(|l| {
+                        let parts: Vec<&str> = l.split('|').collect();
+                        parts.len() >= 2
+                            && (parts[1].contains("PENDING") || parts[1].contains("RUNNING"))
+                    })
+                    .collect();
+                if !active_jobs.is_empty() {
+                    let first_id = active_jobs[0].split('|').next().unwrap_or("").trim();
+                    return Ok(ModuleOutput::ok(format!(
+                        "Job '{}' is already active (job_id={})",
+                        name, first_id
+                    ))
+                    .with_data("job_id", serde_json::json!(first_id))
+                    .with_data("job_name", serde_json::json!(name))
+                    .with_data("already_active", serde_json::json!(true)));
+                }
+            }
+        }
+
+        if context.check_mode {
+            return Ok(ModuleOutput::changed("Would submit Slurm job")
+                .with_data(
+                    "job_name",
+                    serde_json::json!(job_name.as_deref().unwrap_or("")),
+                ));
+        }
+
+        // Build sbatch command
+        let cmd = build_sbatch_command(params)?;
+        let stdout = run_cmd_ok(connection, &cmd, context)?;
+
+        // Parse "Submitted batch job <ID>"
+        let job_id = parse_sbatch_output(&stdout).ok_or_else(|| {
+            ModuleError::ExecutionFailed(format!(
+                "Could not parse job ID from sbatch output: {}",
+                stdout.trim()
+            ))
+        })?;
+
+        Ok(ModuleOutput::changed(format!(
+            "Submitted batch job {}",
+            job_id
+        ))
+        .with_data("job_id", serde_json::json!(job_id))
+        .with_data(
+            "job_name",
+            serde_json::json!(job_name.as_deref().unwrap_or("")),
+        ))
+    }
+
+    fn action_cancel(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let job_id = params.get_string_required("job_id")?;
+
+        // Check if job is still active
+        let (ok, stdout, _) = run_cmd(
+            connection,
+            &format!("squeue --noheader -j {} -o '%T' 2>/dev/null", job_id),
+            context,
+        )?;
+
+        if !ok || stdout.trim().is_empty() {
+            return Ok(ModuleOutput::ok(format!(
+                "Job {} is not active (already completed or unknown)",
+                job_id
+            ))
+            .with_data("job_id", serde_json::json!(job_id)));
+        }
+
+        if context.check_mode {
+            return Ok(
+                ModuleOutput::changed(format!("Would cancel job {}", job_id))
+                    .with_data("job_id", serde_json::json!(job_id)),
+            );
+        }
+
+        let mut cmd = format!("scancel {}", job_id);
+        if let Some(signal) = params.get_string("signal")? {
+            cmd = format!("scancel --signal={} {}", signal, job_id);
+        }
+
+        run_cmd_ok(connection, &cmd, context)?;
+
+        Ok(
+            ModuleOutput::changed(format!("Cancelled job {}", job_id))
+                .with_data("job_id", serde_json::json!(job_id)),
+        )
+    }
+
+    fn action_status(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let job_id = params.get_string_required("job_id")?;
+
+        // Try squeue first (active jobs)
+        let (ok, stdout, _) = run_cmd(
+            connection,
+            &format!(
+                "squeue --noheader -j {} -o '%i|%j|%u|%T|%P|%D|%C|%l|%M|%R' 2>/dev/null",
+                job_id
+            ),
+            context,
+        )?;
+
+        if ok && !stdout.trim().is_empty() {
+            let fields = [
+                "job_id",
+                "name",
+                "user",
+                "state",
+                "partition",
+                "nodes",
+                "cpus",
+                "time_limit",
+                "time_used",
+                "reason",
+            ];
+            let jobs = parse_pipe_delimited(&stdout, &fields);
+            if let Some(job) = jobs.into_iter().next() {
+                return Ok(ModuleOutput::ok(format!("Job {} is active", job_id))
+                    .with_data("job", job)
+                    .with_data("source", serde_json::json!("squeue")));
+            }
+        }
+
+        // Fallback to sacct for completed jobs
+        let (ok2, stdout2, _) = run_cmd(
+            connection,
+            &format!(
+                "sacct --noheader --parsable2 -j {} --format=JobID,JobName,User,State,Partition,NNodes,NCPUs,Timelimit,Elapsed,ExitCode 2>/dev/null",
+                job_id
+            ),
+            context,
+        )?;
+
+        if ok2 && !stdout2.trim().is_empty() {
+            let fields = [
+                "job_id",
+                "name",
+                "user",
+                "state",
+                "partition",
+                "nodes",
+                "cpus",
+                "time_limit",
+                "elapsed",
+                "exit_code",
+            ];
+            let jobs = parse_pipe_delimited(&stdout2, &fields);
+            if let Some(job) = jobs.into_iter().next() {
+                return Ok(
+                    ModuleOutput::ok(format!("Job {} found in accounting", job_id))
+                        .with_data("job", job)
+                        .with_data("source", serde_json::json!("sacct")),
+                );
+            }
+        }
+
+        Err(ModuleError::ExecutionFailed(format!(
+            "Job {} not found in squeue or sacct",
+            job_id
+        )))
+    }
+}
+
+/// Build an sbatch command from parameters.
+fn build_sbatch_command(params: &ModuleParams) -> ModuleResult<String> {
+    let script = params.get_string("script")?;
+    let script_path = params.get_string("script_path")?;
+
+    if script.is_none() && script_path.is_none() {
+        return Err(ModuleError::MissingParameter(
+            "Either 'script' or 'script_path' is required for submit".to_string(),
+        ));
+    }
+
+    let mut args = Vec::new();
+
+    if let Some(name) = params.get_string("job_name")? {
+        args.push(format!("--job-name={}", name));
+    }
+    if let Some(partition) = params.get_string("partition")? {
+        args.push(format!("--partition={}", partition));
+    }
+    if let Some(nodes) = params.get_string("nodes")? {
+        args.push(format!("--nodes={}", nodes));
+    }
+    if let Some(ntasks) = params.get_string("ntasks")? {
+        args.push(format!("--ntasks={}", ntasks));
+    }
+    if let Some(time_limit) = params.get_string("time_limit")? {
+        args.push(format!("--time={}", time_limit));
+    }
+    if let Some(output) = params.get_string("output")? {
+        args.push(format!("--output={}", output));
+    }
+    if let Some(error) = params.get_string("error")? {
+        args.push(format!("--error={}", error));
+    }
+    if let Some(extra) = params.get_string("extra_args")? {
+        args.push(extra);
+    }
+
+    let args_str = args.join(" ");
+
+    if let Some(path) = script_path {
+        Ok(format!("sbatch {} {}", args_str, path).trim().to_string())
+    } else {
+        let script_content = script.unwrap();
+        // Use heredoc for inline script
+        let escaped = script_content.replace('\'', "'\\''");
+        Ok(format!(
+            "sbatch {} --wrap '{}'",
+            args_str, escaped
+        )
+        .trim()
+        .to_string())
+    }
+}
+
+/// Parse sbatch output to extract job ID.
+/// Expected format: "Submitted batch job 12345"
+fn parse_sbatch_output(output: &str) -> Option<String> {
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("Submitted batch job ") {
+            return trimmed
+                .strip_prefix("Submitted batch job ")
+                .map(|s| s.trim().to_string());
+        }
+    }
+    None
+}
+
+/// Generic pipe-delimited output parser.
+fn parse_pipe_delimited(output: &str, fields: &[&str]) -> Vec<serde_json::Value> {
+    output
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| {
+            let parts: Vec<&str> = line.split('|').collect();
+            if parts.len() < fields.len() {
+                return None;
+            }
+            let mut map = serde_json::Map::new();
+            for (i, &field) in fields.iter().enumerate() {
+                map.insert(
+                    field.to_string(),
+                    serde_json::Value::String(parts[i].trim().to_string()),
+                );
+            }
+            Some(serde_json::Value::Object(map))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_sbatch_output() {
+        assert_eq!(
+            parse_sbatch_output("Submitted batch job 12345\n"),
+            Some("12345".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_sbatch_output_with_prefix() {
+        let output = "Some warning message\nSubmitted batch job 99999\n";
+        assert_eq!(parse_sbatch_output(output), Some("99999".to_string()));
+    }
+
+    #[test]
+    fn test_parse_sbatch_output_empty() {
+        assert_eq!(parse_sbatch_output(""), None);
+    }
+
+    #[test]
+    fn test_parse_sbatch_output_no_match() {
+        assert_eq!(parse_sbatch_output("Error: invalid job\n"), None);
+    }
+
+    #[test]
+    fn test_build_sbatch_command_script_path() {
+        let mut params = ModuleParams::new();
+        params.insert("script_path".to_string(), serde_json::json!("/tmp/job.sh"));
+        params.insert("job_name".to_string(), serde_json::json!("test_job"));
+        params.insert("partition".to_string(), serde_json::json!("compute"));
+        params.insert("nodes".to_string(), serde_json::json!("4"));
+        params.insert("time_limit".to_string(), serde_json::json!("2:00:00"));
+
+        let cmd = build_sbatch_command(&params).unwrap();
+        assert!(cmd.contains("sbatch"));
+        assert!(cmd.contains("--job-name=test_job"));
+        assert!(cmd.contains("--partition=compute"));
+        assert!(cmd.contains("--nodes=4"));
+        assert!(cmd.contains("--time=2:00:00"));
+        assert!(cmd.contains("/tmp/job.sh"));
+    }
+
+    #[test]
+    fn test_build_sbatch_command_inline_script() {
+        let mut params = ModuleParams::new();
+        params.insert(
+            "script".to_string(),
+            serde_json::json!("#!/bin/bash\necho hello"),
+        );
+        params.insert("job_name".to_string(), serde_json::json!("inline_job"));
+
+        let cmd = build_sbatch_command(&params).unwrap();
+        assert!(cmd.contains("sbatch"));
+        assert!(cmd.contains("--job-name=inline_job"));
+        assert!(cmd.contains("--wrap"));
+    }
+
+    #[test]
+    fn test_build_sbatch_command_no_script() {
+        let params = ModuleParams::new();
+        let result = build_sbatch_command(&params);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_build_sbatch_command_extra_args() {
+        let mut params = ModuleParams::new();
+        params.insert("script_path".to_string(), serde_json::json!("/job.sh"));
+        params.insert(
+            "extra_args".to_string(),
+            serde_json::json!("--mem=4G --gres=gpu:1"),
+        );
+
+        let cmd = build_sbatch_command(&params).unwrap();
+        assert!(cmd.contains("--mem=4G --gres=gpu:1"));
+        assert!(cmd.contains("/job.sh"));
+    }
+
+    #[test]
+    fn test_build_sbatch_command_all_params() {
+        let mut params = ModuleParams::new();
+        params.insert("script_path".to_string(), serde_json::json!("/job.sh"));
+        params.insert("job_name".to_string(), serde_json::json!("full_job"));
+        params.insert("partition".to_string(), serde_json::json!("gpu"));
+        params.insert("nodes".to_string(), serde_json::json!("2"));
+        params.insert("ntasks".to_string(), serde_json::json!("8"));
+        params.insert("time_limit".to_string(), serde_json::json!("4:00:00"));
+        params.insert(
+            "output".to_string(),
+            serde_json::json!("/logs/out_%j.log"),
+        );
+        params.insert(
+            "error".to_string(),
+            serde_json::json!("/logs/err_%j.log"),
+        );
+
+        let cmd = build_sbatch_command(&params).unwrap();
+        assert!(cmd.contains("--job-name=full_job"));
+        assert!(cmd.contains("--partition=gpu"));
+        assert!(cmd.contains("--nodes=2"));
+        assert!(cmd.contains("--ntasks=8"));
+        assert!(cmd.contains("--time=4:00:00"));
+        assert!(cmd.contains("--output=/logs/out_%j.log"));
+        assert!(cmd.contains("--error=/logs/err_%j.log"));
+    }
+
+    #[test]
+    fn test_parse_pipe_delimited_jobs() {
+        let output = "12345|my_job|alice|RUNNING|compute|4|128|2-00:00:00|0:05:30|(Resources)\n";
+        let fields = ["job_id", "name", "user", "state", "partition", "nodes", "cpus", "time_limit", "time_used", "reason"];
+        let jobs = parse_pipe_delimited(output, &fields);
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0]["job_id"], "12345");
+        assert_eq!(jobs[0]["state"], "RUNNING");
+    }
+
+    #[test]
+    fn test_parse_pipe_delimited_empty() {
+        let fields = ["a", "b"];
+        let result = parse_pipe_delimited("", &fields);
+        assert!(result.is_empty());
+    }
+}

--- a/src/modules/hpc/slurm_queue.rs
+++ b/src/modules/hpc/slurm_queue.rs
@@ -1,0 +1,546 @@
+//! Slurm partition (queue) management module
+//!
+//! Manage partitions at runtime via scontrol create/update/delete.
+//!
+//! # Parameters
+//!
+//! - `action` (required): "create", "update", "delete", or "state"
+//! - `name` (required): Partition name
+//! - `nodes` (optional): Node list for the partition
+//! - `default` (optional): Whether this is the default partition ("yes"/"no")
+//! - `max_time` (optional): Maximum time limit (e.g. "7-00:00:00")
+//! - `max_nodes` (optional): Maximum nodes per job
+//! - `state` (optional): Partition state ("UP" or "DOWN")
+//! - `priority_tier` (optional): Priority tier value
+//! - `allow_groups` (optional): Allowed groups (comma-separated)
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::runtime::Handle;
+
+use crate::connection::{Connection, ExecuteOptions};
+use crate::modules::{
+    Module, ModuleContext, ModuleError, ModuleOutput, ModuleParams, ModuleResult, ParamExt,
+    ParallelizationHint,
+};
+
+fn get_exec_options(context: &ModuleContext) -> ExecuteOptions {
+    let mut options = ExecuteOptions::new();
+    if context.r#become {
+        options = options.with_escalation(context.become_user.clone());
+        if let Some(ref method) = context.become_method {
+            options.escalate_method = Some(method.clone());
+        }
+        if let Some(ref password) = context.become_password {
+            options.escalate_password = Some(password.clone());
+        }
+    }
+    options
+}
+
+fn run_cmd(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<(bool, String, String)> {
+    let options = get_exec_options(context);
+    let result = Handle::current()
+        .block_on(async { connection.execute(cmd, Some(options)).await })
+        .map_err(|e| ModuleError::ExecutionFailed(format!("Connection error: {}", e)))?;
+    Ok((result.success, result.stdout, result.stderr))
+}
+
+fn run_cmd_ok(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<String> {
+    let (success, stdout, stderr) = run_cmd(connection, cmd, context)?;
+    if !success {
+        return Err(ModuleError::ExecutionFailed(format!(
+            "Command failed: {}",
+            stderr.trim()
+        )));
+    }
+    Ok(stdout)
+}
+
+pub struct SlurmQueueModule;
+
+impl Module for SlurmQueueModule {
+    fn name(&self) -> &'static str {
+        "slurm_queue"
+    }
+
+    fn description(&self) -> &'static str {
+        "Manage Slurm partitions at runtime (create, update, delete, state)"
+    }
+
+    fn parallelization_hint(&self) -> ParallelizationHint {
+        ParallelizationHint::GlobalExclusive
+    }
+
+    fn execute(
+        &self,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let connection = context
+            .connection
+            .as_ref()
+            .ok_or_else(|| ModuleError::ExecutionFailed("No connection available".to_string()))?;
+
+        let action = params.get_string_required("action")?;
+        let name = params.get_string_required("name")?;
+
+        match action.as_str() {
+            "create" => self.action_create(connection, &name, params, context),
+            "update" => self.action_update(connection, &name, params, context),
+            "delete" => self.action_delete(connection, &name, context),
+            "state" => self.action_state(connection, &name, params, context),
+            _ => Err(ModuleError::InvalidParameter(format!(
+                "Invalid action '{}'. Must be 'create', 'update', 'delete', or 'state'",
+                action
+            ))),
+        }
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &["action", "name"]
+    }
+
+    fn optional_params(&self) -> HashMap<&'static str, serde_json::Value> {
+        let mut m = HashMap::new();
+        m.insert("nodes", serde_json::json!(null));
+        m.insert("default", serde_json::json!(null));
+        m.insert("max_time", serde_json::json!(null));
+        m.insert("max_nodes", serde_json::json!(null));
+        m.insert("state", serde_json::json!(null));
+        m.insert("priority_tier", serde_json::json!(null));
+        m.insert("allow_groups", serde_json::json!(null));
+        m
+    }
+}
+
+impl SlurmQueueModule {
+    fn get_partition(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        name: &str,
+        context: &ModuleContext,
+    ) -> ModuleResult<Option<HashMap<String, String>>> {
+        let (ok, stdout, _) = run_cmd(
+            connection,
+            &format!("scontrol show partition {} -o 2>/dev/null", name),
+            context,
+        )?;
+        if !ok || stdout.trim().is_empty() || stdout.contains("not found") {
+            return Ok(None);
+        }
+        Ok(Some(parse_scontrol_oneliner(&stdout)))
+    }
+
+    fn action_create(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        name: &str,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        // Idempotency: check if partition already exists
+        if let Some(existing) = self.get_partition(connection, name, context)? {
+            return Ok(
+                ModuleOutput::ok(format!("Partition '{}' already exists", name))
+                    .with_data("partition", serde_json::json!(existing)),
+            );
+        }
+
+        if context.check_mode {
+            return Ok(
+                ModuleOutput::changed(format!("Would create partition '{}'", name))
+                    .with_data("name", serde_json::json!(name)),
+            );
+        }
+
+        let props = build_partition_properties(params)?;
+        let cmd = format!("scontrol create PartitionName={} {}", name, props);
+        run_cmd_ok(connection, &cmd, context)?;
+
+        let current = self.get_partition(connection, name, context)?;
+
+        Ok(
+            ModuleOutput::changed(format!("Created partition '{}'", name))
+                .with_data("name", serde_json::json!(name))
+                .with_data("partition", serde_json::json!(current)),
+        )
+    }
+
+    fn action_update(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        name: &str,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        // Check existence
+        let current = self.get_partition(connection, name, context)?.ok_or_else(|| {
+            ModuleError::ExecutionFailed(format!(
+                "Partition '{}' does not exist; cannot update",
+                name
+            ))
+        })?;
+
+        // Build desired properties and compare
+        let desired = build_desired_properties(params)?;
+        let changes = compute_property_changes(&current, &desired);
+
+        if changes.is_empty() {
+            return Ok(
+                ModuleOutput::ok(format!("Partition '{}' is already up to date", name))
+                    .with_data("partition", serde_json::json!(current)),
+            );
+        }
+
+        if context.check_mode {
+            return Ok(ModuleOutput::changed(format!(
+                "Would update partition '{}': {}",
+                name,
+                changes
+                    .iter()
+                    .map(|(k, v)| format!("{}={}", k, v))
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            ))
+            .with_data("changes", serde_json::json!(changes)));
+        }
+
+        let update_str: String = changes
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let cmd = format!(
+            "scontrol update PartitionName={} {}",
+            name, update_str
+        );
+        run_cmd_ok(connection, &cmd, context)?;
+
+        let updated = self.get_partition(connection, name, context)?;
+
+        Ok(
+            ModuleOutput::changed(format!("Updated partition '{}'", name))
+                .with_data("name", serde_json::json!(name))
+                .with_data("changes", serde_json::json!(changes))
+                .with_data("partition", serde_json::json!(updated)),
+        )
+    }
+
+    fn action_delete(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        name: &str,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        // Idempotency: check if partition exists
+        if self.get_partition(connection, name, context)?.is_none() {
+            return Ok(
+                ModuleOutput::ok(format!("Partition '{}' does not exist", name))
+                    .with_data("name", serde_json::json!(name)),
+            );
+        }
+
+        if context.check_mode {
+            return Ok(
+                ModuleOutput::changed(format!("Would delete partition '{}'", name))
+                    .with_data("name", serde_json::json!(name)),
+            );
+        }
+
+        run_cmd_ok(
+            connection,
+            &format!("scontrol delete PartitionName={}", name),
+            context,
+        )?;
+
+        Ok(
+            ModuleOutput::changed(format!("Deleted partition '{}'", name))
+                .with_data("name", serde_json::json!(name)),
+        )
+    }
+
+    fn action_state(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        name: &str,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let desired_state = params.get_string_required("state")?;
+        let desired_upper = desired_state.to_uppercase();
+
+        if desired_upper != "UP" && desired_upper != "DOWN" {
+            return Err(ModuleError::InvalidParameter(format!(
+                "Invalid state '{}'. Must be 'UP' or 'DOWN'",
+                desired_state
+            )));
+        }
+
+        let current = self.get_partition(connection, name, context)?.ok_or_else(|| {
+            ModuleError::ExecutionFailed(format!("Partition '{}' does not exist", name))
+        })?;
+
+        let current_state = current.get("State").map(|s| s.to_uppercase());
+        if current_state.as_deref() == Some(&desired_upper) {
+            return Ok(ModuleOutput::ok(format!(
+                "Partition '{}' is already {}",
+                name, desired_upper
+            ))
+            .with_data("state", serde_json::json!(desired_upper)));
+        }
+
+        if context.check_mode {
+            return Ok(ModuleOutput::changed(format!(
+                "Would set partition '{}' to {}",
+                name, desired_upper
+            ))
+            .with_data("state", serde_json::json!(desired_upper)));
+        }
+
+        run_cmd_ok(
+            connection,
+            &format!(
+                "scontrol update PartitionName={} State={}",
+                name, desired_upper
+            ),
+            context,
+        )?;
+
+        Ok(ModuleOutput::changed(format!(
+            "Set partition '{}' to {}",
+            name, desired_upper
+        ))
+        .with_data("name", serde_json::json!(name))
+        .with_data("state", serde_json::json!(desired_upper)))
+    }
+}
+
+/// Parse scontrol one-liner output into key-value HashMap.
+/// Format: "Key1=Value1 Key2=Value2 Key3=Value3"
+fn parse_scontrol_oneliner(output: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    let line = output.lines().next().unwrap_or("").trim();
+    for token in line.split_whitespace() {
+        if let Some((key, value)) = token.split_once('=') {
+            map.insert(key.to_string(), value.to_string());
+        }
+    }
+    map
+}
+
+/// Build scontrol partition property string from params.
+fn build_partition_properties(params: &ModuleParams) -> ModuleResult<String> {
+    let mut props = Vec::new();
+
+    if let Some(nodes) = params.get_string("nodes")? {
+        props.push(format!("Nodes={}", nodes));
+    }
+    if let Some(default) = params.get_string("default")? {
+        let val = if default.to_lowercase() == "yes" || default.to_lowercase() == "true" {
+            "YES"
+        } else {
+            "NO"
+        };
+        props.push(format!("Default={}", val));
+    }
+    if let Some(max_time) = params.get_string("max_time")? {
+        props.push(format!("MaxTime={}", max_time));
+    }
+    if let Some(max_nodes) = params.get_string("max_nodes")? {
+        props.push(format!("MaxNodes={}", max_nodes));
+    }
+    if let Some(state) = params.get_string("state")? {
+        props.push(format!("State={}", state.to_uppercase()));
+    }
+    if let Some(priority) = params.get_string("priority_tier")? {
+        props.push(format!("PriorityTier={}", priority));
+    }
+    if let Some(groups) = params.get_string("allow_groups")? {
+        props.push(format!("AllowGroups={}", groups));
+    }
+
+    Ok(props.join(" "))
+}
+
+/// Build a map of desired scontrol property names to values (using Slurm key names).
+fn build_desired_properties(params: &ModuleParams) -> ModuleResult<HashMap<String, String>> {
+    let mut desired = HashMap::new();
+    if let Some(nodes) = params.get_string("nodes")? {
+        desired.insert("Nodes".to_string(), nodes);
+    }
+    if let Some(default) = params.get_string("default")? {
+        let val = if default.to_lowercase() == "yes" || default.to_lowercase() == "true" {
+            "YES".to_string()
+        } else {
+            "NO".to_string()
+        };
+        desired.insert("Default".to_string(), val);
+    }
+    if let Some(max_time) = params.get_string("max_time")? {
+        desired.insert("MaxTime".to_string(), max_time);
+    }
+    if let Some(max_nodes) = params.get_string("max_nodes")? {
+        desired.insert("MaxNodes".to_string(), max_nodes);
+    }
+    if let Some(state) = params.get_string("state")? {
+        desired.insert("State".to_string(), state.to_uppercase());
+    }
+    if let Some(priority) = params.get_string("priority_tier")? {
+        desired.insert("PriorityTier".to_string(), priority);
+    }
+    if let Some(groups) = params.get_string("allow_groups")? {
+        desired.insert("AllowGroups".to_string(), groups);
+    }
+    Ok(desired)
+}
+
+/// Compare desired properties against current and return only differences.
+fn compute_property_changes(
+    current: &HashMap<String, String>,
+    desired: &HashMap<String, String>,
+) -> HashMap<String, String> {
+    let mut changes = HashMap::new();
+    for (key, desired_val) in desired {
+        let needs_change = match current.get(key) {
+            Some(current_val) => current_val != desired_val,
+            None => true,
+        };
+        if needs_change {
+            changes.insert(key.clone(), desired_val.clone());
+        }
+    }
+    changes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_scontrol_oneliner() {
+        let output =
+            "PartitionName=compute AllowGroups=ALL AllowAccounts=ALL Default=YES MaxTime=UNLIMITED State=UP TotalCPUs=512 TotalNodes=16\n";
+        let map = parse_scontrol_oneliner(output);
+        assert_eq!(map.get("PartitionName"), Some(&"compute".to_string()));
+        assert_eq!(map.get("Default"), Some(&"YES".to_string()));
+        assert_eq!(map.get("State"), Some(&"UP".to_string()));
+        assert_eq!(map.get("TotalCPUs"), Some(&"512".to_string()));
+        assert_eq!(map.get("TotalNodes"), Some(&"16".to_string()));
+        assert_eq!(map.get("MaxTime"), Some(&"UNLIMITED".to_string()));
+    }
+
+    #[test]
+    fn test_parse_scontrol_oneliner_empty() {
+        let map = parse_scontrol_oneliner("");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_parse_scontrol_oneliner_no_equals() {
+        let map = parse_scontrol_oneliner("JustSomeText NoEquals Here");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_build_partition_properties() {
+        let mut params = ModuleParams::new();
+        params.insert("nodes".to_string(), serde_json::json!("node[01-10]"));
+        params.insert("default".to_string(), serde_json::json!("yes"));
+        params.insert("max_time".to_string(), serde_json::json!("7-00:00:00"));
+        params.insert("state".to_string(), serde_json::json!("up"));
+
+        let props = build_partition_properties(&params).unwrap();
+        assert!(props.contains("Nodes=node[01-10]"));
+        assert!(props.contains("Default=YES"));
+        assert!(props.contains("MaxTime=7-00:00:00"));
+        assert!(props.contains("State=UP"));
+    }
+
+    #[test]
+    fn test_build_partition_properties_empty() {
+        let params = ModuleParams::new();
+        let props = build_partition_properties(&params).unwrap();
+        assert!(props.is_empty());
+    }
+
+    #[test]
+    fn test_build_desired_properties() {
+        let mut params = ModuleParams::new();
+        params.insert("nodes".to_string(), serde_json::json!("node[01-05]"));
+        params.insert("default".to_string(), serde_json::json!("no"));
+        params.insert("priority_tier".to_string(), serde_json::json!("100"));
+
+        let desired = build_desired_properties(&params).unwrap();
+        assert_eq!(desired.get("Nodes"), Some(&"node[01-05]".to_string()));
+        assert_eq!(desired.get("Default"), Some(&"NO".to_string()));
+        assert_eq!(desired.get("PriorityTier"), Some(&"100".to_string()));
+    }
+
+    #[test]
+    fn test_compute_property_changes_no_changes() {
+        let mut current = HashMap::new();
+        current.insert("State".to_string(), "UP".to_string());
+        current.insert("Nodes".to_string(), "node[01-10]".to_string());
+
+        let mut desired = HashMap::new();
+        desired.insert("State".to_string(), "UP".to_string());
+        desired.insert("Nodes".to_string(), "node[01-10]".to_string());
+
+        let changes = compute_property_changes(&current, &desired);
+        assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn test_compute_property_changes_with_changes() {
+        let mut current = HashMap::new();
+        current.insert("State".to_string(), "UP".to_string());
+        current.insert("Nodes".to_string(), "node[01-10]".to_string());
+        current.insert("MaxTime".to_string(), "UNLIMITED".to_string());
+
+        let mut desired = HashMap::new();
+        desired.insert("State".to_string(), "DOWN".to_string());
+        desired.insert("Nodes".to_string(), "node[01-10]".to_string());
+        desired.insert("MaxTime".to_string(), "7-00:00:00".to_string());
+
+        let changes = compute_property_changes(&current, &desired);
+        assert_eq!(changes.len(), 2);
+        assert_eq!(changes.get("State"), Some(&"DOWN".to_string()));
+        assert_eq!(changes.get("MaxTime"), Some(&"7-00:00:00".to_string()));
+        assert!(!changes.contains_key("Nodes"));
+    }
+
+    #[test]
+    fn test_compute_property_changes_new_property() {
+        let current = HashMap::new();
+        let mut desired = HashMap::new();
+        desired.insert("PriorityTier".to_string(), "50".to_string());
+
+        let changes = compute_property_changes(&current, &desired);
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes.get("PriorityTier"), Some(&"50".to_string()));
+    }
+
+    #[test]
+    fn test_build_partition_properties_allow_groups() {
+        let mut params = ModuleParams::new();
+        params.insert(
+            "allow_groups".to_string(),
+            serde_json::json!("admin,research"),
+        );
+        params.insert("max_nodes".to_string(), serde_json::json!("8"));
+
+        let props = build_partition_properties(&params).unwrap();
+        assert!(props.contains("AllowGroups=admin,research"));
+        assert!(props.contains("MaxNodes=8"));
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1678,6 +1678,10 @@ impl ModuleRegistry {
             Hpc: [
                 hpc::SlurmConfigModule,
                 hpc::SlurmOpsModule,
+                hpc::SlurmJobModule,
+                hpc::SlurmInfoModule,
+                hpc::SlurmQueueModule,
+                hpc::SlurmAccountModule,
             ],
         );
 


### PR DESCRIPTION
## Summary

- Add `slurm_job` module: submit, cancel, and query Slurm jobs via sbatch/scancel/squeue/sacct with idempotent job-name checks
- Add `slurm_info` module: gather cluster state as structured facts (nodes, jobs, partitions, accounts, cluster summary)
- Add `slurm_queue` module: manage partitions at runtime via scontrol create/update/delete with property-level idempotency
- Add `slurm_account` module: manage accounts and user associations via sacctmgr with existence checks

Closes #587 (Phase 1)

## Test plan

- [x] `cargo build --features slurm` compiles cleanly
- [x] `cargo test --features slurm` — 36 unit tests pass (output parsing, command construction, parameter validation)
- [x] `cargo clippy --features slurm` — no warnings from new modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)