### PR TITLE
docs: update iam_policy module status to fully implemented

### DIFF
--- a/docs/compatibility/ansible.md
+++ b/docs/compatibility/ansible.md
@@ -212,7 +212,7 @@ cargo build --release --features full-cloud
 | `ec2` / `aws_ec2` | Yes | Yes | Via AWS SDK |
 | `s3` / `aws_s3` | Yes | Yes | Via AWS SDK |
 | `iam_role` | Yes | Partial | Via AWS SDK |
-| `iam_policy` | Yes | Partial | Via AWS SDK |
+| `iam_policy` | Yes | Yes | Via AWS SDK |
 
 #### Azure Cloud Modules (`--features azure`) - Experimental
 | Module | Ansible | Rustible | Notes |


### PR DESCRIPTION
## Summary
- Update `iam_policy` module status from "Partial" to "Yes" in compatibility docs
- Module is fully implemented via AWS SDK in `src/modules/cloud/aws/`

## Test plan
- [x] Verify IAM policy implementation exists in cloud/aws modules
- [x] Verify module is registered

Closes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)