### PR TITLE
docs: update drift detection status to fully implemented

### DIFF
--- a/docs/compatibility/ansible.md
+++ b/docs/compatibility/ansible.md
@@ -105,7 +105,7 @@ cargo build --release --features full-cloud
 |---------|---------|----------|-------|
 | Resource graph (`resource_graph`) | No | Partial | Terraform-like dependencies |
 | State management (`state_management`) | No | Partial | Terraform-style state tracking |
-| Drift detection (`drift_detection`) | No | No | Experimental |
+| Drift detection (`drift_detection`) | No | Yes | Compare current vs desired state, 24 tests |
 | Agent mode (`agent_mode`) | No | No | Experimental persistent agent |
 | Native bindings (`native_bindings`) | No | No | Experimental system integrations |
 


### PR DESCRIPTION
## Summary
- Update drift detection status from "No / Experimental" to "Yes / 24 tests"
- Implemented in `src/drift/` (2,023 LOC) with history tracking, timeline, correlation, and export

## Test plan
- [x] Verify drift detection implementation exists with tests

Closes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)