### PR TITLE
🎨 Palette: Improve interactive step prompt visibility

### DIFF
--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -137,6 +137,7 @@ use crate::recovery::{RecoveryManager, TaskOutcome, TransactionId};
 
 use dialoguer::theme::ColorfulTheme;
 use console::Term;
+use colored::Colorize;
 
 /// Errors that can occur during playbook and task execution.
 ///
@@ -991,7 +992,13 @@ impl Executor {
 
             if step_mode {
                 let term = Term::stderr();
-                let prompt = format!("Perform task: {}?", task.name);
+                let prompt = format!(
+                    "{} {} ({}) {}",
+                    "Perform task:".bold(),
+                    task.name.cyan().bold(),
+                    task.module.dimmed(),
+                    "[y,n,c,a]".dimmed()
+                );
                 let mut continue_outer_loop = false;
 
                 loop {


### PR DESCRIPTION
*   💡 **What:** Enhanced the interactive task confirmation prompt (`--step`) with colors and better formatting.
*   🎯 **Why:** The previous prompt was plain and didn't clearly indicate available options. Users might not know they can abort or continue without stepping.
*   📸 **Changes:**
    *   Bold "Perform task:" label.
    *   Cyan Task Name for visibility.
    *   Dimmed module name for context.
    *   Explicit `[y,n,c,a]` hint.
*   ♿ **Accessibility:** Improved visual hierarchy with color and font weight. Added explicit hints for keyboard interaction options.

---
*PR created automatically by Jules for task [1502392820458538780](https://jules.google.com/task/1502392820458538780) started by @dolagoartur*