### PR TITLE
feat: add PBS Pro runtime integration modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ distributed = []
 hpc = ["slurm", "gpu"]
 # Slurm workload manager modules
 slurm = []
+# PBS Pro workload manager modules
+pbs = []
 # GPU management modules (NVIDIA, ROCm)
 gpu = []
 # InfiniBand / RDMA / OFED support
@@ -63,7 +65,7 @@ full-aws = ["full", "aws"]
 # Full feature set with provisioning
 full-provisioning = ["full-aws", "provisioning"]
 # Full feature set with all HPC support
-full-hpc = ["full", "hpc", "ofed", "parallel_fs", "redfish", "vsphere"]
+full-hpc = ["full", "hpc", "pbs", "ofed", "parallel_fs", "redfish", "vsphere"]
 # Pure Rust build (no C dependencies)
 pure-rust = ["russh", "local"]
 

--- a/src/modules/hpc/mod.rs
+++ b/src/modules/hpc/mod.rs
@@ -80,6 +80,12 @@ pub mod slurm_job;
 pub mod slurm_queue;
 #[cfg(feature = "slurm")]
 pub mod slurmrestd;
+#[cfg(feature = "pbs")]
+pub mod pbs_job;
+#[cfg(feature = "pbs")]
+pub mod pbs_queue;
+#[cfg(feature = "pbs")]
+pub mod pbs_server;
 pub mod toolchain;
 
 pub use boot_profile::BootProfileModule;
@@ -117,4 +123,10 @@ pub use slurm_job::SlurmJobModule;
 pub use slurm_queue::SlurmQueueModule;
 #[cfg(feature = "slurm")]
 pub use slurmrestd::SlurmrestdModule;
+#[cfg(feature = "pbs")]
+pub use pbs_job::PbsJobModule;
+#[cfg(feature = "pbs")]
+pub use pbs_queue::PbsQueueModule;
+#[cfg(feature = "pbs")]
+pub use pbs_server::PbsServerModule;
 pub use toolchain::HpcToolchainModule;

