### PR TITLE
🎨 Palette: Improve CLI output visual polish with box drawing characters

### DIFF
--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -124,15 +124,19 @@ impl OutputFormatter {
         }
 
         let width = measure_text_width(title);
-        let line = "─".repeat(width + 4);
+        let horizontal = "─".repeat(width + 4);
+
         if self.use_color {
-            println!("\n{}", line.bright_blue());
-            println!("{}", format!("  {}  ", title).bright_blue().bold());
-            println!("{}\n", line.bright_blue());
+            println!("\n{}", format!("┌{}┐", horizontal).bright_blue());
+            println!(
+                "{}",
+                format!("│  {}  │", title).bright_blue().bold()
+            );
+            println!("{}\n", format!("└{}┘", horizontal).bright_blue());
         } else {
-            println!("\n{}", line);
-            println!("  {}  ", title);
-            println!("{}\n", line);
+            println!("\n┌{}┐", horizontal);
+            println!("│  {}  │", title);
+            println!("└{}┘\n", horizontal);
         }
     }
 
@@ -145,10 +149,10 @@ impl OutputFormatter {
         let width = measure_text_width(title);
         if self.use_color {
             println!("\n{}", title.cyan().bold());
-            println!("{}", "-".repeat(width).cyan());
+            println!("{}", "─".repeat(width).cyan());
         } else {
             println!("\n{}", title);
-            println!("{}", "-".repeat(width));
+            println!("{}", "─".repeat(width));
         }
     }
 


### PR DESCRIPTION
Improved the visual polish of the CLI output by using Unicode box drawing characters for banners and section headers.

- **Banner:** Now displays a boxed title using `┌`, `┐`, `└`, `┘`, `│`, `─` characters.
- **Section:** Now uses the `─` character for underlining, providing consistency with other headers like Play and Task headers.

This change enhances the readability and professional look of the tool's output without introducing new dependencies or changing functionality.

---
*PR created automatically by Jules for task [63065086227291220](https://jules.google.com/task/63065086227291220) started by @dolagoartur*