### PR TITLE
docs: update win_copy module status to fully implemented

### DIFF
--- a/docs/compatibility/ansible.md
+++ b/docs/compatibility/ansible.md
@@ -235,7 +235,7 @@ cargo build --release --features full-cloud
 #### Windows Modules (`--features winrm`) - Experimental
 | Module | Ansible | Rustible | Notes |
 |--------|---------|----------|-------|
-| `win_copy` | Yes | Partial | Requires WinRM |
+| `win_copy` | Yes | Yes | 7 tests, requires WinRM |
 | `win_feature` | Yes | Partial | Requires WinRM |
 | `win_service` | Yes | Partial | Requires WinRM |
 | `win_package` | Yes | Partial | Requires WinRM |


### PR DESCRIPTION
## Summary
- Update `win_copy` module status from "Partial" to "Yes / 7 tests, requires WinRM"
- Module is fully implemented in `src/modules/windows/win_copy.rs` (485 LOC, 7 tests)

## Test plan
- [x] Verify `src/modules/windows/win_copy.rs` exists with implementation and tests

Closes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)