--- a/src/modules/hpc/pbs_job.rs
+++ b/src/modules/hpc/pbs_job.rs
@@ -1,0 +1,654 @@
+//! PBS Pro job management module
+//!
+//! Submit, cancel, hold, release, and query PBS jobs via qsub/qdel/qstat.
+//!
+//! # Parameters
+//!
+//! - `action` (required): "submit", "cancel", "status", "hold", or "release"
+//! - `script` (optional): Inline job script content (for submit)
+//! - `script_path` (optional): Path to job script file (for submit)
+//! - `job_name` (optional): Job name (-N for qsub, used for idempotency)
+//! - `queue` (optional): Target queue (-q)
+//! - `nodes` (optional): Number of nodes (-l nodes=N)
+//! - `ncpus` (optional): Number of CPUs per node (-l ncpus=N)
+//! - `walltime` (optional): Wall time limit (-l walltime=HH:MM:SS)
+//! - `output_path` (optional): stdout file path (-o)
+//! - `error_path` (optional): stderr file path (-e)
+//! - `extra_args` (optional): Additional qsub arguments as a string
+//! - `job_id` (required for cancel/status/hold/release): Job ID to operate on
+//! - `resource_list` (optional): Additional -l resource specifications
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::runtime::Handle;
+
+use crate::connection::{Connection, ExecuteOptions};
+use crate::modules::{
+    Module, ModuleContext, ModuleError, ModuleOutput, ModuleParams, ModuleResult, ParamExt,
+    ParallelizationHint,
+};
+
+fn get_exec_options(context: &ModuleContext) -> ExecuteOptions {
+    let mut options = ExecuteOptions::new();
+    if context.r#become {
+        options = options.with_escalation(context.become_user.clone());
+        if let Some(ref method) = context.become_method {
+            options.escalate_method = Some(method.clone());
+        }
+        if let Some(ref password) = context.become_password {
+            options.escalate_password = Some(password.clone());
+        }
+    }
+    options
+}
+
+fn run_cmd(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<(bool, String, String)> {
+    let options = get_exec_options(context);
+    let result = Handle::current()
+        .block_on(async { connection.execute(cmd, Some(options)).await })
+        .map_err(|e| ModuleError::ExecutionFailed(format!("Connection error: {}", e)))?;
+    Ok((result.success, result.stdout, result.stderr))
+}
+
+fn run_cmd_ok(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<String> {
+    let (success, stdout, stderr) = run_cmd(connection, cmd, context)?;
+    if !success {
+        return Err(ModuleError::ExecutionFailed(format!(
+            "Command failed: {}",
+            stderr.trim()
+        )));
+    }
+    Ok(stdout)
+}
+
+pub struct PbsJobModule;
+
+impl Module for PbsJobModule {
+    fn name(&self) -> &'static str {
+        "pbs_job"
+    }
+
+    fn description(&self) -> &'static str {
+        "Submit, cancel, hold, release, and query PBS Pro jobs (qsub/qdel/qstat)"
+    }
+
+    fn parallelization_hint(&self) -> ParallelizationHint {
+        ParallelizationHint::FullyParallel
+    }
+
+    fn execute(
+        &self,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let connection = context
+            .connection
+            .as_ref()
+            .ok_or_else(|| ModuleError::ExecutionFailed("No connection available".to_string()))?;
+
+        let action = params.get_string_required("action")?;
+
+        match action.as_str() {
+            "submit" => self.action_submit(connection, params, context),
+            "cancel" => self.action_cancel(connection, params, context),
+            "status" => self.action_status(connection, params, context),
+            "hold" => self.action_hold(connection, params, context),
+            "release" => self.action_release(connection, params, context),
+            _ => Err(ModuleError::InvalidParameter(format!(
+                "Invalid action '{}'. Must be 'submit', 'cancel', 'status', 'hold', or 'release'",
+                action
+            ))),
+        }
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &["action"]
+    }
+
+    fn optional_params(&self) -> HashMap<&'static str, serde_json::Value> {
+        let mut m = HashMap::new();
+        m.insert("script", serde_json::json!(null));
+        m.insert("script_path", serde_json::json!(null));
+        m.insert("job_name", serde_json::json!(null));
+        m.insert("queue", serde_json::json!(null));
+        m.insert("nodes", serde_json::json!(null));
+        m.insert("ncpus", serde_json::json!(null));
+        m.insert("walltime", serde_json::json!(null));
+        m.insert("output_path", serde_json::json!(null));
+        m.insert("error_path", serde_json::json!(null));
+        m.insert("extra_args", serde_json::json!(null));
+        m.insert("job_id", serde_json::json!(null));
+        m.insert("resource_list", serde_json::json!(null));
+        m
+    }
+}
+
+impl PbsJobModule {
+    fn action_submit(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let job_name = params.get_string("job_name")?;
+
+        // Idempotency: check if a job with this name is already active
+        if let Some(ref name) = job_name {
+            let (ok, stdout, _) = run_cmd(
+                connection,
+                "qstat -f -F json 2>/dev/null",
+                context,
+            )?;
+            if ok && !stdout.trim().is_empty() {
+                if let Some(existing_id) = find_active_job_by_name(&stdout, name) {
+                    return Ok(ModuleOutput::ok(format!(
+                        "Job '{}' is already active (job_id={})",
+                        name, existing_id
+                    ))
+                    .with_data("job_id", serde_json::json!(existing_id))
+                    .with_data("job_name", serde_json::json!(name))
+                    .with_data("already_active", serde_json::json!(true)));
+                }
+            }
+        }
+
+        if context.check_mode {
+            return Ok(ModuleOutput::changed("Would submit PBS job").with_data(
+                "job_name",
+                serde_json::json!(job_name.as_deref().unwrap_or("")),
+            ));
+        }
+
+        // Build qsub command
+        let cmd = build_qsub_command(params)?;
+        let stdout = run_cmd_ok(connection, &cmd, context)?;
+
+        // Parse job ID from qsub output
+        let job_id = parse_qsub_output(&stdout).ok_or_else(|| {
+            ModuleError::ExecutionFailed(format!(
+                "Could not parse job ID from qsub output: {}",
+                stdout.trim()
+            ))
+        })?;
+
+        Ok(ModuleOutput::changed(format!("Submitted job {}", job_id))
+            .with_data("job_id", serde_json::json!(job_id))
+            .with_data(
+                "job_name",
+                serde_json::json!(job_name.as_deref().unwrap_or("")),
+            ))
+    }
+
+    fn action_cancel(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let job_id = params.get_string_required("job_id")?;
+
+        // Check if job is in a terminal state or not found
+        let (ok, stdout, _) = run_cmd(
+            connection,
+            &format!("qstat -f -F json {} 2>/dev/null", job_id),
+            context,
+        )?;
+
+        if !ok || stdout.trim().is_empty() {
+            return Ok(ModuleOutput::ok(format!(
+                "Job {} is not found (already completed or unknown)",
+                job_id
+            ))
+            .with_data("job_id", serde_json::json!(job_id)));
+        }
+
+        // Check job state — skip if terminal (F=Finished, X=Exiting)
+        if let Some(state) = extract_job_state(&stdout, &job_id) {
+            if state == "F" || state == "X" {
+                return Ok(ModuleOutput::ok(format!(
+                    "Job {} is already in terminal state '{}'",
+                    job_id, state
+                ))
+                .with_data("job_id", serde_json::json!(job_id))
+                .with_data("state", serde_json::json!(state)));
+            }
+        }
+
+        if context.check_mode {
+            return Ok(
+                ModuleOutput::changed(format!("Would cancel job {}", job_id))
+                    .with_data("job_id", serde_json::json!(job_id)),
+            );
+        }
+
+        run_cmd_ok(connection, &format!("qdel {}", job_id), context)?;
+
+        Ok(
+            ModuleOutput::changed(format!("Cancelled job {}", job_id))
+                .with_data("job_id", serde_json::json!(job_id)),
+        )
+    }
+
+    fn action_status(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let job_id = params.get_string_required("job_id")?;
+
+        let stdout = run_cmd_ok(
+            connection,
+            &format!("qstat -f -F json {} 2>/dev/null", job_id),
+            context,
+        )?;
+
+        let jobs = parse_pbs_json_jobs(&stdout);
+
+        if jobs.is_null() || jobs.as_object().is_none_or(|o| o.is_empty()) {
+            return Err(ModuleError::ExecutionFailed(format!(
+                "Job {} not found",
+                job_id
+            )));
+        }
+
+        Ok(ModuleOutput::ok(format!("Job {} status retrieved", job_id))
+            .with_data("jobs", jobs)
+            .with_data("job_id", serde_json::json!(job_id)))
+    }
+
+    fn action_hold(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let job_id = params.get_string_required("job_id")?;
+
+        // Check current hold state
+        let (ok, stdout, _) = run_cmd(
+            connection,
+            &format!("qstat -f -F json {} 2>/dev/null", job_id),
+            context,
+        )?;
+
+        if !ok || stdout.trim().is_empty() {
+            return Err(ModuleError::ExecutionFailed(format!(
+                "Job {} not found",
+                job_id
+            )));
+        }
+
+        // Check Hold_Types — skip if already held
+        if let Some(hold_types) = extract_job_attribute(&stdout, &job_id, "Hold_Types") {
+            if hold_types != "n" && !hold_types.is_empty() {
+                return Ok(ModuleOutput::ok(format!(
+                    "Job {} is already held (Hold_Types={})",
+                    job_id, hold_types
+                ))
+                .with_data("job_id", serde_json::json!(job_id))
+                .with_data("hold_types", serde_json::json!(hold_types)));
+            }
+        }
+
+        if context.check_mode {
+            return Ok(
+                ModuleOutput::changed(format!("Would hold job {}", job_id))
+                    .with_data("job_id", serde_json::json!(job_id)),
+            );
+        }
+
+        run_cmd_ok(connection, &format!("qhold {}", job_id), context)?;
+
+        Ok(
+            ModuleOutput::changed(format!("Held job {}", job_id))
+                .with_data("job_id", serde_json::json!(job_id)),
+        )
+    }
+
+    fn action_release(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let job_id = params.get_string_required("job_id")?;
+
+        // Check current hold state
+        let (ok, stdout, _) = run_cmd(
+            connection,
+            &format!("qstat -f -F json {} 2>/dev/null", job_id),
+            context,
+        )?;
+
+        if !ok || stdout.trim().is_empty() {
+            return Err(ModuleError::ExecutionFailed(format!(
+                "Job {} not found",
+                job_id
+            )));
+        }
+
+        // Check Hold_Types — skip if no hold
+        if let Some(hold_types) = extract_job_attribute(&stdout, &job_id, "Hold_Types") {
+            if hold_types == "n" || hold_types.is_empty() {
+                return Ok(ModuleOutput::ok(format!(
+                    "Job {} is not held (Hold_Types={})",
+                    job_id, hold_types
+                ))
+                .with_data("job_id", serde_json::json!(job_id))
+                .with_data("hold_types", serde_json::json!(hold_types)));
+            }
+        }
+
+        if context.check_mode {
+            return Ok(
+                ModuleOutput::changed(format!("Would release job {}", job_id))
+                    .with_data("job_id", serde_json::json!(job_id)),
+            );
+        }
+
+        run_cmd_ok(connection, &format!("qrls {}", job_id), context)?;
+
+        Ok(
+            ModuleOutput::changed(format!("Released job {}", job_id))
+                .with_data("job_id", serde_json::json!(job_id)),
+        )
+    }
+}
+
+/// Build a qsub command from parameters.
+fn build_qsub_command(params: &ModuleParams) -> ModuleResult<String> {
+    let script = params.get_string("script")?;
+    let script_path = params.get_string("script_path")?;
+
+    if script.is_none() && script_path.is_none() {
+        return Err(ModuleError::MissingParameter(
+            "Either 'script' or 'script_path' is required for submit".to_string(),
+        ));
+    }
+
+    let mut args = Vec::new();
+
+    if let Some(name) = params.get_string("job_name")? {
+        args.push(format!("-N {}", name));
+    }
+    if let Some(queue) = params.get_string("queue")? {
+        args.push(format!("-q {}", queue));
+    }
+
+    // Build resource list items
+    let mut resources = Vec::new();
+    if let Some(nodes) = params.get_string("nodes")? {
+        resources.push(format!("nodes={}", nodes));
+    }
+    if let Some(ncpus) = params.get_string("ncpus")? {
+        resources.push(format!("ncpus={}", ncpus));
+    }
+    if let Some(walltime) = params.get_string("walltime")? {
+        resources.push(format!("walltime={}", walltime));
+    }
+    if let Some(resource_list) = params.get_string("resource_list")? {
+        resources.push(resource_list);
+    }
+    if !resources.is_empty() {
+        args.push(format!("-l {}", resources.join(",")));
+    }
+
+    if let Some(output_path) = params.get_string("output_path")? {
+        args.push(format!("-o {}", output_path));
+    }
+    if let Some(error_path) = params.get_string("error_path")? {
+        args.push(format!("-e {}", error_path));
+    }
+    if let Some(extra) = params.get_string("extra_args")? {
+        args.push(extra);
+    }
+
+    let args_str = args.join(" ");
+
+    if let Some(path) = script_path {
+        Ok(format!("qsub {} {}", args_str, path).trim().to_string())
+    } else {
+        let script_content = script.unwrap();
+        // Pipe inline script via heredoc
+        let escaped = script_content.replace('\'', "'\\''");
+        Ok(format!(
+            "echo '{}' | qsub {}",
+            escaped, args_str
+        )
+        .trim()
+        .to_string())
+    }
+}
+
+/// Parse qsub output to extract job ID.
+/// Expected format: "12345.server" or just "12345"
+fn parse_qsub_output(output: &str) -> Option<String> {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // qsub typically outputs just the job ID on stdout
+    // e.g., "12345.pbs-server" or "12345.hostname"
+    let first_line = trimmed.lines().next()?;
+    let first_line = first_line.trim();
+    if first_line.is_empty() {
+        return None;
+    }
+    // Validate it looks like a job ID (starts with a digit or contains a dot)
+    if first_line.chars().next()?.is_ascii_digit() {
+        Some(first_line.to_string())
+    } else {
+        None
+    }
+}
+
+/// Parse PBS JSON output from `qstat -f -F json` into the Jobs object.
+fn parse_pbs_json_jobs(output: &str) -> serde_json::Value {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return serde_json::Value::Null;
+    }
+    match serde_json::from_str::<serde_json::Value>(trimmed) {
+        Ok(parsed) => {
+            // PBS JSON structure: { "Jobs": { "jobid": { ... }, ... } }
+            if let Some(jobs) = parsed.get("Jobs") {
+                jobs.clone()
+            } else {
+                parsed
+            }
+        }
+        Err(_) => serde_json::Value::Null,
+    }
+}
+
+/// Find an active job by Job_Name in qstat JSON output.
+/// Returns the job ID if found with a non-terminal state.
+fn find_active_job_by_name(output: &str, name: &str) -> Option<String> {
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).ok()?;
+    let jobs = parsed.get("Jobs")?.as_object()?;
+    for (job_id, job_info) in jobs {
+        let job_name = job_info.get("Job_Name")?.as_str()?;
+        if job_name != name {
+            continue;
+        }
+        // Check job state — active means not F (Finished) or X (Exiting)
+        if let Some(state) = job_info.get("job_state").and_then(|s| s.as_str()) {
+            if state != "F" && state != "X" {
+                return Some(job_id.clone());
+            }
+        }
+    }
+    None
+}
+
+/// Extract a job attribute from qstat JSON output.
+fn extract_job_attribute(output: &str, job_id: &str, attribute: &str) -> Option<String> {
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).ok()?;
+    let jobs = parsed.get("Jobs")?.as_object()?;
+    // Try exact job_id match first, then prefix match
+    let job_info = jobs.get(job_id).or_else(|| {
+        jobs.iter()
+            .find(|(k, _)| k.starts_with(&format!("{}.", job_id)) || job_id.starts_with(&format!("{}.", k)))
+            .map(|(_, v)| v)
+    })?;
+    job_info
+        .get(attribute)
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+/// Extract job state from qstat JSON output.
+fn extract_job_state(output: &str, job_id: &str) -> Option<String> {
+    extract_job_attribute(output, job_id, "job_state")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_qsub_output() {
+        assert_eq!(
+            parse_qsub_output("12345.pbs-server\n"),
+            Some("12345.pbs-server".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_qsub_output_bare_id() {
+        assert_eq!(
+            parse_qsub_output("12345\n"),
+            Some("12345".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_qsub_output_empty() {
+        assert_eq!(parse_qsub_output(""), None);
+        assert_eq!(parse_qsub_output("  \n  "), None);
+    }
+
+    #[test]
+    fn test_parse_qsub_output_error() {
+        assert_eq!(parse_qsub_output("qsub: Job rejected\n"), None);
+    }
+
+    #[test]
+    fn test_build_qsub_command_script_path() {
+        let mut params = ModuleParams::new();
+        params.insert("script_path".to_string(), serde_json::json!("/tmp/job.sh"));
+        params.insert("job_name".to_string(), serde_json::json!("test_job"));
+        params.insert("queue".to_string(), serde_json::json!("batch"));
+        params.insert("walltime".to_string(), serde_json::json!("02:00:00"));
+
+        let cmd = build_qsub_command(&params).unwrap();
+        assert!(cmd.contains("qsub"));
+        assert!(cmd.contains("-N test_job"));
+        assert!(cmd.contains("-q batch"));
+        assert!(cmd.contains("-l walltime=02:00:00"));
+        assert!(cmd.contains("/tmp/job.sh"));
+    }
+
+    #[test]
+    fn test_build_qsub_command_inline_script() {
+        let mut params = ModuleParams::new();
+        params.insert(
+            "script".to_string(),
+            serde_json::json!("#!/bin/bash\necho hello"),
+        );
+        params.insert("job_name".to_string(), serde_json::json!("inline_job"));
+
+        let cmd = build_qsub_command(&params).unwrap();
+        assert!(cmd.contains("qsub"));
+        assert!(cmd.contains("-N inline_job"));
+        assert!(cmd.contains("echo hello"));
+    }
+
+    #[test]
+    fn test_build_qsub_command_no_script() {
+        let params = ModuleParams::new();
+        let result = build_qsub_command(&params);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_build_qsub_command_all_params() {
+        let mut params = ModuleParams::new();
+        params.insert("script_path".to_string(), serde_json::json!("/job.sh"));
+        params.insert("job_name".to_string(), serde_json::json!("full_job"));
+        params.insert("queue".to_string(), serde_json::json!("gpu"));
+        params.insert("nodes".to_string(), serde_json::json!("4"));
+        params.insert("ncpus".to_string(), serde_json::json!("32"));
+        params.insert("walltime".to_string(), serde_json::json!("04:00:00"));
+        params.insert(
+            "output_path".to_string(),
+            serde_json::json!("/logs/out.log"),
+        );
+        params.insert(
+            "error_path".to_string(),
+            serde_json::json!("/logs/err.log"),
+        );
+
+        let cmd = build_qsub_command(&params).unwrap();
+        assert!(cmd.contains("-N full_job"));
+        assert!(cmd.contains("-q gpu"));
+        assert!(cmd.contains("nodes=4"));
+        assert!(cmd.contains("ncpus=32"));
+        assert!(cmd.contains("walltime=04:00:00"));
+        assert!(cmd.contains("-o /logs/out.log"));
+        assert!(cmd.contains("-e /logs/err.log"));
+    }
+
+    #[test]
+    fn test_build_qsub_command_extra_args() {
+        let mut params = ModuleParams::new();
+        params.insert("script_path".to_string(), serde_json::json!("/job.sh"));
+        params.insert(
+            "extra_args".to_string(),
+            serde_json::json!("-V -m abe"),
+        );
+
+        let cmd = build_qsub_command(&params).unwrap();
+        assert!(cmd.contains("-V -m abe"));
+        assert!(cmd.contains("/job.sh"));
+    }
+
+    #[test]
+    fn test_parse_pbs_json_jobs() {
+        let json = r#"{
+            "Jobs": {
+                "12345.server": {
+                    "Job_Name": "test",
+                    "job_state": "R",
+                    "queue": "batch"
+                }
+            }
+        }"#;
+        let jobs = parse_pbs_json_jobs(json);
+        assert!(jobs.is_object());
+        assert!(jobs.get("12345.server").is_some());
+        assert_eq!(jobs["12345.server"]["Job_Name"], "test");
+    }
+
+    #[test]
+    fn test_parse_pbs_json_jobs_empty() {
+        let jobs = parse_pbs_json_jobs("");
+        assert!(jobs.is_null());
+    }
+
+    #[test]
+    fn test_parse_pbs_json_jobs_malformed() {
+        let jobs = parse_pbs_json_jobs("not json at all {{{");
+        assert!(jobs.is_null());
+    }
+}

--- a/src/modules/hpc/pbs_queue.rs
+++ b/src/modules/hpc/pbs_queue.rs
@@ -1,0 +1,748 @@
+//! PBS Pro queue management module
+//!
+//! Manage PBS queues via qstat and qmgr (create, delete, enable, disable, start, stop).
+//!
+//! # Parameters
+//!
+//! - `action` (required): "list", "create", "delete", "enable", "disable", "start", "stop",
+//!   or "set_attributes"
+//! - `name` (required): Queue name
+//! - `queue_type` (optional): Queue type ("execution" or "route", default "execution")
+//! - `enabled` (optional): Whether the queue accepts jobs ("True"/"False")
+//! - `started` (optional): Whether the queue routes/runs jobs ("True"/"False")
+//! - `max_run` (optional): Maximum running jobs in queue
+//! - `max_queued` (optional): Maximum queued jobs in queue
+//! - `resources_max_walltime` (optional): Maximum walltime (e.g. "168:00:00")
+//! - `resources_max_ncpus` (optional): Maximum CPUs per job
+//! - `resources_max_mem` (optional): Maximum memory per job (e.g. "256gb")
+//! - `resources_default_walltime` (optional): Default walltime for jobs
+//! - `priority` (optional): Queue priority value
+//! - `acl_groups` (optional): Comma-separated ACL groups
+//! - `attributes` (optional): JSON object of arbitrary queue attributes
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::runtime::Handle;
+
+use crate::connection::{Connection, ExecuteOptions};
+use crate::modules::{
+    Module, ModuleContext, ModuleError, ModuleOutput, ModuleParams, ModuleResult, ParamExt,
+    ParallelizationHint,
+};
+
+fn get_exec_options(context: &ModuleContext) -> ExecuteOptions {
+    let mut options = ExecuteOptions::new();
+    if context.r#become {
+        options = options.with_escalation(context.become_user.clone());
+        if let Some(ref method) = context.become_method {
+            options.escalate_method = Some(method.clone());
+        }
+        if let Some(ref password) = context.become_password {
+            options.escalate_password = Some(password.clone());
+        }
+    }
+    options
+}
+
+fn run_cmd(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<(bool, String, String)> {
+    let options = get_exec_options(context);
+    let result = Handle::current()
+        .block_on(async { connection.execute(cmd, Some(options)).await })
+        .map_err(|e| ModuleError::ExecutionFailed(format!("Connection error: {}", e)))?;
+    Ok((result.success, result.stdout, result.stderr))
+}
+
+fn run_cmd_ok(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<String> {
+    let (success, stdout, stderr) = run_cmd(connection, cmd, context)?;
+    if !success {
+        return Err(ModuleError::ExecutionFailed(format!(
+            "Command failed: {}",
+            stderr.trim()
+        )));
+    }
+    Ok(stdout)
+}
+
+pub struct PbsQueueModule;
+
+impl Module for PbsQueueModule {
+    fn name(&self) -> &'static str {
+        "pbs_queue"
+    }
+
+    fn description(&self) -> &'static str {
+        "Manage PBS Pro queues (create, delete, enable, disable, start, stop, set_attributes)"
+    }
+
+    fn parallelization_hint(&self) -> ParallelizationHint {
+        ParallelizationHint::GlobalExclusive
+    }
+
+    fn execute(
+        &self,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let connection = context
+            .connection
+            .as_ref()
+            .ok_or_else(|| ModuleError::ExecutionFailed("No connection available".to_string()))?;
+
+        let action = params.get_string_required("action")?;
+        let name = params.get_string_required("name")?;
+
+        match action.as_str() {
+            "list" => self.action_list(connection, context),
+            "create" => self.action_create(connection, &name, params, context),
+            "delete" => self.action_delete(connection, &name, context),
+            "enable" => self.action_enable(connection, &name, context),
+            "disable" => self.action_disable(connection, &name, context),
+            "start" => self.action_start(connection, &name, context),
+            "stop" => self.action_stop(connection, &name, context),
+            "set_attributes" => self.action_set_attributes(connection, &name, params, context),
+            _ => Err(ModuleError::InvalidParameter(format!(
+                "Invalid action '{}'. Must be 'list', 'create', 'delete', 'enable', 'disable', 'start', 'stop', or 'set_attributes'",
+                action
+            ))),
+        }
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &["action", "name"]
+    }
+
+    fn optional_params(&self) -> HashMap<&'static str, serde_json::Value> {
+        let mut m = HashMap::new();
+        m.insert("queue_type", serde_json::json!("execution"));
+        m.insert("enabled", serde_json::json!(null));
+        m.insert("started", serde_json::json!(null));
+        m.insert("max_run", serde_json::json!(null));
+        m.insert("max_queued", serde_json::json!(null));
+        m.insert("resources_max_walltime", serde_json::json!(null));
+        m.insert("resources_max_ncpus", serde_json::json!(null));
+        m.insert("resources_max_mem", serde_json::json!(null));
+        m.insert("resources_default_walltime", serde_json::json!(null));
+        m.insert("priority", serde_json::json!(null));
+        m.insert("acl_groups", serde_json::json!(null));
+        m.insert("attributes", serde_json::json!(null));
+        m
+    }
+}
+
+impl PbsQueueModule {
+    fn get_queue_info(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        name: &str,
+        context: &ModuleContext,
+    ) -> ModuleResult<Option<serde_json::Value>> {
+        let (ok, stdout, _) = run_cmd(
+            connection,
+            "qstat -Q -f -F json 2>/dev/null",
+            context,
+        )?;
+        if !ok || stdout.trim().is_empty() {
+            return Ok(None);
+        }
+        let queues = parse_pbs_json_queues(&stdout);
+        if let Some(obj) = queues.as_object() {
+            if let Some(queue) = obj.get(name) {
+                return Ok(Some(queue.clone()));
+            }
+        }
+        Ok(None)
+    }
+
+    fn action_list(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let stdout = run_cmd_ok(
+            connection,
+            "qstat -Q -f -F json 2>/dev/null",
+            context,
+        )?;
+        let queues = parse_pbs_json_queues(&stdout);
+
+        let count = queues.as_object().map_or(0, |o| o.len());
+
+        Ok(ModuleOutput::ok(format!("Listed {} queue(s)", count))
+            .with_data("queues", queues)
+            .with_data("count", serde_json::json!(count)))
+    }
+
+    fn action_create(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        name: &str,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        // Idempotency: check if queue already exists
+        if let Some(existing) = self.get_queue_info(connection, name, context)? {
+            return Ok(
+                ModuleOutput::ok(format!("Queue '{}' already exists", name))
+                    .with_data("queue", existing),
+            );
+        }
+
+        if context.check_mode {
+            return Ok(
+                ModuleOutput::changed(format!("Would create queue '{}'", name))
+                    .with_data("name", serde_json::json!(name)),
+            );
+        }
+
+        let queue_type = params
+            .get_string("queue_type")?
+            .unwrap_or_else(|| "execution".to_string());
+
+        let cmd = format!(
+            "qmgr -c \"create queue {} queue_type={}\"",
+            name, queue_type
+        );
+        run_cmd_ok(connection, &cmd, context)?;
+
+        // Apply additional attributes
+        let attr_cmds = build_queue_attribute_commands(name, params)?;
+        for attr_cmd in &attr_cmds {
+            run_cmd_ok(connection, attr_cmd, context)?;
+        }
+
+        let current = self.get_queue_info(connection, name, context)?;
+
+        Ok(
+            ModuleOutput::changed(format!("Created queue '{}'", name))
+                .with_data("name", serde_json::json!(name))
+                .with_data("queue", serde_json::json!(current)),
+        )
+    }
+
+    fn action_delete(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        name: &str,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        // Idempotency: check if queue exists
+        if self.get_queue_info(connection, name, context)?.is_none() {
+            return Ok(
+                ModuleOutput::ok(format!("Queue '{}' does not exist", name))
+                    .with_data("name", serde_json::json!(name)),
+            );
+        }
+
+        if context.check_mode {
+            return Ok(
+                ModuleOutput::changed(format!("Would delete queue '{}'", name))
+                    .with_data("name", serde_json::json!(name)),
+            );
+        }
+
+        run_cmd_ok(
+            connection,
+            &format!("qmgr -c \"delete queue {}\"", name),
+            context,
+        )?;
+
+        Ok(
+            ModuleOutput::changed(format!("Deleted queue '{}'", name))
+                .with_data("name", serde_json::json!(name)),
+        )
+    }
+
+    fn action_enable(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        name: &str,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        if let Some(info) = self.get_queue_info(connection, name, context)? {
+            if info.get("enabled").and_then(|v| v.as_str()) == Some("True") {
+                return Ok(
+                    ModuleOutput::ok(format!("Queue '{}' is already enabled", name))
+                        .with_data("name", serde_json::json!(name)),
+                );
+            }
+        } else {
+            return Err(ModuleError::ExecutionFailed(format!(
+                "Queue '{}' does not exist",
+                name
+            )));
+        }
+
+        if context.check_mode {
+            return Ok(
+                ModuleOutput::changed(format!("Would enable queue '{}'", name))
+                    .with_data("name", serde_json::json!(name)),
+            );
+        }
+
+        run_cmd_ok(
+            connection,
+            &format!("qmgr -c \"set queue {} enabled=True\"", name),
+            context,
+        )?;
+
+        Ok(
+            ModuleOutput::changed(format!("Enabled queue '{}'", name))
+                .with_data("name", serde_json::json!(name)),
+        )
+    }
+
+    fn action_disable(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        name: &str,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        if let Some(info) = self.get_queue_info(connection, name, context)? {
+            if info.get("enabled").and_then(|v| v.as_str()) == Some("False") {
+                return Ok(
+                    ModuleOutput::ok(format!("Queue '{}' is already disabled", name))
+                        .with_data("name", serde_json::json!(name)),
+                );
+            }
+        } else {
+            return Err(ModuleError::ExecutionFailed(format!(
+                "Queue '{}' does not exist",
+                name
+            )));
+        }
+
+        if context.check_mode {
+            return Ok(
+                ModuleOutput::changed(format!("Would disable queue '{}'", name))
+                    .with_data("name", serde_json::json!(name)),
+            );
+        }
+
+        run_cmd_ok(
+            connection,
+            &format!("qmgr -c \"set queue {} enabled=False\"", name),
+            context,
+        )?;
+
+        Ok(
+            ModuleOutput::changed(format!("Disabled queue '{}'", name))
+                .with_data("name", serde_json::json!(name)),
+        )
+    }
+
+    fn action_start(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        name: &str,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        if let Some(info) = self.get_queue_info(connection, name, context)? {
+            if info.get("started").and_then(|v| v.as_str()) == Some("True") {
+                return Ok(
+                    ModuleOutput::ok(format!("Queue '{}' is already started", name))
+                        .with_data("name", serde_json::json!(name)),
+                );
+            }
+        } else {
+            return Err(ModuleError::ExecutionFailed(format!(
+                "Queue '{}' does not exist",
+                name
+            )));
+        }
+
+        if context.check_mode {
+            return Ok(
+                ModuleOutput::changed(format!("Would start queue '{}'", name))
+                    .with_data("name", serde_json::json!(name)),
+            );
+        }
+
+        run_cmd_ok(
+            connection,
+            &format!("qmgr -c \"set queue {} started=True\"", name),
+            context,
+        )?;
+
+        Ok(
+            ModuleOutput::changed(format!("Started queue '{}'", name))
+                .with_data("name", serde_json::json!(name)),
+        )
+    }
+
+    fn action_stop(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        name: &str,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        if let Some(info) = self.get_queue_info(connection, name, context)? {
+            if info.get("started").and_then(|v| v.as_str()) == Some("False") {
+                return Ok(
+                    ModuleOutput::ok(format!("Queue '{}' is already stopped", name))
+                        .with_data("name", serde_json::json!(name)),
+                );
+            }
+        } else {
+            return Err(ModuleError::ExecutionFailed(format!(
+                "Queue '{}' does not exist",
+                name
+            )));
+        }
+
+        if context.check_mode {
+            return Ok(
+                ModuleOutput::changed(format!("Would stop queue '{}'", name))
+                    .with_data("name", serde_json::json!(name)),
+            );
+        }
+
+        run_cmd_ok(
+            connection,
+            &format!("qmgr -c \"set queue {} started=False\"", name),
+            context,
+        )?;
+
+        Ok(
+            ModuleOutput::changed(format!("Stopped queue '{}'", name))
+                .with_data("name", serde_json::json!(name)),
+        )
+    }
+
+    fn action_set_attributes(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        name: &str,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let current = self.get_queue_info(connection, name, context)?.ok_or_else(|| {
+            ModuleError::ExecutionFailed(format!(
+                "Queue '{}' does not exist; cannot set attributes",
+                name
+            ))
+        })?;
+
+        // Build desired attributes and compute diff
+        let desired = build_queue_desired_attributes(params)?;
+        let changes = compute_queue_changes(&current, &desired);
+
+        if changes.is_empty() {
+            return Ok(
+                ModuleOutput::ok(format!("Queue '{}' attributes are already up to date", name))
+                    .with_data("queue", serde_json::json!(current)),
+            );
+        }
+
+        if context.check_mode {
+            return Ok(ModuleOutput::changed(format!(
+                "Would update queue '{}': {}",
+                name,
+                changes
+                    .iter()
+                    .map(|(k, v)| format!("{}={}", k, v))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ))
+            .with_data("changes", serde_json::json!(changes)));
+        }
+
+        for (key, value) in &changes {
+            let cmd = format!("qmgr -c \"set queue {} {}={}\"", name, key, value);
+            run_cmd_ok(connection, &cmd, context)?;
+        }
+
+        let updated = self.get_queue_info(connection, name, context)?;
+
+        Ok(
+            ModuleOutput::changed(format!("Updated queue '{}' attributes", name))
+                .with_data("name", serde_json::json!(name))
+                .with_data("changes", serde_json::json!(changes))
+                .with_data("queue", serde_json::json!(updated)),
+        )
+    }
+}
+
+/// Parse PBS JSON output from `qstat -Q -f -F json` into the Queue object.
+fn parse_pbs_json_queues(output: &str) -> serde_json::Value {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return serde_json::Value::Null;
+    }
+    match serde_json::from_str::<serde_json::Value>(trimmed) {
+        Ok(parsed) => {
+            // PBS JSON structure: { "Queue": { "qname": { ... }, ... } }
+            if let Some(queues) = parsed.get("Queue") {
+                queues.clone()
+            } else {
+                parsed
+            }
+        }
+        Err(_) => serde_json::Value::Null,
+    }
+}
+
+/// Build qmgr commands to set queue attributes from params.
+fn build_queue_attribute_commands(
+    name: &str,
+    params: &ModuleParams,
+) -> ModuleResult<Vec<String>> {
+    let mut commands = Vec::new();
+
+    let attr_map: &[(&str, &str)] = &[
+        ("enabled", "enabled"),
+        ("started", "started"),
+        ("max_run", "max_run"),
+        ("max_queued", "max_queued"),
+        ("resources_max_walltime", "resources_max.walltime"),
+        ("resources_max_ncpus", "resources_max.ncpus"),
+        ("resources_max_mem", "resources_max.mem"),
+        ("resources_default_walltime", "resources_default.walltime"),
+        ("priority", "Priority"),
+        ("acl_groups", "acl_groups"),
+    ];
+
+    for (param_name, pbs_attr) in attr_map {
+        if let Some(value) = params.get_string(param_name)? {
+            commands.push(format!(
+                "qmgr -c \"set queue {} {}={}\"",
+                name, pbs_attr, value
+            ));
+        }
+    }
+
+    // Handle arbitrary attributes from JSON object
+    if let Some(serde_json::Value::Object(attrs)) = params.get("attributes") {
+        for (key, value) in attrs {
+            let val_str = match value {
+                serde_json::Value::String(s) => s.clone(),
+                other => other.to_string(),
+            };
+            commands.push(format!(
+                "qmgr -c \"set queue {} {}={}\"",
+                name, key, val_str
+            ));
+        }
+    }
+
+    Ok(commands)
+}
+
+/// Build a map of desired PBS attribute names to values from params.
+fn build_queue_desired_attributes(
+    params: &ModuleParams,
+) -> ModuleResult<HashMap<String, String>> {
+    let mut desired = HashMap::new();
+
+    let attr_map: &[(&str, &str)] = &[
+        ("enabled", "enabled"),
+        ("started", "started"),
+        ("max_run", "max_run"),
+        ("max_queued", "max_queued"),
+        ("resources_max_walltime", "resources_max.walltime"),
+        ("resources_max_ncpus", "resources_max.ncpus"),
+        ("resources_max_mem", "resources_max.mem"),
+        ("resources_default_walltime", "resources_default.walltime"),
+        ("priority", "Priority"),
+        ("acl_groups", "acl_groups"),
+    ];
+
+    for (param_name, pbs_attr) in attr_map {
+        if let Some(value) = params.get_string(param_name)? {
+            desired.insert(pbs_attr.to_string(), value);
+        }
+    }
+
+    // Handle arbitrary attributes from JSON object
+    if let Some(serde_json::Value::Object(attrs)) = params.get("attributes") {
+        for (key, value) in attrs {
+            let val_str = match value {
+                serde_json::Value::String(s) => s.clone(),
+                other => other.to_string(),
+            };
+            desired.insert(key.clone(), val_str);
+        }
+    }
+
+    Ok(desired)
+}
+
+/// Compare desired attributes against current queue info and return only differences.
+fn compute_queue_changes(
+    current: &serde_json::Value,
+    desired: &HashMap<String, String>,
+) -> HashMap<String, String> {
+    let mut changes = HashMap::new();
+    for (key, desired_val) in desired {
+        let needs_change = match current.get(key).and_then(|v| {
+            v.as_str()
+                .map(|s| s.to_string())
+                .or_else(|| Some(v.to_string()))
+        }) {
+            Some(current_val) => {
+                // Strip quotes from JSON stringified values
+                let clean = current_val.trim_matches('"');
+                clean != desired_val.as_str()
+            }
+            None => true,
+        };
+        if needs_change {
+            changes.insert(key.clone(), desired_val.clone());
+        }
+    }
+    changes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_pbs_json_queues() {
+        let json = r#"{
+            "Queue": {
+                "batch": {
+                    "queue_type": "Execution",
+                    "enabled": "True",
+                    "started": "True",
+                    "total_jobs": 42
+                },
+                "gpu": {
+                    "queue_type": "Execution",
+                    "enabled": "True",
+                    "started": "False"
+                }
+            }
+        }"#;
+        let queues = parse_pbs_json_queues(json);
+        assert!(queues.is_object());
+        assert!(queues.get("batch").is_some());
+        assert!(queues.get("gpu").is_some());
+        assert_eq!(queues["batch"]["enabled"], "True");
+    }
+
+    #[test]
+    fn test_parse_pbs_json_queues_empty() {
+        let queues = parse_pbs_json_queues("");
+        assert!(queues.is_null());
+    }
+
+    #[test]
+    fn test_parse_pbs_json_queues_malformed() {
+        let queues = parse_pbs_json_queues("not valid json {{{");
+        assert!(queues.is_null());
+    }
+
+    #[test]
+    fn test_build_queue_attribute_commands() {
+        let mut params = ModuleParams::new();
+        params.insert("enabled".to_string(), serde_json::json!("True"));
+        params.insert("started".to_string(), serde_json::json!("True"));
+        params.insert(
+            "resources_max_walltime".to_string(),
+            serde_json::json!("168:00:00"),
+        );
+        params.insert("priority".to_string(), serde_json::json!("100"));
+
+        let cmds = build_queue_attribute_commands("batch", &params).unwrap();
+        assert_eq!(cmds.len(), 4);
+        assert!(cmds.iter().any(|c| c.contains("enabled=True")));
+        assert!(cmds.iter().any(|c| c.contains("started=True")));
+        assert!(cmds
+            .iter()
+            .any(|c| c.contains("resources_max.walltime=168:00:00")));
+        assert!(cmds.iter().any(|c| c.contains("Priority=100")));
+    }
+
+    #[test]
+    fn test_build_queue_attribute_commands_empty() {
+        let params = ModuleParams::new();
+        let cmds = build_queue_attribute_commands("batch", &params).unwrap();
+        assert!(cmds.is_empty());
+    }
+
+    #[test]
+    fn test_build_queue_attribute_commands_all_params() {
+        let mut params = ModuleParams::new();
+        params.insert("enabled".to_string(), serde_json::json!("True"));
+        params.insert("started".to_string(), serde_json::json!("True"));
+        params.insert("max_run".to_string(), serde_json::json!("50"));
+        params.insert("max_queued".to_string(), serde_json::json!("200"));
+        params.insert(
+            "resources_max_walltime".to_string(),
+            serde_json::json!("72:00:00"),
+        );
+        params.insert("resources_max_ncpus".to_string(), serde_json::json!("128"));
+        params.insert(
+            "resources_max_mem".to_string(),
+            serde_json::json!("256gb"),
+        );
+        params.insert(
+            "resources_default_walltime".to_string(),
+            serde_json::json!("01:00:00"),
+        );
+        params.insert("priority".to_string(), serde_json::json!("50"));
+        params.insert(
+            "acl_groups".to_string(),
+            serde_json::json!("admin,research"),
+        );
+
+        let cmds = build_queue_attribute_commands("batch", &params).unwrap();
+        assert_eq!(cmds.len(), 10);
+    }
+
+    #[test]
+    fn test_compute_queue_changes_no_changes() {
+        let current = serde_json::json!({
+            "enabled": "True",
+            "started": "True",
+            "Priority": "100"
+        });
+        let mut desired = HashMap::new();
+        desired.insert("enabled".to_string(), "True".to_string());
+        desired.insert("started".to_string(), "True".to_string());
+        desired.insert("Priority".to_string(), "100".to_string());
+
+        let changes = compute_queue_changes(&current, &desired);
+        assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn test_compute_queue_changes_with_changes() {
+        let current = serde_json::json!({
+            "enabled": "True",
+            "started": "True",
+            "Priority": "100"
+        });
+        let mut desired = HashMap::new();
+        desired.insert("enabled".to_string(), "False".to_string());
+        desired.insert("started".to_string(), "True".to_string());
+        desired.insert("Priority".to_string(), "200".to_string());
+
+        let changes = compute_queue_changes(&current, &desired);
+        assert_eq!(changes.len(), 2);
+        assert_eq!(changes.get("enabled"), Some(&"False".to_string()));
+        assert_eq!(changes.get("Priority"), Some(&"200".to_string()));
+    }
+
+    #[test]
+    fn test_compute_queue_changes_new_attribute() {
+        let current = serde_json::json!({
+            "enabled": "True"
+        });
+        let mut desired = HashMap::new();
+        desired.insert("max_run".to_string(), "50".to_string());
+
+        let changes = compute_queue_changes(&current, &desired);
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes.get("max_run"), Some(&"50".to_string()));
+    }
+}

--- a/src/modules/hpc/pbs_server.rs
+++ b/src/modules/hpc/pbs_server.rs
@@ -1,0 +1,482 @@
+//! PBS Pro server configuration module
+//!
+//! Query and set PBS server attributes via qmgr, and manage custom resources.
+//!
+//! # Parameters
+//!
+//! - `action` (required): "query", "set_attributes", or "manage_resources"
+//! - `attributes` (optional): JSON object of server attributes to set
+//! - `default_queue` (optional): Default queue name
+//! - `scheduling` (optional): Enable/disable scheduling ("True"/"False")
+//! - `node_fail_requeue` (optional): Requeue on node failure ("True"/"False")
+//! - `max_run` (optional): Maximum running jobs across server
+//! - `max_queued` (optional): Maximum queued jobs across server
+//! - `query_other_jobs` (optional): Allow users to query other jobs ("True"/"False")
+//! - `resources_default_walltime` (optional): Default walltime for server
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::runtime::Handle;
+
+use crate::connection::{Connection, ExecuteOptions};
+use crate::modules::{
+    Module, ModuleContext, ModuleError, ModuleOutput, ModuleParams, ModuleResult, ParamExt,
+    ParallelizationHint,
+};
+
+fn get_exec_options(context: &ModuleContext) -> ExecuteOptions {
+    let mut options = ExecuteOptions::new();
+    if context.r#become {
+        options = options.with_escalation(context.become_user.clone());
+        if let Some(ref method) = context.become_method {
+            options.escalate_method = Some(method.clone());
+        }
+        if let Some(ref password) = context.become_password {
+            options.escalate_password = Some(password.clone());
+        }
+    }
+    options
+}
+
+fn run_cmd(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<(bool, String, String)> {
+    let options = get_exec_options(context);
+    let result = Handle::current()
+        .block_on(async { connection.execute(cmd, Some(options)).await })
+        .map_err(|e| ModuleError::ExecutionFailed(format!("Connection error: {}", e)))?;
+    Ok((result.success, result.stdout, result.stderr))
+}
+
+fn run_cmd_ok(
+    connection: &Arc<dyn Connection + Send + Sync>,
+    cmd: &str,
+    context: &ModuleContext,
+) -> ModuleResult<String> {
+    let (success, stdout, stderr) = run_cmd(connection, cmd, context)?;
+    if !success {
+        return Err(ModuleError::ExecutionFailed(format!(
+            "Command failed: {}",
+            stderr.trim()
+        )));
+    }
+    Ok(stdout)
+}
+
+pub struct PbsServerModule;
+
+impl Module for PbsServerModule {
+    fn name(&self) -> &'static str {
+        "pbs_server"
+    }
+
+    fn description(&self) -> &'static str {
+        "Query and configure PBS Pro server attributes (qmgr print/set server)"
+    }
+
+    fn parallelization_hint(&self) -> ParallelizationHint {
+        ParallelizationHint::GlobalExclusive
+    }
+
+    fn execute(
+        &self,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let connection = context
+            .connection
+            .as_ref()
+            .ok_or_else(|| ModuleError::ExecutionFailed("No connection available".to_string()))?;
+
+        let action = params.get_string_required("action")?;
+
+        match action.as_str() {
+            "query" => self.action_query(connection, context),
+            "set_attributes" => self.action_set_attributes(connection, params, context),
+            "manage_resources" => self.action_manage_resources(connection, params, context),
+            _ => Err(ModuleError::InvalidParameter(format!(
+                "Invalid action '{}'. Must be 'query', 'set_attributes', or 'manage_resources'",
+                action
+            ))),
+        }
+    }
+
+    fn required_params(&self) -> &[&'static str] {
+        &["action"]
+    }
+
+    fn optional_params(&self) -> HashMap<&'static str, serde_json::Value> {
+        let mut m = HashMap::new();
+        m.insert("attributes", serde_json::json!(null));
+        m.insert("default_queue", serde_json::json!(null));
+        m.insert("scheduling", serde_json::json!(null));
+        m.insert("node_fail_requeue", serde_json::json!(null));
+        m.insert("max_run", serde_json::json!(null));
+        m.insert("max_queued", serde_json::json!(null));
+        m.insert("query_other_jobs", serde_json::json!(null));
+        m.insert("resources_default_walltime", serde_json::json!(null));
+        m
+    }
+}
+
+impl PbsServerModule {
+    fn action_query(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let stdout = run_cmd_ok(
+            connection,
+            "qmgr -c \"print server\" 2>/dev/null",
+            context,
+        )?;
+
+        let server_attrs = parse_qmgr_server_output(&stdout);
+
+        Ok(ModuleOutput::ok(format!(
+            "Retrieved {} server attribute(s)",
+            server_attrs.len()
+        ))
+        .with_data("server", serde_json::json!(server_attrs)))
+    }
+
+    fn action_set_attributes(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        // Get current server state
+        let stdout = run_cmd_ok(
+            connection,
+            "qmgr -c \"print server\" 2>/dev/null",
+            context,
+        )?;
+        let current = parse_qmgr_server_output(&stdout);
+
+        // Build desired attributes
+        let desired = build_server_attribute_pairs(params)?;
+        let changes = compute_server_changes(&current, &desired);
+
+        if changes.is_empty() {
+            return Ok(
+                ModuleOutput::ok("Server attributes are already up to date")
+                    .with_data("server", serde_json::json!(current)),
+            );
+        }
+
+        if context.check_mode {
+            return Ok(ModuleOutput::changed(format!(
+                "Would update server: {}",
+                changes
+                    .iter()
+                    .map(|(k, v)| format!("{}={}", k, v))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ))
+            .with_data("changes", serde_json::json!(changes)));
+        }
+
+        for (key, value) in &changes {
+            let cmd = format!("qmgr -c \"set server {}={}\"", key, value);
+            run_cmd_ok(connection, &cmd, context)?;
+        }
+
+        // Re-read current state
+        let (_, new_stdout, _) = run_cmd(
+            connection,
+            "qmgr -c \"print server\" 2>/dev/null",
+            context,
+        )?;
+        let updated = parse_qmgr_server_output(&new_stdout);
+
+        Ok(ModuleOutput::changed("Updated server attributes")
+            .with_data("changes", serde_json::json!(changes))
+            .with_data("server", serde_json::json!(updated)))
+    }
+
+    fn action_manage_resources(
+        &self,
+        connection: &Arc<dyn Connection + Send + Sync>,
+        params: &ModuleParams,
+        context: &ModuleContext,
+    ) -> ModuleResult<ModuleOutput> {
+        let attrs = params.get("attributes").ok_or_else(|| {
+            ModuleError::MissingParameter(
+                "attributes is required for manage_resources action".to_string(),
+            )
+        })?;
+
+        let resources = attrs.as_object().ok_or_else(|| {
+            ModuleError::InvalidParameter(
+                "attributes must be a JSON object mapping resource_name -> resource_type"
+                    .to_string(),
+            )
+        })?;
+
+        // Query existing resources
+        let (_, stdout, _) = run_cmd(
+            connection,
+            "qmgr -c \"print server\" 2>/dev/null",
+            context,
+        )?;
+        let current = parse_qmgr_server_output(&stdout);
+
+        let mut created = Vec::new();
+        let mut skipped = Vec::new();
+
+        for (name, type_val) in resources {
+            let resource_type = match type_val {
+                serde_json::Value::String(s) => s.clone(),
+                other => other.to_string().trim_matches('"').to_string(),
+            };
+
+            // Check if resource already exists (appears as "resources" line in print server)
+            let resource_key = format!("resources {}", name);
+            if current.contains_key(&resource_key) {
+                skipped.push(name.clone());
+                continue;
+            }
+
+            if context.check_mode {
+                created.push(name.clone());
+                continue;
+            }
+
+            let cmd = format!(
+                "qmgr -c \"create resource {} type={}\"",
+                name, resource_type
+            );
+            run_cmd_ok(connection, &cmd, context)?;
+            created.push(name.clone());
+        }
+
+        if created.is_empty() {
+            return Ok(
+                ModuleOutput::ok("All resources already exist")
+                    .with_data("skipped", serde_json::json!(skipped)),
+            );
+        }
+
+        let msg = if context.check_mode {
+            format!("Would create {} resource(s)", created.len())
+        } else {
+            format!("Created {} resource(s)", created.len())
+        };
+
+        Ok(ModuleOutput::changed(msg)
+            .with_data("created", serde_json::json!(created))
+            .with_data("skipped", serde_json::json!(skipped)))
+    }
+}
+
+/// Parse `qmgr -c "print server"` text output into key-value pairs.
+///
+/// Lines look like:
+///   set server scheduling = True
+///   set server default_queue = batch
+///   set server resources_default.walltime = 01:00:00
+///
+/// Comment lines (starting with #) and blank lines are skipped.
+fn parse_qmgr_server_output(output: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for line in output.lines() {
+        let trimmed = line.trim();
+
+        // Skip empty lines and comments
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        // Parse "set server key = value" lines
+        if let Some(rest) = trimmed.strip_prefix("set server ") {
+            if let Some((key, value)) = rest.split_once('=') {
+                map.insert(
+                    key.trim().to_string(),
+                    value.trim().to_string(),
+                );
+            }
+        }
+
+        // Also handle "create resource name type=string" style lines
+        if let Some(rest) = trimmed.strip_prefix("create resource ") {
+            if let Some((name, _type_info)) = rest.split_once(' ') {
+                map.insert(
+                    format!("resources {}", name.trim()),
+                    rest.trim().to_string(),
+                );
+            }
+        }
+    }
+    map
+}
+
+/// Build server attribute key-value pairs from params.
+fn build_server_attribute_pairs(
+    params: &ModuleParams,
+) -> ModuleResult<HashMap<String, String>> {
+    let mut desired = HashMap::new();
+
+    let attr_map: &[(&str, &str)] = &[
+        ("default_queue", "default_queue"),
+        ("scheduling", "scheduling"),
+        ("node_fail_requeue", "node_fail_requeue"),
+        ("max_run", "max_run"),
+        ("max_queued", "max_queued"),
+        ("query_other_jobs", "query_other_jobs"),
+        ("resources_default_walltime", "resources_default.walltime"),
+    ];
+
+    for (param_name, pbs_attr) in attr_map {
+        if let Some(value) = params.get_string(param_name)? {
+            desired.insert(pbs_attr.to_string(), value);
+        }
+    }
+
+    // Handle arbitrary attributes from JSON object
+    if let Some(serde_json::Value::Object(attrs)) = params.get("attributes") {
+        for (key, value) in attrs {
+            let val_str = match value {
+                serde_json::Value::String(s) => s.clone(),
+                other => other.to_string(),
+            };
+            desired.insert(key.clone(), val_str);
+        }
+    }
+
+    Ok(desired)
+}
+
+/// Compare desired attributes against current server state and return only differences.
+fn compute_server_changes(
+    current: &HashMap<String, String>,
+    desired: &HashMap<String, String>,
+) -> HashMap<String, String> {
+    let mut changes = HashMap::new();
+    for (key, desired_val) in desired {
+        let needs_change = match current.get(key) {
+            Some(current_val) => current_val != desired_val,
+            None => true,
+        };
+        if needs_change {
+            changes.insert(key.clone(), desired_val.clone());
+        }
+    }
+    changes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_qmgr_server_output() {
+        let output = r#"#
+# Set server attributes.
+#
+set server scheduling = True
+set server default_queue = batch
+set server log_events = 511
+set server resources_default.walltime = 01:00:00
+set server node_fail_requeue = True
+"#;
+        let attrs = parse_qmgr_server_output(output);
+        assert_eq!(attrs.get("scheduling"), Some(&"True".to_string()));
+        assert_eq!(attrs.get("default_queue"), Some(&"batch".to_string()));
+        assert_eq!(attrs.get("log_events"), Some(&"511".to_string()));
+        assert_eq!(
+            attrs.get("resources_default.walltime"),
+            Some(&"01:00:00".to_string())
+        );
+        assert_eq!(attrs.get("node_fail_requeue"), Some(&"True".to_string()));
+    }
+
+    #[test]
+    fn test_parse_qmgr_server_output_empty() {
+        let attrs = parse_qmgr_server_output("");
+        assert!(attrs.is_empty());
+    }
+
+    #[test]
+    fn test_parse_qmgr_server_output_comments() {
+        let output = "# This is a comment\n# Another comment\n";
+        let attrs = parse_qmgr_server_output(output);
+        assert!(attrs.is_empty());
+    }
+
+    #[test]
+    fn test_build_server_attribute_commands() {
+        let mut params = ModuleParams::new();
+        params.insert(
+            "default_queue".to_string(),
+            serde_json::json!("batch"),
+        );
+        params.insert("scheduling".to_string(), serde_json::json!("True"));
+        params.insert(
+            "resources_default_walltime".to_string(),
+            serde_json::json!("02:00:00"),
+        );
+
+        let pairs = build_server_attribute_pairs(&params).unwrap();
+        assert_eq!(pairs.get("default_queue"), Some(&"batch".to_string()));
+        assert_eq!(pairs.get("scheduling"), Some(&"True".to_string()));
+        assert_eq!(
+            pairs.get("resources_default.walltime"),
+            Some(&"02:00:00".to_string())
+        );
+    }
+
+    #[test]
+    fn test_build_server_attribute_commands_empty() {
+        let params = ModuleParams::new();
+        let pairs = build_server_attribute_pairs(&params).unwrap();
+        assert!(pairs.is_empty());
+    }
+
+    #[test]
+    fn test_compute_server_changes_no_changes() {
+        let mut current = HashMap::new();
+        current.insert("scheduling".to_string(), "True".to_string());
+        current.insert("default_queue".to_string(), "batch".to_string());
+
+        let mut desired = HashMap::new();
+        desired.insert("scheduling".to_string(), "True".to_string());
+        desired.insert("default_queue".to_string(), "batch".to_string());
+
+        let changes = compute_server_changes(&current, &desired);
+        assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn test_compute_server_changes_with_changes() {
+        let mut current = HashMap::new();
+        current.insert("scheduling".to_string(), "True".to_string());
+        current.insert("default_queue".to_string(), "batch".to_string());
+        current.insert("log_events".to_string(), "511".to_string());
+
+        let mut desired = HashMap::new();
+        desired.insert("scheduling".to_string(), "False".to_string());
+        desired.insert("default_queue".to_string(), "batch".to_string());
+        desired.insert("log_events".to_string(), "255".to_string());
+
+        let changes = compute_server_changes(&current, &desired);
+        assert_eq!(changes.len(), 2);
+        assert_eq!(changes.get("scheduling"), Some(&"False".to_string()));
+        assert_eq!(changes.get("log_events"), Some(&"255".to_string()));
+        assert!(!changes.contains_key("default_queue"));
+    }
+
+    #[test]
+    fn test_compute_server_changes_new_attribute() {
+        let current = HashMap::new();
+        let mut desired = HashMap::new();
+        desired.insert("max_run".to_string(), "100".to_string());
+
+        let changes = compute_server_changes(&current, &desired);
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes.get("max_run"), Some(&"100".to_string()));
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1686,6 +1686,15 @@ impl ModuleRegistry {
             ],
         );
 
+        #[cfg(feature = "pbs")]
+        register_modules!(registry,
+            Hpc: [
+                hpc::PbsJobModule,
+                hpc::PbsQueueModule,
+                hpc::PbsServerModule,
+            ],
+        );
+
         #[cfg(feature = "gpu")]
         register_modules!(registry,
             Hpc: [


### PR DESCRIPTION
## Summary

- Add three PBS Pro (OpenPBS / Altair PBS Professional) runtime modules, extending HPC scheduler support beyond Slurm (Phase 3 after #587 and #589)
- New `pbs` feature flag in Cargo.toml, added to `full-hpc` meta-feature
- **pbs_job**: submit/cancel/status/hold/release via qsub/qdel/qstat/qhold/qrls with idempotency checks
- **pbs_queue**: list/create/delete/enable/disable/start/stop/set_attributes via qmgr with idempotency checks
- **pbs_server**: query/set_attributes/manage_resources via qmgr with diff-based idempotency

PBS modules use native JSON parsing (`qstat -F json`) where available and a custom parser for `qmgr` text output. 29 unit tests covering all helper functions and parsers.

## Test plan

- [x] `cargo build --features pbs` compiles cleanly
- [x] `cargo build --features slurm,pbs` compiles cleanly (both features together)
- [x] `cargo test --features pbs -- pbs_` — 29 tests pass
- [x] `cargo clippy --features pbs` — no warnings from new modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)