### PR TITLE
docs: define beta entry criteria and close alpha checklist gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ performance/security characteristics.
   focuses on state inventory and workflow bridging, not full replacement.
 - Several feature flags remain stubbed or partial and require explicit
   `experimental` opt-in (see `Cargo.toml`).
-- Security hardening and coverage gaps are tracked in `docs/ALPHA_READINESS_ISSUES.md`.
-- Maintainers can track release tasks in `docs/ALPHA_LAUNCH_CHECKLIST.md`.
+- Alpha readiness risks and active ownership are tracked in `docs/ALPHA_READINESS_ISSUES.md`.
+- Alpha release execution tasks are tracked in `docs/ALPHA_LAUNCH_CHECKLIST.md`.
+- Beta promotion criteria and sign-off requirements are defined in `docs/BETA_ENTRY_CRITERIA.md`.
 - Use in production environments only after validating against your own risk model.
 
 ## Quick Start

--- a/docs/ALPHA_LAUNCH_CHECKLIST.md
+++ b/docs/ALPHA_LAUNCH_CHECKLIST.md
@@ -1,32 +1,95 @@
 # Alpha Launch Checklist
 
-This checklist is a short, maintainer-focused guide for an alpha release.
+Use this checklist for each alpha release candidate. An item is complete only when
+the checkbox is checked and both `Owner` and `Evidence` are filled in.
+
+## Release Snapshot
+
+- Release candidate: `TBD`
+- Target ship date: `TBD`
+- Release lead: `TBD`
+- Last updated: `YYYY-MM-DD`
 
 ## Product and Messaging
-- [ ] Confirm README alpha status is visible and accurate.
-- [ ] Document the supported feature flags and known limitations.
-- [ ] Publish or update alpha release notes in `docs/CHANGELOG.md`.
+
+- [ ] README alpha status reflects current scope, risks, and supported scenarios.
+  - Owner: `TBD`
+  - Evidence: `README.md` line reference or PR link.
+- [ ] Experimental features and feature-flag expectations are documented.
+  - Owner: `TBD`
+  - Evidence: Link to `Cargo.toml` + docs update.
+- [ ] Alpha release notes are published in `docs/CHANGELOG.md`.
+  - Owner: `TBD`
+  - Evidence: Changelog section link.
 
 ## Documentation
-- [ ] Link to `CONTRIBUTING.md`, `SECURITY.md`, and `CODE_OF_CONDUCT.md` from README.
-- [ ] Ensure the quick start and migration guides match current CLI behavior.
-- [ ] Keep `docs/ALPHA_READINESS_ISSUES.md` up to date.
+
+- [ ] README links to `CONTRIBUTING.md`, `SECURITY.md`, and `CODE_OF_CONDUCT.md`.
+  - Owner: `TBD`
+  - Evidence: `README.md` line reference.
+- [ ] Quick start commands are validated against current CLI behavior.
+  - Owner: `TBD`
+  - Evidence: Command output for `rustible run` and `rustible check`.
+- [ ] `docs/ALPHA_READINESS_ISSUES.md` is reviewed and has owner/evidence on all open risks.
+  - Owner: `TBD`
+  - Evidence: Last-reviewed date + updated rows in readiness doc.
 
 ## Security and Safety
-- [ ] Resolve any critical security audit items.
-- [ ] Run dependency scanning (for example, `cargo audit`).
-- [ ] Validate default settings for SSH host key checking and vault usage.
+
+- [ ] No untriaged critical findings remain from current security work.
+  - Owner: `TBD`
+  - Evidence: Security issue links and current disposition.
+- [ ] Dependency scan passes (for example: `cargo audit`).
+  - Owner: `TBD`
+  - Evidence: Latest command output or CI job URL.
+- [ ] SSH host key checking and vault defaults are validated for safe baseline behavior.
+  - Owner: `TBD`
+  - Evidence: Config snippet and test notes.
 
 ## Quality and Testing
-- [ ] CI is green for `ci.yml`, `security.yml`, and `docker.yml`.
-- [ ] Run `cargo test --all-features` on a clean workspace.
-- [ ] Smoke test `rustible run`, `rustible check`, and `rustible vault` on a sample inventory.
+
+- [ ] `ci.yml`, `security.yml`, and `docker.yml` are green on the candidate commit.
+  - Owner: `TBD`
+  - Evidence: Workflow run URLs.
+- [ ] `cargo test --all-features` passes on a clean workspace.
+  - Owner: `TBD`
+  - Evidence: Local run log or CI artifact.
+- [ ] Smoke tests pass for `rustible run`, `rustible check`, and `rustible vault`.
+  - Owner: `TBD`
+  - Evidence: Command transcript or test script output.
 
 ## Release and Distribution
