### PR TITLE
🎨 Palette: Mask input for `vault encrypt-string`

### DIFF
--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -619,9 +619,10 @@ impl VaultArgs {
                 let plaintext = if let Some(ref s) = args.string {
                     s.as_bytes().to_vec()
                 } else if std::io::stdin().is_terminal() {
-                    let input: String = Input::with_theme(&ColorfulTheme::default())
-                        .with_prompt("📝 Enter text to encrypt")
-                        .interact_text()?;
+                    let input = dialoguer::Password::with_theme(&ColorfulTheme::default())
+                        .with_prompt("📝 Enter text to encrypt (hidden)")
+                        .with_confirmation("🔐 Confirm text to encrypt", "Inputs do not match")
+                        .interact()?;
                     input.as_bytes().to_vec()
                 } else {
                     let mut input = String::new();


### PR DESCRIPTION
This PR enhances the UX and security of the `rustible vault encrypt-string` command by masking the interactive input. Previously, the command echoed the input text to the terminal, which is insecure for secrets.

**Changes:**
- Switched from `dialoguer::Input` to `dialoguer::Password` for `encrypt-string` when running interactively.
- Added a confirmation step (`.with_confirmation()`) to ensure the user inputs the correct secret, as they can no longer see it.
- Updated prompt text for clarity.

**Verification:**
- Verified with `cargo check` and `cargo test --bin rustible`.
- Code review confirmed the change is correct and beneficial.

---
*PR created automatically by Jules for task [5759877602204553709](https://jules.google.com/task/5759877602204553709) started by @dolagoartur*