### PR TITLE
docs: promote provisioning feature flag from Experimental to Beta

### DIFF
--- a/docs/compatibility/ansible.md
+++ b/docs/compatibility/ansible.md
@@ -43,7 +43,7 @@ cargo build --release --features full-cloud
 | `gcp` | Experimental | GCP cloud modules (stub) |
 | `database` | Experimental | Database modules (disabled) |
 | `winrm` | Experimental | Windows Remote Management |
-| `provisioning` | Experimental | Terraform-like provisioning |
+| `provisioning` | Beta | Terraform-like provisioning (state, plans, apply) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Promote `provisioning` feature flag from "Experimental" to "Beta"
- Provisioning engine is fully implemented (21,746 LOC, 333 tests) with state, plans, and apply

## Test plan
- [x] Verify provisioning implementation in `src/provisioning/`
- [x] Verify extensive test coverage (333 tests)

Closes #700

🤖 Generated with [Claude Code](https://claude.com/claude-code)