-- [ ] Verify release workflow builds artifacts for all targets.
-- [ ] Confirm Docker image builds and tags if shipping containers.
-- [ ] Tag the release using semver (alpha tags allowed).
+
+- [ ] Release workflow artifacts are produced for supported targets.
+  - Owner: `TBD`
+  - Evidence: Artifact list with run URL.
+- [ ] Docker image build/tag process is verified (if containers are shipped).
+  - Owner: `TBD`
+  - Evidence: Image tag and digest.
+- [ ] Alpha tag and release commit are prepared using semver alpha format.
+  - Owner: `TBD`
+  - Evidence: Proposed tag name and commit SHA.
 
 ## Feedback and Support
-- [ ] Decide how users should file issues and share feedback.
-- [ ] Track alpha adopters and early feedback themes.
+
+- [ ] Feedback intake path is explicit (GitHub issue labels/templates or discussion path).
+  - Owner: `TBD`
+  - Evidence: Link to issue template, label, or docs section.
+- [ ] Alpha adopter feedback themes are tracked in one place.
+  - Owner: `TBD`
+  - Evidence: Link to tracking issue/project.
+
+## Alpha Go/No-Go Sign-Off
+
+- [ ] Engineering sign-off recorded.
+  - Owner: `TBD`
+  - Evidence: Link to sign-off comment.
+- [ ] Security sign-off recorded.
+  - Owner: `TBD`
+  - Evidence: Link to sign-off comment.
+- [ ] Docs/Developer experience sign-off recorded.
+  - Owner: `TBD`
+  - Evidence: Link to sign-off comment.
+- [ ] Release lead decision recorded (`GO` or `NO-GO`).
+  - Owner: `TBD`
+  - Evidence: Link to final decision record.

--- a/docs/ALPHA_READINESS_ISSUES.md
+++ b/docs/ALPHA_READINESS_ISSUES.md
@@ -1,53 +1,69 @@
 # Alpha Readiness Issues
 
-This is a triage view of open alpha launch risks based on current code TODOs and
-security audit findings. Update as items are resolved or re-scoped.
+This tracker captures alpha risks and their current disposition. Every open item
+must keep ownership, next action, and evidence current.
+
+- Last reviewed: `YYYY-MM-DD`
+- Release lead: `TBD`
 
 ## Blockers (must fix before alpha)
 
-## High (should fix before alpha, or document clearly)
+- _No current blockers. Add one immediately when discovered._
+
+## High (fix before alpha or explicitly waive)
+
+- _No current high-severity items. Keep this section empty only if triaged._
 
 ## Medium (fix soon or keep out of alpha scope)
