### PR TITLE
🛡️ Sentinel: [HIGH] Fix CRLF injection in CronModule

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -85,3 +85,8 @@
 **Vulnerability:** The `UserModule` was constructing `useradd` and `usermod` commands by joining the `groups` list with commas and injecting it directly into the shell command string (e.g., `-G group1,group2`). This allowed an attacker to inject shell metacharacters (e.g., `; rm -rf /`) via a malicious group name, leading to arbitrary command execution.
 **Learning:** Even when some arguments are escaped (like `name` or `home`), missing escaping on any user-controlled input that is part of a shell command string compromises the entire command. String concatenation for shell commands is inherently risky.
 **Prevention:** Always use `shell_escape` on *all* user-provided strings before incorporating them into a shell command. For list parameters (like `groups`), ensure the *joined* result is escaped if it is treated as a single shell argument, or escape individual elements if they are separate arguments.
+
+## 2025-02-17 - Cron Module CRLF Injection
+**Vulnerability:** The `CronModule` in `src/modules/cron.rs` was vulnerable to CRLF injection because it did not validate that the `name` (and other parameters like `job`) of a cron job were free of newline characters. This allowed an attacker to inject arbitrary lines into the crontab file, potentially creating malicious cron jobs running as the target user.
+**Learning:** When generating configuration files that are line-based (like crontabs), always validate user input for newline characters to prevent injection of new entries.
+**Prevention:** Implement strict validation for all parameters that are written to line-based configuration files. Use helper functions like `validate_no_newlines` to enforce this constraint consistently.

--- a/src/modules/cron.rs
+++ b/src/modules/cron.rs
@@ -318,6 +318,17 @@ impl CronModule {
         }
         Ok(())
     }
+
+    /// Validate that a string does not contain newlines to prevent injection
+    fn validate_no_newlines(value: &str, param_name: &str) -> ModuleResult<()> {
+        if value.contains('\n') || value.contains('\r') {
+            return Err(ModuleError::InvalidParameter(format!(
+                "{} cannot contain newlines",
+                param_name
+            )));
+        }
+        Ok(())
+    }
 }
 
 impl Module for CronModule {
@@ -349,13 +360,23 @@ impl Module for CronModule {
         })?;
 
         let name = params.get_string_required("name")?;
+        Self::validate_no_newlines(&name, "name")?;
+
         let state_str = params
             .get_string("state")?
             .unwrap_or_else(|| "present".to_string());
         let state = CronState::from_str(&state_str)?;
 
         let job_cmd = params.get_string("job")?;
+        if let Some(ref j) = job_cmd {
+            Self::validate_no_newlines(j, "job")?;
+        }
+
         let user = params.get_string("user")?;
+        if let Some(ref u) = user {
+            Self::validate_no_newlines(u, "user")?;
+        }
+
         let minute = params
             .get_string("minute")?
             .unwrap_or_else(|| "*".to_string());
@@ -374,6 +395,7 @@ impl Module for CronModule {
 
         // Validate special_time if provided
         if let Some(ref st) = special_time {
+            Self::validate_no_newlines(st, "special_time")?;
             if !SPECIAL_TIME_REGEX.is_match(st) {
                 return Err(ModuleError::InvalidParameter(format!(
                     "Invalid special_time '{}'. Valid values: @reboot, @yearly, @annually, @monthly, @weekly, @daily, @midnight, @hourly",
@@ -592,5 +614,16 @@ mod tests {
         assert_eq!(module.name(), "cron");
         assert_eq!(module.classification(), ModuleClassification::RemoteCommand);
         assert_eq!(module.required_params(), &["name"]);
+    }
+
+    #[test]
+    fn test_validate_no_newlines() {
+        assert!(CronModule::validate_no_newlines("test", "name").is_ok());
+        assert!(CronModule::validate_no_newlines("test_123", "name").is_ok());
+
+        // Test newline injection
+        assert!(CronModule::validate_no_newlines("test\n", "name").is_err());
+        assert!(CronModule::validate_no_newlines("test\rinjection", "name").is_err());
+        assert!(CronModule::validate_no_newlines("multi\nline", "name").is_err());
     }
 }


### PR DESCRIPTION
Implemented `validate_no_newlines` helper in `CronModule` and applied it to `name`, `job`, `user`, and `special_time` parameters to prevent attackers from injecting arbitrary lines into crontab files. Added unit tests to verify the validation logic.

---
*PR created automatically by Jules for task [11351291172106274714](https://jules.google.com/task/11351291172106274714) started by @dolagoartur*