### PR TITLE
🎨 Palette: Improve execution mode visibility

### DIFF
--- a/src/cli/commands/check.rs
+++ b/src/cli/commands/check.rs
@@ -95,10 +95,6 @@ impl CheckArgs {
             distribution_strategy: "adaptive".to_string(),
         };
 
-        ctx.output.banner("CHECK MODE - DRY RUN");
-        ctx.output
-            .warning("No changes will be made to the target systems");
-
         run_args.execute(ctx).await
     }
 }

--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -478,12 +478,21 @@ impl RunArgs {
         }
 
         // Display banner
+        let mode_suffix = if self.plan {
+            " [PLAN]"
+        } else if ctx.check_mode {
+            " [CHECK]"
+        } else {
+            ""
+        };
+
         ctx.output.banner(&format!(
-            "PLAYBOOK: {}",
+            "PLAYBOOK: {}{}",
             self.playbook
                 .file_name()
                 .unwrap_or_default()
-                .to_string_lossy()
+                .to_string_lossy(),
+            mode_suffix
         ));
 
         // Load playbook using executor's Playbook parser
@@ -566,7 +575,7 @@ impl RunArgs {
         // "Plan mode is implemented on top of executor or clearly separated as non-executing"
         if self.plan {
             ctx.output
-                .plan("WARNING: Running in PLAN MODE - showing execution plan only");
+                .warning("Running in PLAN MODE - showing execution plan only");
             let playbook_content = std::fs::read_to_string(&self.playbook)?;
             let playbook_yaml: serde_yaml::Value = serde_yaml::from_str(&playbook_content)?;
             let mut plan_lines: Vec<String> = Vec::new();


### PR DESCRIPTION
*   💡 **What:** Enhanced the main playbook execution banner to include `[PLAN]` or `[CHECK]` suffixes and used a yellow warning style for the Plan Mode message. Removed redundant banner/warning outputs from the `check` command.
*   🎯 **Why:** To improve clarity and reduce visual noise. Users running `rustible check` previously saw duplicate banners, and `rustible run --plan` displayed the mode as plain text which could be missed. This change unifies the experience and makes the execution mode immediately visible in the main banner.
*   📸 **Before:**
    ```
    [BANNER: CHECK MODE - DRY RUN]
    [WARNING: No changes will be made...]

    [BANNER: PLAYBOOK: site.yml]
    ```
*   📸 **After:**
    ```
    [BANNER: PLAYBOOK: site.yml [CHECK]]
    [WARNING: Running in CHECK MODE...]
    ```
*   ♿ **Accessibility:** Improved visual hierarchy by using semantic warning colors for critical mode information.

---
*PR created automatically by Jules for task [16223314898300793435](https://jules.google.com/task/16223314898300793435) started by @dolagoartur*