### PR TITLE
docs: promote gcp feature flag from Experimental to Beta

### DIFF
--- a/docs/compatibility/ansible.md
+++ b/docs/compatibility/ansible.md
@@ -40,7 +40,7 @@ cargo build --release --features full-cloud
 | `kubernetes` | Stable | Kubernetes pod execution |
 | `aws` | Stable | AWS cloud modules (EC2, S3, IAM) |
 | `azure` | Experimental | Azure cloud modules (stub) |
-| `gcp` | Experimental | GCP cloud modules (stub) |
+| `gcp` | Beta | GCP cloud modules (Compute Engine) |
 | `database` | Experimental | Database modules (disabled) |
 | `winrm` | Experimental | Windows Remote Management |
 | `provisioning` | Experimental | Terraform-like provisioning |


### PR DESCRIPTION
## Summary
- Promote `gcp` feature flag from "Experimental" to "Beta" in compatibility docs
- GCP cloud modules are fully implemented (2,098 LOC, 15 tests) with Compute Engine support

## Test plan
- [x] Verify GCP module implementation in `src/modules/cloud/gcp/`
- [x] Verify tests exist (15 tests in compute.rs)

Closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)