### PR TITLE
🛡️ Sentinel: [HIGH] Harden Windows command execution against injection

### DIFF
--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -409,14 +409,12 @@ pub fn validate_command_args(args: &str) -> ModuleResult<()> {
     // check if it actually contains any characters that are part of dangerous patterns.
     // If it doesn't contain any of these characters, it's safe even if it has quotes.
     //
-    // Safe characters: alphanumeric, space, _, -, ., /, :, +, =, ,, @, %
-    let is_safe = args.bytes().all(|b| {
-        matches!(b,
-            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' |
-            b' ' | b'_' | b'-' | b'.' | b'/' | b':' |
-            b'+' | b'=' | b',' | b'@' | b'%'
-        )
-    });
+    // Safe characters: alphanumeric, space, _, -, ., /, :, +, =, ,, @
+    let is_safe = args.bytes().all(|b| matches!(b,
+        b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' |
+        b' ' | b'_' | b'-' | b'.' | b'/' | b':' |
+        b'+' | b'=' | b',' | b'@'
+    ));
 
     if !has_dangerous_chars {
         return Ok(());
@@ -449,7 +447,7 @@ pub fn validate_command_args(args: &str) -> ModuleResult<()> {
         ("$", "variable expansion $"),
         ("#", "shell comment #"),
         ("%", "variable expansion %"),
-        ("^", "shell escape ^"),
+        ("^", "cmd.exe escape ^"),
     ];
 
     for (pattern, description) in dangerous_patterns {
@@ -2108,6 +2106,13 @@ mod tests {
         // Currently, without the fix, this test would fail (because it returns Ok).
         // The goal is to make this test pass by fixing the code to return Err.
         assert!(validate_command_args("bash -c 'echo pwned' #").is_err());
+    }
+
+    #[test]
+    fn test_validate_command_args_rejects_windows_metachars() {
+        assert!(validate_command_args("echo %USERNAME%").is_err());
+        assert!(validate_command_args("echo ^& calc.exe").is_err());
+        assert!(validate_command_args("%COMSPEC%").is_err());
     }
 
     #[test]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -168,6 +168,10 @@ pub fn cmd_escape(s: &str) -> Cow<'_, str> {
     for c in s.chars() {
         if c == '"' {
             escaped.push_str("\"\"");
+        } else if c == '%' {
+            // Insert empty string ("") after % to prevent variable expansion in cmd.exe
+            // e.g. %VAR% becomes %""VAR%""
+            escaped.push_str("%\"\"");
         } else {
             escaped.push(c);
         }
@@ -353,6 +357,11 @@ mod tests {
         assert_eq!(cmd_escape("foo&bar"), "\"foo&bar\"");
         assert_eq!(cmd_escape("foo|bar"), "\"foo|bar\"");
         assert_eq!(cmd_escape(""), "\"\"");
+
+        // Test environment variable expansion prevention
+        // % is replaced with %"" which breaks the variable token in cmd.exe
+        assert_eq!(cmd_escape("%USERNAME%"), "\"%\"\"USERNAME%\"\"\"");
+        assert_eq!(cmd_escape("foo%bar"), "\"foo%\"\"bar\"");
     }
 
     #[test]


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Harden Windows command execution against injection

🚨 Severity: HIGH
💡 Vulnerability: Windows command execution via `cmd.exe` allows environment variable expansion (`%VAR%`) and special character escaping (`^`) even inside double quotes (for `%`) or in raw strings. This could allow attackers to inject commands or disclose environment variables if they can control part of the command string.
🎯 Impact: Potential Remote Code Execution (RCE) or Information Disclosure on Windows hosts if user input is used to construct commands.
🔧 Fix:
    1.  Modified `cmd_escape` to neutralize `%` by injecting empty strings (`%""`), which breaks variable tokens in `cmd.exe` without altering the literal string value.
    2.  Updated `validate_command_args` to reject `%` and `^` in raw command strings, forcing a "fail-closed" behavior for these dangerous characters.
✅ Verification: Added unit tests `test_cmd_escape` (verifying `%` escaping) and `test_validate_command_args_rejects_windows_metachars` (verifying rejection of `%` and `^`). Confirmed that all module tests pass.

---
*PR created automatically by Jules for task [9490688386948733044](https://jules.google.com/task/9490688386948733044) started by @dolagoartur*