### PR TITLE
🎨 Palette: Improve interactive file selection UX

### DIFF
--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -110,8 +110,10 @@ impl InteractiveSession {
                 .validate_with(|input: &String| -> Result<(), &str> {
                     let expanded = shellexpand::tilde(input);
                     let path = Path::new(expanded.as_ref());
-                    if path.exists() {
+                    if path.is_file() {
                         Ok(())
+                    } else if path.exists() {
+                        Err("Path is a directory; please provide a playbook file")
                     } else {
                         Err("Path does not exist")
                     }
@@ -139,8 +141,10 @@ impl InteractiveSession {
                 .validate_with(|input: &String| -> Result<(), &str> {
                     let expanded = shellexpand::tilde(input);
                     let path = Path::new(expanded.as_ref());
-                    if path.exists() {
+                    if path.is_file() {
                         Ok(())
+                    } else if path.exists() {
+                        Err("Path is a directory; please provide a playbook file")
                     } else {
                         Err("Path does not exist")
                     }

--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use colored::Colorize;
 use console::Term;
 use dialoguer::{theme::ColorfulTheme, Confirm, Input, MultiSelect, Select};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Interactive session state
 pub struct InteractiveSession {
@@ -101,20 +101,54 @@ impl InteractiveSession {
     /// Prompt for playbook selection
     pub fn select_playbook(&self, playbooks: &[PathBuf]) -> Result<Option<PathBuf>> {
         if playbooks.is_empty() {
-            println!("{}", "No playbooks found in current directory.".yellow());
-            return Ok(None);
+            println!(
+                "{}",
+                "No playbooks found. Please enter path manually.".yellow()
+            );
+            let custom: String = Input::with_theme(&self.theme)
+                .with_prompt("✏️  Enter playbook path")
+                .validate_with(|input: &String| -> Result<(), &str> {
+                    let expanded = shellexpand::tilde(input);
+                    let path = Path::new(expanded.as_ref());
+                    if path.exists() {
+                        Ok(())
+                    } else {
+                        Err("Path does not exist")
+                    }
+                })
+                .interact_on(&self.term)?;
+            let expanded = shellexpand::tilde(&custom);
+            return Ok(Some(PathBuf::from(expanded.as_ref())));
         }
 
-        let items: Vec<String> = playbooks
+        let mut items: Vec<String> = playbooks
             .iter()
             .map(|p| format!("📖 {}", p.display()))
             .collect();
+        items.push("✏️ Enter custom path...".to_string());
 
         let selection = Select::with_theme(&self.theme)
             .with_prompt("📖 Select a playbook")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;
+
+        if selection == items.len() - 1 {
+            let custom: String = Input::with_theme(&self.theme)
+                .with_prompt("✏️  Enter playbook path")
+                .validate_with(|input: &String| -> Result<(), &str> {
+                    let expanded = shellexpand::tilde(input);
+                    let path = Path::new(expanded.as_ref());
+                    if path.exists() {
+                        Ok(())
+                    } else {
+                        Err("Path does not exist")
+                    }
+                })
+                .interact_on(&self.term)?;
+            let expanded = shellexpand::tilde(&custom);
+            return Ok(Some(PathBuf::from(expanded.as_ref())));
+        }
 
         Ok(Some(playbooks[selection].clone()))
     }
@@ -125,11 +159,17 @@ impl InteractiveSession {
             let custom: String = Input::with_theme(&self.theme)
                 .with_prompt("✏️  Enter inventory path (or 'localhost' for local)")
                 .default("localhost".to_string())
-                .validate_with(|input: &String| -> Result<(), String> {
+                .validate_with(|input: &String| -> Result<(), &str> {
                     if input == "localhost" {
                         return Ok(());
                     }
-                    validate_path_exists(input)
+                    let expanded = shellexpand::tilde(input);
+                    let path = Path::new(expanded.as_ref());
+                    if path.exists() {
+                        Ok(())
+                    } else {
+                        Err("Path does not exist")
+                    }
                 })
                 .interact_on(&self.term)?;
 
@@ -160,8 +200,23 @@ impl InteractiveSession {
         if selection == items.len() - 2 {
             let custom: String = Input::with_theme(&self.theme)
                 .with_prompt("✏️  Enter inventory path")
-                .validate_with(validate_path_exists)
+                .validate_with(|input: &String| -> Result<(), &str> {
+                    if input == "localhost" {
+                        return Ok(());
+                    }
+                    let expanded = shellexpand::tilde(input);
+                    let path = Path::new(expanded.as_ref());
+                    if path.exists() {
+                        Ok(())
+                    } else {
+                        Err("Path does not exist")
+                    }
+                })
                 .interact_on(&self.term)?;
+
+            if custom == "localhost" {
+                return Ok(None);
+            }
             let expanded = shellexpand::tilde(&custom);
             return Ok(Some(PathBuf::from(expanded.as_ref())));
         }


### PR DESCRIPTION
This PR enhances the interactive mode UX (`src/cli/interactive.rs`) by adding proper validation and usability improvements for file selection.

**Changes:**
1.  **Custom Playbook Selection:** Added a "Enter custom path..." option to the playbook selection list, allowing users to select playbooks outside the current directory or `playbooks/` folder.
2.  **Path Validation:** Implemented validation for custom inventory and playbook paths. The CLI now checks if the entered path exists *before* accepting it, preventing runtime errors later.
3.  **Tilde Expansion:** Used `shellexpand::tilde` to support `~/path/to/file` syntax in interactive prompts, which is a standard and expected shell behavior.
4.  **Empty State Handling:** When no playbooks are found, instead of just printing a warning and exiting the menu, the CLI now prompts the user to enter a path manually.

**UX Improvements:**
-   **Prevents Errors:** Users get immediate feedback if they type a non-existent path.
-   **More Flexible:** Users can easily run playbooks/inventories from anywhere on the filesystem without leaving interactive mode.
-   **More Intuitive:** Supports standard shell tilde expansion for home directories.

**Testing:**
-   Verified `cargo check` passes.
-   Code logic uses standard `Path::exists()` and `shellexpand` which are reliable.
-   Existing unit tests passed (no regressions).


---
*PR created automatically by Jules for task [11580466807717561149](https://jules.google.com/task/11580466807717561149) started by @dolagoartur*