### PR TITLE
docs: update mysql_db module status to implemented

### DIFF
--- a/docs/compatibility/ansible.md
+++ b/docs/compatibility/ansible.md
@@ -246,7 +246,7 @@ cargo build --release --features full-cloud
 |--------|---------|----------|-------|
 | `postgresql_db` | Yes | Disabled | Pending sqlx integration |
 | `postgresql_user` | Yes | Disabled | Pending sqlx integration |
-| `mysql_db` | Yes | Disabled | Pending sqlx integration |
+| `mysql_db` | Yes | Yes | Via sqlx, 6 tests, requires `database` feature |
 | `mysql_user` | Yes | Disabled | Pending sqlx integration |
 
 ---


### PR DESCRIPTION
## Summary
- Update `mysql_db` module status from "Disabled / Pending sqlx integration" to "Yes / Via sqlx, 6 tests"
- Module is fully implemented in `src/modules/database/mysql_db.rs`

## Test plan
- [x] Verify `src/modules/database/mysql_db.rs` exists with implementation and tests

Closes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)