-- `--ask-become-pass` is not implemented.
-  Issue: https://github.com/adolago/rustible/issues/165
-  Reference: `src/cli/commands/run.rs`.
-- Keyboard-interactive SSH auth is not implemented.
-  Issue: https://github.com/adolago/rustible/issues/166
-  Reference: `src/connection/ssh.rs`.
-- Resource graph state comparison TODO for Terraform-like flows.
-  Issue: https://github.com/adolago/rustible/issues/167
-  Reference: `src/executor/resource_graph.rs`.
-- `russh_auth` TODO for API update indicates potential drift with current russh.
-  Issue: https://github.com/adolago/rustible/issues/168
-  Reference: `src/connection/mod.rs`.
-## Low (track for later)
-- Password material is stored as `String` and not zeroized.
-  Issue: https://github.com/adolago/rustible/issues/170
-  Reference: `docs/security/SECURITY_AUDIT_REPORT.md`, `src/vault.rs`.
-- Security audit documents are dated; re-run or reconcile with current CI results.
-  Issue: https://github.com/adolago/rustible/issues/171
-  References: `docs/security/SECURITY_AUDIT_REPORT.md`, `.github/workflows/security.yml`.
+
+- [ ] `--ask-become-pass` is not implemented ([#165](https://github.com/adolago/rustible/issues/165)).
+  - Owner: `TBD`
+  - Next action: Decide implementation plan or remove from documented alpha scope.
+  - Evidence: `src/cli/commands/run.rs` and linked PR/decision issue.
+- [ ] Keyboard-interactive SSH auth is not implemented ([#166](https://github.com/adolago/rustible/issues/166)).
+  - Owner: `TBD`
+  - Next action: Implement support or document unsupported auth modes clearly.
+  - Evidence: `src/connection/ssh.rs` and linked PR/doc update.
+- [ ] Resource graph state comparison TODO remains for provisioning flows ([#167](https://github.com/adolago/rustible/issues/167)).
+  - Owner: `TBD`
+  - Next action: Implement comparison path or gate the feature out of alpha.
+  - Evidence: `tests/resource_graph_state_comparison_tests.rs` and linked implementation PR.
+- [ ] `russh_auth` TODO indicates potential API drift with current russh ([#168](https://github.com/adolago/rustible/issues/168)).
+  - Owner: `TBD`
+  - Next action: Verify current API assumptions and remove stale TODO.
+  - Evidence: `src/connection/mod.rs` and compatibility test/PR link.
+
+## Low (track for later or batch for beta)
+
+- [ ] Password material is stored as `String` and not zeroized ([#170](https://github.com/adolago/rustible/issues/170)).
+  - Owner: `TBD`
+  - Next action: Assess zeroization implementation options and risk level.
+  - Evidence: `docs/security/SECURITY_AUDIT_REPORT.md`, `src/vault.rs`.
+- [ ] Security audit documents may be stale; re-run/reconcile with current CI results ([#171](https://github.com/adolago/rustible/issues/171)).
+  - Owner: `TBD`
+  - Next action: Refresh audit artifacts and align with `.github/workflows/security.yml`.
+  - Evidence: Updated security report link + workflow run URL.
 
 ## Resolved (post-triage)
-- Privilege escalation username injection risk in become command builders.
-  Issue: https://github.com/adolago/rustible/issues/159
-  References: `docs/security/BECOME_AUDIT.md`, `src/connection/russh.rs`,
-  `src/connection/ssh.rs`, `src/connection/local.rs`.
-- Path injection risk in ownership changes during local execution.
-  Issue: https://github.com/adolago/rustible/issues/160
-  Reference: `docs/security/BECOME_AUDIT.md`, `src/connection/local.rs`.
-- Deprecated `serde_yaml` dependency flagged in security audit.
-  Issue: https://github.com/adolago/rustible/issues/161
-  References: `docs/security/SECURITY_AUDIT_REPORT.md`, `Cargo.toml`.
-- DynamoDB state lock operations implemented for provisioning backend.
-  Issue: https://github.com/adolago/rustible/issues/164
-  Reference: `src/provisioning/state_lock.rs`.
-- Stubbed feature flags gated behind explicit experimental opt-in.
-  Issue: https://github.com/adolago/rustible/issues/169
-  References: `Cargo.toml`, `README.md`.
-- Python module local execution path implemented for executor fallback.
-  Issue: https://github.com/adolago/rustible/issues/163
-  Reference: `src/executor/task.rs`.
-- Coverage improvements for executor task execution paths.
-  Issue: https://github.com/adolago/rustible/issues/162
-  Reference: `src/executor/task.rs`.
+
+- [x] Privilege escalation username injection risk in become command builders ([#159](https://github.com/adolago/rustible/issues/159)).
+  - Owner: `Completed`
+  - Evidence: `docs/security/BECOME_AUDIT.md`, `src/connection/russh.rs`, `src/connection/ssh.rs`, `src/connection/local.rs`.
+- [x] Path injection risk in ownership changes during local execution ([#160](https://github.com/adolago/rustible/issues/160)).
+  - Owner: `Completed`
+  - Evidence: `docs/security/BECOME_AUDIT.md`, `src/connection/local.rs`.
+- [x] Deprecated `serde_yaml` dependency flagged in security audit ([#161](https://github.com/adolago/rustible/issues/161)).
+  - Owner: `Completed`
+  - Evidence: `docs/security/SECURITY_AUDIT_REPORT.md`, `Cargo.toml`.
+- [x] DynamoDB state lock operations implemented for provisioning backend ([#164](https://github.com/adolago/rustible/issues/164)).
+  - Owner: `Completed`
+  - Evidence: `src/provisioning/state_lock.rs`.
+- [x] Stubbed feature flags now require explicit experimental opt-in ([#169](https://github.com/adolago/rustible/issues/169)).
+  - Owner: `Completed`
+  - Evidence: `Cargo.toml`, `README.md`.
+- [x] Python module local execution path implemented for executor fallback ([#163](https://github.com/adolago/rustible/issues/163)).
+  - Owner: `Completed`
+  - Evidence: `src/executor/task.rs`.
+- [x] Coverage improvements completed for executor task execution paths ([#162](https://github.com/adolago/rustible/issues/162)).
+  - Owner: `Completed`
+  - Evidence: `src/executor/task.rs`.

--- a/docs/BETA_ENTRY_CRITERIA.md
+++ b/docs/BETA_ENTRY_CRITERIA.md
@@ -1,0 +1,110 @@
+# Beta Entry Criteria
+
+This document defines the minimum bar to move from alpha to beta for a specific
+release candidate. All required criteria must be checked, or explicitly waived.
+
+## Candidate Snapshot
+
+- Candidate version: `TBD`
+- Target beta date: `TBD`
+- Release lead: `TBD`
+- Last updated: `YYYY-MM-DD`
+
+## Required Criteria (All Must Pass)
+
+### 1) Readiness Risk Gate
+
+- [ ] No open **Blocker** issues remain in `docs/ALPHA_READINESS_ISSUES.md`.
+  - Owner: `TBD`
+  - Evidence: Link to current readiness doc review.
+- [ ] No open **High** issues remain, or each has an approved waiver.
+  - Owner: `TBD`
+  - Evidence: Readiness doc + waiver links.
+- [ ] Any remaining **Medium/Low** issues have explicit beta disposition (`fix`, `defer`, or `out-of-scope`).
+  - Owner: `TBD`
+  - Evidence: Updated issue rows and linked decisions.
+
+### 2) Quality and Reliability Gate
+
+- [ ] `ci.yml`, `security.yml`, and `docker.yml` are green on the candidate commit.
+  - Owner: `TBD`
+  - Evidence: Workflow URLs.
+- [ ] `cargo test --all-features` passes on the candidate commit.
+  - Owner: `TBD`
+  - Evidence: CI run link or local run artifact.
+- [ ] Smoke tests pass for `rustible run`, `rustible check`, and `rustible vault`.
+  - Owner: `TBD`
+  - Evidence: Command transcript or automated smoke test log.
+
+### 3) Security and Supply Chain Gate
+
+- [ ] Dependency scan is clean or has approved risk acceptances.
+  - Owner: `TBD`
+  - Evidence: `cargo audit` output or equivalent CI log.
+- [ ] Security-sensitive defaults (SSH host key checking, vault behavior) are validated.
+  - Owner: `TBD`
+  - Evidence: Test notes or regression checklist link.
+- [ ] Security documentation is current with code and CI behavior.
+  - Owner: `TBD`
+  - Evidence: Updated docs and security workflow evidence.
+
+### 4) Docs and Operator Readiness Gate
+
+- [ ] README status and limitations are current for beta-facing users.
+  - Owner: `TBD`
+  - Evidence: `README.md` update link.
+- [ ] `docs/CHANGELOG.md` contains beta entry notes and known limitations.
+  - Owner: `TBD`
+  - Evidence: Changelog section link.
+- [ ] Support and feedback intake path is documented and active.
+  - Owner: `TBD`
+  - Evidence: Issue template/label/docs link.
+
+## Waiver Process
+
+Use a waiver only when shipping risk is understood and time-bound.
+
+1. Create a waiver record in the beta decision thread with:
+   - Criterion ID (for example: `2.2`).
+   - Risk statement and user impact.
+   - Mitigation plan and owner.
+   - Expiration date.
+2. Obtain explicit approvals from Engineering Lead and Security Lead.
+3. Link the waiver from the affected checklist item evidence field.
+
+## Required Sign-Offs
+
+- [ ] Engineering Lead sign-off recorded.
+  - Owner: `TBD`
+  - Evidence: Link to sign-off comment.
+- [ ] Security Lead sign-off recorded.
+  - Owner: `TBD`
+  - Evidence: Link to sign-off comment.
+- [ ] Docs/Developer Experience sign-off recorded.
+  - Owner: `TBD`
+  - Evidence: Link to sign-off comment.
+- [ ] Release Lead final decision recorded (`GO` or `NO-GO`).
+  - Owner: `TBD`
+  - Evidence: Link to final decision record.
+
+## Beta Decision Record Template
+
+```markdown
+## Beta Entry Decision
+- Candidate version:
+- Decision date:
+- Release lead:
+- Outcome: GO / NO-GO
+
+### Open waivers
+- Waiver ID:
+- Criterion:
+- Expiration:
+- Mitigation owner:
+
+### Sign-offs
+- Engineering Lead:
+- Security Lead:
+- Docs/DevEx Lead:
+- Release Lead:
+```


### PR DESCRIPTION
Closes #790

## Summary
- convert `docs/ALPHA_LAUNCH_CHECKLIST.md` into an actionable checklist with owner/evidence fields and explicit sign-off steps
- convert `docs/ALPHA_READINESS_ISSUES.md` into a statused risk tracker with ownership, next actions, and evidence for open/resolved items
- add `docs/BETA_ENTRY_CRITERIA.md` with explicit beta hard gates, waiver process, and required approver sign-offs
- update `README.md` alpha messaging to reference readiness tracking, alpha execution checklist, and beta entry criteria
