### PR TITLE
docs: update fail module status to implemented

### DIFF
--- a/docs/compatibility/ansible.md
+++ b/docs/compatibility/ansible.md
@@ -179,7 +179,7 @@ cargo build --release --features full-cloud
 | `debug` | Yes | Yes | Needs tests |
 | `set_fact` | Yes | Yes | Needs tests |
 | `assert` | Yes | Yes | Needs tests |
-| `fail` | Yes | No | Planned for v0.2 |
+| `fail` | Yes | Yes | 5 tests |
 | `meta` | Yes | No | Planned for v0.2 |
 | `include_vars` | Yes | Yes | Needs tests |
 | `pause` | Yes | Yes | 31 tests |


### PR DESCRIPTION
## Summary
- Update `fail` module status from "No / Planned for v0.2" to "Yes / 5 tests" in compatibility docs
- Module is fully implemented (138 LOC, 5 tests) in `src/modules/fail.rs` and registered in mod.rs

## Test plan
- [x] Verify `src/modules/fail.rs` exists with implementation and tests
- [x] Verify module is registered in `src/modules/mod.rs`

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)