### PR TITLE
🎨 Palette: Use box-drawing characters for CLI headers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -48,3 +48,7 @@
 ## 2024-03-24 - [Clean Interactive Loops]
 **Learning:** Reprinting a growing list of items in an interactive loop (like adding variables) without clearing the previous iteration's output causes "scroll spam" that clutters the terminal and pushes context off-screen.
 **Action:** Use `term.clear_last_lines(n)` to refresh the list in-place, creating a stable TUI-like experience even within a simple CLI loop. Ensure output streams (stdout vs stderr) are consistent to make clearing work reliably.
+
+## 2026-07-28 - [Box Drawing for Modern Aesthetics]
+**Learning:** Legacy CLI tools often use ASCII characters (like `*`) for separators, which can feel dated. Replacing them with Unicode box-drawing characters (like `─`) creates a cleaner, more continuous visual flow that matches modern design sensibilities without sacrificing terminal compatibility.
+**Action:** Replace repeated ASCII separator characters with their Unicode box-drawing equivalents (`─`, `━`, `═`) in headers and banners to improve visual polish.

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -159,7 +159,7 @@ impl OutputFormatter {
         }
 
         let header = format!("PLAY [{}]", play_name);
-        let stars = "*".repeat(80_usize.saturating_sub(measure_text_width(&header)));
+        let stars = "─".repeat(80_usize.saturating_sub(measure_text_width(&header)));
 
         if self.use_color {
             println!(
@@ -179,7 +179,7 @@ impl OutputFormatter {
         }
 
         let header = format!("TASK [{}]", task_name);
-        let stars = "*".repeat(80_usize.saturating_sub(measure_text_width(&header)));
+        let stars = "─".repeat(80_usize.saturating_sub(measure_text_width(&header)));
 
         if self.use_color {
             println!(
@@ -326,7 +326,7 @@ impl OutputFormatter {
         }
 
         let header = "PLAY RECAP";
-        let stars = "*".repeat(80 - header.len());
+        let stars = "─".repeat(80_usize.saturating_sub(measure_text_width(header)));
 
         if self.use_color {
             println!(


### PR DESCRIPTION
Replaced legacy ASCII `*` separators with Unicode `─` in CLI headers (`PLAY`, `TASK`, `PLAY RECAP`) to improve visual consistency and polish. This aligns the header style with other parts of the CLI (like the start banner) that already use box-drawing characters. Also hardened the `recap` header calculation against potential length issues.

Testing:
- Verified `cargo build` passes.
- Verified `cargo test --lib cli::output::tests` passes.


---
*PR created automatically by Jules for task [5241128654842077014](https://jules.google.com/task/5241128654842077014) started by @dolagoartur*