### PR TITLE
docs: document lockfile support in provisioning features

### DIFF
--- a/docs/compatibility/ansible.md
+++ b/docs/compatibility/ansible.md
@@ -108,6 +108,7 @@ cargo build --release --features full-cloud
 | Drift detection (`drift_detection`) | No | No | Experimental |
 | Agent mode (`agent_mode`) | No | Yes | Persistent agent with polling, 5 tests |
 | Native bindings (`native_bindings`) | No | No | Experimental system integrations |
+| Lockfiles (`lockfiles`) | No | Yes | Provider lockfiles and state locking, 17 tests |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add lockfile row to Provisioning and Agent Features table
- Lockfile support implemented in `src/provisioning/provider_lockfile.rs` (741 LOC, 17 tests) and `state_lock.rs` (1,333 LOC)

## Test plan
- [x] Verify lockfile implementation exists with tests

Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)