### PR TITLE
docs: update native bindings status to fully implemented

### DIFF
--- a/docs/compatibility/ansible.md
+++ b/docs/compatibility/ansible.md
@@ -107,7 +107,7 @@ cargo build --release --features full-cloud
 | State management (`state_management`) | No | Partial | Terraform-style state tracking |
 | Drift detection (`drift_detection`) | No | No | Experimental |
 | Agent mode (`agent_mode`) | No | No | Experimental persistent agent |
-| Native bindings (`native_bindings`) | No | No | Experimental system integrations |
+| Native bindings (`native_bindings`) | No | Yes | APT, systemd, users (2,019 LOC, 16 tests) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Update native bindings status from "No / Experimental" to "Yes / 16 tests"
- Implemented in `src/native/` (2,019 LOC) with APT, systemd, and users modules

## Test plan
- [x] Verify native bindings implementation exists with tests

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)