### PR TITLE
🛡️ Sentinel: Fix CRLF injection in cron module

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -85,3 +85,8 @@
 **Vulnerability:** The `UserModule` was constructing `useradd` and `usermod` commands by joining the `groups` list with commas and injecting it directly into the shell command string (e.g., `-G group1,group2`). This allowed an attacker to inject shell metacharacters (e.g., `; rm -rf /`) via a malicious group name, leading to arbitrary command execution.
 **Learning:** Even when some arguments are escaped (like `name` or `home`), missing escaping on any user-controlled input that is part of a shell command string compromises the entire command. String concatenation for shell commands is inherently risky.
 **Prevention:** Always use `shell_escape` on *all* user-provided strings before incorporating them into a shell command. For list parameters (like `groups`), ensure the *joined* result is escaped if it is treated as a single shell argument, or escape individual elements if they are separate arguments.
+
+## 2025-06-03 - CRLF Injection in Cron Module
+**Vulnerability:** The `cron` module constructed crontab entries by directly interpolating the `name`, `job`, and `user` parameters into a formatted string. This allowed an attacker to inject newline characters (`\n`), creating new crontab entries (CRLF injection) and potentially executing arbitrary commands or disrupting existing jobs.
+**Learning:** When generating configuration files or formatted strings where newlines are significant delimiters (like crontabs), user input must be strictly validated to prevent injection of delimiters.
+**Prevention:** Strictly validate all input parameters that are interpolated into line-based formats. Reject inputs containing `\n` or `\r`.

--- a/src/modules/cron.rs
+++ b/src/modules/cron.rs
@@ -318,6 +318,17 @@ impl CronModule {
         }
         Ok(())
     }
+
+    /// Validate that a string contains no newlines (CRLF injection prevention)
+    fn validate_no_newlines(value: &str, param_name: &str) -> ModuleResult<()> {
+        if value.contains('\n') || value.contains('\r') {
+            return Err(ModuleError::InvalidParameter(format!(
+                "{} cannot contain newlines (CRLF injection risk)",
+                param_name
+            )));
+        }
+        Ok(())
+    }
 }
 
 impl Module for CronModule {
@@ -335,6 +346,26 @@ impl Module for CronModule {
 
     fn required_params(&self) -> &[&'static str] {
         &["name"]
+    }
+
+    fn validate_params(&self, params: &ModuleParams) -> ModuleResult<()> {
+        if let Some(name) = params.get_string("name")? {
+            Self::validate_no_newlines(&name, "name")?;
+        }
+
+        if let Some(job) = params.get_string("job")? {
+            Self::validate_no_newlines(&job, "job")?;
+        }
+
+        if let Some(user) = params.get_string("user")? {
+            Self::validate_no_newlines(&user, "user")?;
+        }
+
+        if let Some(special_time) = params.get_string("special_time")? {
+            Self::validate_no_newlines(&special_time, "special_time")?;
+        }
+
+        Ok(())
     }
 
     fn execute(

--- a/tests/security_cron_crlf.rs
+++ b/tests/security_cron_crlf.rs
@@ -1,0 +1,45 @@
+use rustible::modules::cron::CronModule;
+use rustible::modules::Module;
+use std::collections::HashMap;
+
+#[test]
+fn test_cron_module_rejects_crlf_in_name() {
+    let module = CronModule;
+    let mut params = HashMap::new();
+    params.insert("name".to_string(), serde_json::json!("job\nname"));
+    params.insert("job".to_string(), serde_json::json!("echo hello"));
+
+    // This should fail after fix
+    let result = module.validate_params(&params);
+
+    // For now (before fix), we assert that it is NOT an error, to verify the test runs.
+    // BUT since I am implementing the fix, I want this test to pass IF it returns an error.
+    // Since I haven't implemented the fix yet, this test will fail if I assert is_err().
+    // I will write the test assuming the fix is present, so it will fail now, confirming the need for a fix.
+    assert!(result.is_err(), "Should reject newlines in name");
+}
+
+#[test]
+fn test_cron_module_rejects_crlf_in_job() {
+    let module = CronModule;
+    let mut params = HashMap::new();
+    params.insert("name".to_string(), serde_json::json!("job"));
+    params.insert("job".to_string(), serde_json::json!("echo hello\nrm -rf /"));
+
+    // This should fail after fix
+    let result = module.validate_params(&params);
+    assert!(result.is_err(), "Should reject newlines in job");
+}
+
+#[test]
+fn test_cron_module_rejects_crlf_in_user() {
+    let module = CronModule;
+    let mut params = HashMap::new();
+    params.insert("name".to_string(), serde_json::json!("job"));
+    params.insert("job".to_string(), serde_json::json!("echo hello"));
+    params.insert("user".to_string(), serde_json::json!("root\n"));
+
+    // This should fail after fix
+    let result = module.validate_params(&params);
+    assert!(result.is_err(), "Should reject newlines in user");
+}


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix CRLF injection vulnerability in cron module

🚨 Severity: HIGH
💡 Vulnerability: The `cron` module was vulnerable to CRLF injection. User-supplied parameters (`name`, `job`, `user`) were interpolated directly into crontab lines without validation for newline characters. This allowed an attacker to inject arbitrary cron entries by including `\n` in these fields.
🎯 Impact: An attacker could execute arbitrary commands with the privileges of the target user by injecting malicious cron jobs.
🔧 Fix: Implemented strict validation in `CronModule` to reject any parameter containing newlines (`\n` or `\r`).
✅ Verification: Added a new test suite `tests/security_cron_crlf.rs` which verifies that `CronModule::validate_params` correctly returns an error when newlines are present in susceptible fields. All tests pass.

---
*PR created automatically by Jules for task [17550742486788610109](https://jules.google.com/task/17550742486788610109) started by @dolagoartur*