### PR TITLE
⚡ Bolt: Optimize shell_escape performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,6 +319,10 @@ harness = false
 name = "inventory_scale"
 harness = false
 
+[[bench]]
+name = "utils_benchmark"
+harness = false
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/benches/utils_benchmark.rs
+++ b/benches/utils_benchmark.rs
@@ -1,0 +1,57 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use rustible::utils::shell_escape;
+
+fn bench_shell_escape(c: &mut Criterion) {
+    let mut group = c.benchmark_group("shell_escape");
+
+    // Test cases
+    let simple = "simple";
+    let with_space = "with space";
+    let with_single_quote = "don't";
+    let injection = "rm -rf /; echo 'owned'";
+    let complex = "echo \"Hello World\" | grep 'Hello' > /dev/null";
+    let unicode = "café";
+
+    // Very long string
+    let long_string = "a".repeat(10000);
+    let long_string_with_quotes = "a'".repeat(5000);
+
+    group.bench_function("simple", |b| {
+        b.iter(|| shell_escape(black_box(simple)))
+    });
+
+    group.bench_function("with_space", |b| {
+        b.iter(|| shell_escape(black_box(with_space)))
+    });
+
+    group.bench_function("with_single_quote", |b| {
+        b.iter(|| shell_escape(black_box(with_single_quote)))
+    });
+
+    group.bench_function("complex_injection", |b| {
+        b.iter(|| shell_escape(black_box(injection)))
+    });
+
+    group.bench_function("complex_command", |b| {
+        b.iter(|| shell_escape(black_box(complex)))
+    });
+
+    group.bench_function("unicode", |b| {
+        b.iter(|| shell_escape(black_box(unicode)))
+    });
+
+    group.throughput(Throughput::Bytes(long_string.len() as u64));
+    group.bench_function("long_string_safe", |b| {
+        b.iter(|| shell_escape(black_box(&long_string)))
+    });
+
+    group.throughput(Throughput::Bytes(long_string_with_quotes.len() as u64));
+    group.bench_function("long_string_escaped", |b| {
+        b.iter(|| shell_escape(black_box(&long_string_with_quotes)))
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_shell_escape);
+criterion_main!(benches);

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -128,19 +128,24 @@ pub fn shell_escape(s: &str) -> Cow<'_, str> {
         return Cow::Borrowed(s);
     }
 
-    let mut escaped = String::with_capacity(s.len() + 16);
-    escaped.push('\'');
+    // Optimization: avoid UTF-8 decoding in chars() iterator
+    let mut escaped = Vec::with_capacity(s.len() + 16);
+    escaped.push(b'\'');
 
-    for c in s.chars() {
-        if c == '\'' {
-            escaped.push_str("'\\''");
+    for b in s.bytes() {
+        if b == b'\'' {
+            escaped.extend_from_slice(b"'\\''");
         } else {
-            escaped.push(c);
+            escaped.push(b);
         }
     }
 
-    escaped.push('\'');
-    Cow::Owned(escaped)
+    escaped.push(b'\'');
+
+    // Safety: The input string `s` is valid UTF-8. We only append ASCII bytes
+    // (single quotes and backslashes), so the result is guaranteed to be valid UTF-8.
+    let escaped_str = unsafe { String::from_utf8_unchecked(escaped) };
+    Cow::Owned(escaped_str)
 }
 
 /// Escape a string for safe use in Windows cmd.exe.


### PR DESCRIPTION
⚡ Bolt: Optimized `shell_escape` performance

💡 What:
Optimized `shell_escape` in `src/utils/mod.rs` to use byte iteration instead of char iteration.

🎯 Why:
The previous implementation used `chars()` which performs UTF-8 decoding on every character. Since we only need to escape `'` (single quote) which is a single-byte ASCII character (0x27), and we wrap the result in single quotes, we can safely operate on bytes. This avoids decoding overhead and uses `Vec<u8>` to avoid repeated UTF-8 validation during string construction.

📊 Impact:
- Expected to be significantly faster for long strings or high throughput scenarios (e.g. generating many commands for inventory).
- Reduces CPU overhead for every command execution.

🔬 Measurement:
Added `benches/utils_benchmark.rs`. Verified correctness with `cargo test --lib utils::tests`.

---
*PR created automatically by Jules for task [2205368724608409885](https://jules.google.com/task/2205368724608409885) started by @dolagoartur*