### PR TITLE
docs: promote azure feature flag from Experimental to Beta

### DIFF
--- a/docs/compatibility/ansible.md
+++ b/docs/compatibility/ansible.md
@@ -39,7 +39,7 @@ cargo build --release --features full-cloud
 | `docker` | Stable | Docker container execution |
 | `kubernetes` | Stable | Kubernetes pod execution |
 | `aws` | Stable | AWS cloud modules (EC2, S3, IAM) |
-| `azure` | Experimental | Azure cloud modules (stub) |
+| `azure` | Beta | Azure cloud modules (VM, resource groups) |
 | `gcp` | Experimental | GCP cloud modules (stub) |
 | `database` | Experimental | Database modules (disabled) |
 | `winrm` | Experimental | Windows Remote Management |


### PR DESCRIPTION
## Summary
- Promote `azure` feature flag from "Experimental" to "Beta" in compatibility docs
- Azure cloud modules are fully implemented (1,979 LOC, 20 tests) with VM and resource group support

## Test plan
- [x] Verify Azure module implementation in `src/modules/cloud/azure/`
- [x] Verify tests exist (20 tests in vm.rs)

Closes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)