### PR TITLE
fix(distributed): execute work units and track task outcomes

### DIFF
--- a/src/distributed/controller.rs
+++ b/src/distributed/controller.rs
@@ -13,6 +13,7 @@ use super::types::{
     ClusterConfig, ControllerHealth, ControllerId, ControllerInfo, ControllerLoad, ControllerRole,
     TaskSpec, WorkUnit, WorkUnitId, WorkUnitState,
 };
+use indexmap::IndexMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
@@ -235,6 +236,57 @@ impl Controller {
         let mut work_unit_failed = None;
 
         for (task_index, task) in tasks.into_iter().enumerate() {
+            if let Some(condition) = task.when.as_deref() {
+                match crate::parser::evaluate_condition(condition, &IndexMap::new()) {
+                    Ok(false) => {
+                        let mut work_units = self.work_units.write().await;
+                        let execution = work_units
+                            .get_mut(&id)
+                            .ok_or_else(|| ControllerError::WorkUnitNotFound(id.clone()))?;
+                        execution.task_results.insert(
+                            task_index,
+                            TaskResult {
+                                success: true,
+                                changed: false,
+                                result: serde_json::json!({
+                                    "skipped": true,
+                                    "when": condition,
+                                }),
+                                error: None,
+                            },
+                        );
+                        continue;
+                    }
+                    Ok(true) => {}
+                    Err(error) => {
+                        let error = format!(
+                            "task {} ('{}') has invalid when condition '{}': {}",
+                            task_index, task.name, condition, error
+                        );
+                        let mut work_units = self.work_units.write().await;
+                        let execution = work_units
+                            .get_mut(&id)
+                            .ok_or_else(|| ControllerError::WorkUnitNotFound(id.clone()))?;
+                        execution.task_results.insert(
+                            task_index,
+                            Self::task_error(
+                                error.clone(),
+                                serde_json::json!({ "when": condition }),
+                            ),
+                        );
+                        if !task.ignore_errors {
+                            execution.state = WorkUnitState::Failed {
+                                error: error.clone(),
+                            };
+                            execution.work_unit.state = execution.state.clone();
+                            work_unit_failed = Some(error);
+                            break;
+                        }
+                        continue;
+                    }
+                }
+            }
+
             let task_result = self.execute_task(&task).await;
             let task_success = task_result.success;
             let task_error = task_result
@@ -652,5 +704,35 @@ mod tests {
         let task_result = execution.task_results.get(&0).unwrap();
         assert!(!task_result.success);
         assert!(task_result.error.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_execute_work_unit_skips_task_when_condition_is_false() {
+        let controller = Controller::new(test_config()).await.unwrap();
+
+        let mut task = test_task(
+            "conditionally skipped task",
+            "command",
+            HashMap::from([("program".to_string(), json!("echo"))]),
+        );
+        task.when = Some("false".to_string());
+
+        let work_unit = WorkUnit::new(RunId::generate(), 0, vec![]).with_task(task);
+        let work_unit_id = work_unit.id.clone();
+
+        controller.execute_work_unit(work_unit).await.unwrap();
+
+        let state = controller
+            .get_work_unit_status(&work_unit_id)
+            .await
+            .unwrap();
+        assert!(matches!(state, WorkUnitState::Completed));
+
+        let work_units = controller.work_units.read().await;
+        let execution = work_units.get(&work_unit_id).unwrap();
+        let task_result = execution.task_results.get(&0).unwrap();
+        assert!(task_result.success);
+        assert!(task_result.error.is_none());
+        assert_eq!(task_result.result.get("skipped"), Some(&json!(true)));
     }
 }

--- a/src/distributed/controller.rs
+++ b/src/distributed/controller.rs
@@ -11,11 +11,12 @@ use super::cluster::ClusterManager;
 use super::raft::{RaftNode, RaftState};
 use super::types::{
     ClusterConfig, ControllerHealth, ControllerId, ControllerInfo, ControllerLoad, ControllerRole,
-    WorkUnit, WorkUnitId, WorkUnitState,
+    TaskSpec, WorkUnit, WorkUnitId, WorkUnitState,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
+use tokio::process::Command;
 use tokio::sync::{mpsc, RwLock};
 
 /// Controller node for distributed execution
@@ -209,6 +210,7 @@ impl Controller {
     /// Execute a work unit locally
     async fn execute_work_unit(&self, work_unit: WorkUnit) -> Result<(), ControllerError> {
         let id = work_unit.id.clone();
+        let tasks = work_unit.tasks.clone();
 
         tracing::info!(
             "Controller {} executing work unit {}",
@@ -230,22 +232,213 @@ impl Controller {
             );
         }
 
-        // TODO: Actually execute the tasks
-        // For now, just mark as completed
-        {
+        let mut work_unit_failed = None;
+
+        for (task_index, task) in tasks.into_iter().enumerate() {
+            let task_result = self.execute_task(&task).await;
+            let task_success = task_result.success;
+            let task_error = task_result
+                .error
+                .clone()
+                .unwrap_or_else(|| format!("task '{}' failed", task.name));
+
             let mut work_units = self.work_units.write().await;
-            if let Some(execution) = work_units.get_mut(&id) {
-                execution.state = WorkUnitState::Completed;
+            let execution = work_units
+                .get_mut(&id)
+                .ok_or_else(|| ControllerError::WorkUnitNotFound(id.clone()))?;
+
+            execution.task_results.insert(task_index, task_result);
+
+            if !task_success && !task.ignore_errors {
+                let error = format!(
+                    "task {} ('{}') failed: {}",
+                    task_index, task.name, task_error
+                );
+                execution.state = WorkUnitState::Failed {
+                    error: error.clone(),
+                };
+                execution.work_unit.state = execution.state.clone();
+                work_unit_failed = Some(error);
+                break;
             }
         }
 
-        tracing::info!(
-            "Controller {} completed work unit {}",
-            self.config.controller_id,
-            id
-        );
+        if let Some(error) = work_unit_failed {
+            tracing::warn!(
+                "Controller {} failed work unit {}: {}",
+                self.config.controller_id,
+                id,
+                error
+            );
+        } else {
+            {
+                let mut work_units = self.work_units.write().await;
+                let execution = work_units
+                    .get_mut(&id)
+                    .ok_or_else(|| ControllerError::WorkUnitNotFound(id.clone()))?;
+                execution.state = WorkUnitState::Completed;
+                execution.work_unit.state = WorkUnitState::Completed;
+            }
+
+            tracing::info!(
+                "Controller {} completed work unit {}",
+                self.config.controller_id,
+                id
+            );
+        }
 
         Ok(())
+    }
+
+    async fn execute_task(&self, task: &TaskSpec) -> TaskResult {
+        match task.module.as_str() {
+            "command" => Self::execute_command_task(task).await,
+            "shell" => Self::execute_shell_task(task).await,
+            other => Self::task_error(
+                format!("unsupported task module '{}'", other),
+                serde_json::json!({ "module": other }),
+            ),
+        }
+    }
+
+    async fn execute_command_task(task: &TaskSpec) -> TaskResult {
+        let parsed =
+            if let Some(program) = task.args.get("program").and_then(|value| value.as_str()) {
+                let args = match task.args.get("argv") {
+                    Some(value) => {
+                        let Some(argv) = value.as_array() else {
+                            return Self::task_error(
+                                "command task 'argv' must be an array".to_string(),
+                                serde_json::json!({ "program": program }),
+                            );
+                        };
+
+                        let mut parsed_args = Vec::with_capacity(argv.len());
+                        for value in argv {
+                            let Some(arg) = value.as_str() else {
+                                return Self::task_error(
+                                    "command task 'argv' entries must be strings".to_string(),
+                                    serde_json::json!({ "program": program }),
+                                );
+                            };
+                            parsed_args.push(arg.to_string());
+                        }
+                        parsed_args
+                    }
+                    None => Vec::new(),
+                };
+
+                Ok((program.to_string(), args))
+            } else if let Some(cmd) = task
+                .args
+                .get("cmd")
+                .or_else(|| task.args.get("command"))
+                .and_then(|value| value.as_str())
+            {
+                match shell_words::split(cmd) {
+                    Ok(parts) if !parts.is_empty() => Ok((parts[0].clone(), parts[1..].to_vec())),
+                    Ok(_) => Err("command task 'cmd' cannot be empty".to_string()),
+                    Err(error) => Err(format!("failed to parse command task 'cmd': {}", error)),
+                }
+            } else {
+                Err("command task requires either 'program' or 'cmd' argument".to_string())
+            };
+
+        let (program, args) = match parsed {
+            Ok(value) => value,
+            Err(error) => {
+                return Self::task_error(error, serde_json::json!({ "module": "command" }))
+            }
+        };
+
+        let mut command = Command::new(&program);
+        command.args(&args);
+
+        let metadata = serde_json::json!({
+            "module": "command",
+            "program": program,
+            "args": args,
+        });
+        Self::run_process(command, metadata).await
+    }
+
+    async fn execute_shell_task(task: &TaskSpec) -> TaskResult {
+        let Some(command) = task
+            .args
+            .get("cmd")
+            .or_else(|| task.args.get("command"))
+            .and_then(|value| value.as_str())
+        else {
+            return Self::task_error(
+                "shell task requires 'cmd' argument".to_string(),
+                serde_json::json!({ "module": "shell" }),
+            );
+        };
+
+        #[cfg(target_os = "windows")]
+        let process = {
+            let mut cmd = Command::new("cmd");
+            cmd.arg("/C").arg(command);
+            cmd
+        };
+
+        #[cfg(not(target_os = "windows"))]
+        let process = {
+            let mut cmd = Command::new("sh");
+            cmd.arg("-c").arg(command);
+            cmd
+        };
+
+        let metadata = serde_json::json!({
+            "module": "shell",
+            "command": command,
+        });
+        Self::run_process(process, metadata).await
+    }
+
+    async fn run_process(mut command: Command, metadata: serde_json::Value) -> TaskResult {
+        match command.output().await {
+            Ok(output) => {
+                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                let exit_code = output.status.code();
+                let success = output.status.success();
+                let error = if success {
+                    None
+                } else if !stderr.trim().is_empty() {
+                    Some(stderr.trim().to_string())
+                } else if let Some(code) = exit_code {
+                    Some(format!("process exited with status {}", code))
+                } else {
+                    Some("process terminated by signal".to_string())
+                };
+
+                TaskResult {
+                    success,
+                    changed: false,
+                    result: serde_json::json!({
+                        "execution": metadata,
+                        "stdout": stdout,
+                        "stderr": stderr,
+                        "exit_code": exit_code,
+                    }),
+                    error,
+                }
+            }
+            Err(error) => Self::task_error(
+                format!("failed to start process: {}", error),
+                serde_json::json!({ "execution": metadata }),
+            ),
+        }
+    }
+
+    fn task_error(error: String, result: serde_json::Value) -> TaskResult {
+        TaskResult {
+            success: false,
+            changed: false,
+            result,
+            error: Some(error),
+        }
     }
 
     /// Select the best controller to execute a work unit
@@ -355,6 +548,9 @@ pub enum ControllerError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::distributed::types::{RunId, TaskSpec};
+    use serde_json::json;
+    use std::collections::HashMap;
 
     fn test_config() -> ClusterConfig {
         ClusterConfig {
@@ -388,5 +584,73 @@ mod tests {
         assert_eq!(info.id, config.controller_id);
         assert_eq!(info.health, ControllerHealth::Healthy);
         assert_eq!(info.capacity, config.capacity);
+    }
+
+    fn test_task(name: &str, module: &str, args: HashMap<String, serde_json::Value>) -> TaskSpec {
+        TaskSpec {
+            name: name.to_string(),
+            module: module.to_string(),
+            args,
+            when: None,
+            register: None,
+            ignore_errors: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_work_unit_not_completed_when_task_cannot_execute() {
+        let controller = Controller::new(test_config()).await.unwrap();
+
+        let task = test_task("missing command args", "command", HashMap::new());
+        let work_unit = WorkUnit::new(RunId::generate(), 0, vec![]).with_task(task);
+        let work_unit_id = work_unit.id.clone();
+
+        controller.execute_work_unit(work_unit).await.unwrap();
+
+        let state = controller
+            .get_work_unit_status(&work_unit_id)
+            .await
+            .unwrap();
+        assert!(matches!(state, WorkUnitState::Failed { .. }));
+        assert!(!matches!(state, WorkUnitState::Completed));
+
+        let work_units = controller.work_units.read().await;
+        let execution = work_units.get(&work_unit_id).unwrap();
+        let task_result = execution.task_results.get(&0).unwrap();
+        assert!(!task_result.success);
+        assert!(task_result.error.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_execute_work_unit_marks_failed_on_task_failure() {
+        let controller = Controller::new(test_config()).await.unwrap();
+
+        let mut args = HashMap::new();
+        args.insert("program".to_string(), json!("rustc"));
+        args.insert(
+            "argv".to_string(),
+            json!(["--definitely-invalid-flag-for-controller-test"]),
+        );
+
+        let task = test_task("failing rustc command", "command", args);
+        let work_unit = WorkUnit::new(RunId::generate(), 0, vec![]).with_task(task);
+        let work_unit_id = work_unit.id.clone();
+
+        controller.execute_work_unit(work_unit).await.unwrap();
+
+        let state = controller
+            .get_work_unit_status(&work_unit_id)
+            .await
+            .unwrap();
+        match state {
+            WorkUnitState::Failed { error } => assert!(error.contains("task 0")),
+            other => panic!("expected failed state, got {:?}", other),
+        }
+
+        let work_units = controller.work_units.read().await;
+        let execution = work_units.get(&work_unit_id).unwrap();
+        let task_result = execution.task_results.get(&0).unwrap();
+        assert!(!task_result.success);
+        assert!(task_result.error.is_some());
     }
 }


### PR DESCRIPTION
## Summary
- implement real work-unit task execution in `Controller::execute_work_unit`
- execute supported task modules (`command`, `shell`) using task `module` + `args`
- persist per-task results (stdout/stderr/exit code), errors, and final work-unit state
- mark work units `Failed` on task failures instead of placeholder completion
- add regression tests for non-placeholder completion behavior and failure-state tracking

Closes #787

## Test evidence
- `cargo test --features distributed distributed::controller::tests -- --nocapture`
- Result: 4 passed; 0 failed
- Covered tests:
  - `test_controller_creation`
  - `test_controller_info`
  - `test_execute_work_unit_not_completed_when_task_cannot_execute`
  - `test_execute_work_unit_marks_failed_on_task_failure`
