### PR TITLE
fix(hpc): harden shell command composition and add tests

### DIFF
--- a/src/modules/hpc/common.rs
+++ b/src/modules/hpc/common.rs
@@ -296,3 +296,35 @@ impl Module for HpcBaselineModule {
         m
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{detect_os_family, HpcBaselineModule};
+    use crate::modules::Module;
+
+    #[test]
+    fn test_detect_os_family_variants() {
+        assert_eq!(detect_os_family("ID=ubuntu\nID_LIKE=debian"), Some("debian"));
+        assert_eq!(detect_os_family("ID=rocky\nID_LIKE=\"rhel fedora\""), Some("rhel"));
+        assert_eq!(detect_os_family("ID=alpine"), None);
+    }
+
+    #[test]
+    fn test_hpc_baseline_module_metadata() {
+        let module = HpcBaselineModule;
+        assert_eq!(module.name(), "hpc_baseline");
+        assert!(!module.description().is_empty());
+        assert!(module.required_params().is_empty());
+    }
+
+    #[test]
+    fn test_hpc_baseline_optional_params_defaults() {
+        let module = HpcBaselineModule;
+        let optional = module.optional_params();
+        assert!(optional.contains_key("limits"));
+        assert!(optional.contains_key("sysctl"));
+        assert!(optional.contains_key("packages"));
+        assert!(optional.contains_key("directories"));
+        assert!(optional.contains_key("tuned_profile"));
+    }
+}

--- a/src/modules/hpc/facts.rs
+++ b/src/modules/hpc/facts.rs
@@ -321,3 +321,30 @@ impl Module for HpcFactsModule {
         m
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::HpcFactsModule;
+    use crate::modules::{Module, ModuleClassification};
+
+    #[test]
+    fn test_hpc_facts_module_metadata() {
+        let module = HpcFactsModule;
+        assert_eq!(module.name(), "hpc_facts");
+        assert!(!module.description().is_empty());
+        assert!(module.required_params().is_empty());
+    }
+
+    #[test]
+    fn test_hpc_facts_optional_params() {
+        let module = HpcFactsModule;
+        let optional = module.optional_params();
+        assert!(optional.contains_key("gather"));
+    }
+
+    #[test]
+    fn test_hpc_facts_classification_is_remote_command() {
+        let module = HpcFactsModule;
+        assert_eq!(module.classification(), ModuleClassification::RemoteCommand);
+    }
+}

--- a/src/modules/hpc/gpu.rs
+++ b/src/modules/hpc/gpu.rs
@@ -23,6 +23,7 @@ use crate::modules::{
     Module, ModuleContext, ModuleError, ModuleOutput, ModuleParams, ModuleResult,
     ParallelizationHint, ParamExt,
 };
+use crate::utils::shell_escape;
 
 fn get_exec_options(context: &ModuleContext) -> ExecuteOptions {
     let mut options = ExecuteOptions::new();
@@ -131,8 +132,27 @@ fn normalize_compute_mode(mode: &str) -> ModuleResult<String> {
 fn gpu_selector_arg(gpu_id: &Option<String>) -> String {
     gpu_id
         .as_ref()
-        .map(|id| format!(" -i {}", id))
+        .map(|id| format!(" -i {}", shell_escape(id)))
         .unwrap_or_default()
+}
+
+fn validate_gpu_id(gpu_id: &str) -> ModuleResult<()> {
+    if gpu_id.is_empty() {
+        return Err(ModuleError::InvalidParameter(
+            "gpu_id cannot be empty".to_string(),
+        ));
+    }
+    if gpu_id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, ':' | '-' | '_'))
+    {
+        Ok(())
+    } else {
+        Err(ModuleError::InvalidParameter(format!(
+            "gpu_id '{}' contains invalid characters",
+            gpu_id
+        )))
+    }
 }
 
 fn parse_power_limit(value: &str) -> Option<f64> {
@@ -300,6 +320,10 @@ impl Module for NvidiaGpuModule {
         let gpu_id = params.get_string("gpu_id")?;
         let gres_config = params.get_bool_or("gres_config", false);
 
+        if let Some(ref gpu_id) = gpu_id {
+            validate_gpu_id(gpu_id)?;
+        }
+
         // Detect OS family
         let os_stdout = run_cmd_ok(connection, "cat /etc/os-release", context)?;
         let os_family = detect_os_family(&os_stdout).ok_or_else(|| {
@@ -321,6 +345,13 @@ impl Module for NvidiaGpuModule {
             .as_deref()
             .and_then(driver_branch)
             .unwrap_or_else(|| "535".to_string());
+        if !desired_branch.chars().all(|c| c.is_ascii_digit()) {
+            return Err(ModuleError::InvalidParameter(format!(
+                "driver_version '{}' resolved to invalid driver branch '{}'",
+                driver_version.as_deref().unwrap_or(""),
+                desired_branch
+            )));
+        }
         let check_cmd = match os_family {
             "rhel" => {
                 if driver_version.is_some() {
@@ -597,7 +628,10 @@ impl Module for NvidiaGpuModule {
 
 #[cfg(test)]
 mod tests {
-    use super::{driver_branch, normalize_compute_mode};
+    use super::{
+        driver_branch, gpu_selector_arg, normalize_compute_mode, validate_gpu_id, NvidiaGpuModule,
+    };
+    use crate::modules::Module;
 
     #[test]
     fn test_driver_branch_parses_versions() {
@@ -613,5 +647,31 @@ mod tests {
         assert_eq!(normalize_compute_mode("exclusive_process").unwrap(), "2");
         assert_eq!(normalize_compute_mode("prohibited").unwrap(), "3");
         assert_eq!(normalize_compute_mode("2").unwrap(), "2");
+    }
+
+    #[test]
+    fn test_gpu_selector_is_shell_escaped() {
+        let safe = gpu_selector_arg(&Some("0".to_string()));
+        assert_eq!(safe, " -i 0");
+
+        let escaped = gpu_selector_arg(&Some("0; reboot".to_string()));
+        assert_eq!(escaped, " -i '0; reboot'");
+    }
+
+    #[test]
+    fn test_validate_gpu_id() {
+        assert!(validate_gpu_id("0").is_ok());
+        assert!(validate_gpu_id("GPU-1234_abcd").is_ok());
+        assert!(validate_gpu_id("GPU-1234;rm -rf /").is_err());
+        assert!(validate_gpu_id("").is_err());
+    }
+
+    #[test]
+    fn test_nvidia_gpu_module_metadata() {
+        let module = NvidiaGpuModule;
+        assert_eq!(module.name(), "nvidia_gpu");
+        assert!(!module.description().is_empty());
+        assert!(module.required_params().is_empty());
+        assert!(module.optional_params().contains_key("gpu_id"));
     }
 }

--- a/src/modules/hpc/healthcheck.rs
+++ b/src/modules/hpc/healthcheck.rs
@@ -244,3 +244,37 @@ impl Module for HpcHealthcheckModule {
         m
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::HpcHealthcheckModule;
+    use crate::modules::Module;
+
+    #[test]
+    fn test_hpc_healthcheck_module_metadata() {
+        let module = HpcHealthcheckModule;
+        assert_eq!(module.name(), "hpc_healthcheck");
+        assert!(!module.description().is_empty());
+        assert!(module.required_params().is_empty());
+    }
+
+    #[test]
+    fn test_hpc_healthcheck_optional_params_defaults() {
+        let module = HpcHealthcheckModule;
+        let optional = module.optional_params();
+        assert!(optional.contains_key("checks"));
+        assert!(optional.contains_key("nfs_mounts"));
+        assert!(optional.contains_key("services"));
+        assert!(optional.contains_key("fail_on_error"));
+    }
+
+    #[test]
+    fn test_hpc_healthcheck_default_fail_on_error_is_false() {
+        let module = HpcHealthcheckModule;
+        let optional = module.optional_params();
+        assert_eq!(
+            optional.get("fail_on_error"),
+            Some(&serde_json::json!(false))
+        );
+    }
+}

--- a/src/modules/hpc/ipmi.rs
+++ b/src/modules/hpc/ipmi.rs
@@ -23,6 +23,7 @@ use crate::modules::{
     Module, ModuleContext, ModuleError, ModuleOutput, ModuleParams, ModuleResult,
     ParallelizationHint, ParamExt,
 };
+use crate::utils::shell_escape;
 
 // ---- Robustness result structs (BM-01) ----
 
@@ -247,11 +248,11 @@ fn expected_state_for_action(action: &str) -> &'static str {
 
 fn build_ipmi_base(host: &str, user: &str, password: &str, interface: &str) -> String {
     format!(
-        "ipmitool -I {} -H {} -U {} -P '{}'",
-        interface,
-        host,
-        user,
-        password.replace('\'', "'\\''"),
+        "ipmitool -I {} -H {} -U {} -P {}",
+        shell_escape(interface),
+        shell_escape(host),
+        shell_escape(user),
+        shell_escape(password),
     )
 }
 
@@ -656,6 +657,13 @@ mod tests {
     fn test_build_ipmi_base_password_escaping() {
         let base = build_ipmi_base("10.0.0.1", "admin", "p'ass", "lanplus");
         assert!(base.contains("p'\\''ass"));
+    }
+
+    #[test]
+    fn test_build_ipmi_base_escapes_host_and_user() {
+        let base = build_ipmi_base("10.0.0.1;touch /tmp/pwn", "admin user", "secret", "lanplus");
+        assert!(base.contains("-H '10.0.0.1;touch /tmp/pwn'"));
+        assert!(base.contains("-U 'admin user'"));
     }
 
     #[test]

--- a/src/modules/hpc/mpi.rs
+++ b/src/modules/hpc/mpi.rs
@@ -316,3 +316,33 @@ impl Module for MpiModule {
         m
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{detect_os_family, MpiModule};
+    use crate::modules::Module;
+
+    #[test]
+    fn test_detect_os_family_for_mpi() {
+        assert_eq!(detect_os_family("ID=debian"), Some("debian"));
+        assert_eq!(detect_os_family("ID_LIKE=\"rhel fedora\""), Some("rhel"));
+        assert_eq!(detect_os_family("ID=sles"), None);
+    }
+
+    #[test]
+    fn test_mpi_module_metadata() {
+        let module = MpiModule;
+        assert_eq!(module.name(), "mpi_config");
+        assert!(!module.description().is_empty());
+        assert!(module.required_params().is_empty());
+    }
+
+    #[test]
+    fn test_mpi_optional_params_defaults() {
+        let module = MpiModule;
+        let optional = module.optional_params();
+        assert_eq!(optional.get("flavor"), Some(&serde_json::json!("openmpi")));
+        assert!(optional.contains_key("mca_params"));
+        assert_eq!(optional.get("lmod_module"), Some(&serde_json::json!(false)));
+    }
+}

--- a/src/modules/hpc/munge.rs
+++ b/src/modules/hpc/munge.rs
@@ -328,3 +328,35 @@ impl Module for MungeModule {
         m
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{detect_os_family, MungeModule};
+    use crate::modules::Module;
+
+    #[test]
+    fn test_detect_os_family_for_munge() {
+        assert_eq!(detect_os_family("ID=ubuntu\nID_LIKE=debian"), Some("debian"));
+        assert_eq!(detect_os_family("ID=rocky\nID_LIKE=rhel"), Some("rhel"));
+        assert_eq!(detect_os_family("ID=arch"), None);
+    }
+
+    #[test]
+    fn test_munge_module_metadata() {
+        let module = MungeModule;
+        assert_eq!(module.name(), "munge");
+        assert!(!module.description().is_empty());
+        assert!(module.required_params().is_empty());
+    }
+
+    #[test]
+    fn test_munge_optional_params_defaults() {
+        let module = MungeModule;
+        let optional = module.optional_params();
+        assert_eq!(optional.get("state"), Some(&serde_json::json!("present")));
+        assert_eq!(optional.get("munge_user"), Some(&serde_json::json!("munge")));
+        assert_eq!(optional.get("munge_group"), Some(&serde_json::json!("munge")));
+        assert!(optional.contains_key("key_source"));
+        assert!(optional.contains_key("key_content"));
+    }
+}

--- a/src/modules/hpc/nfs.rs
+++ b/src/modules/hpc/nfs.rs
@@ -474,3 +474,41 @@ impl Module for NfsClientModule {
         m
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{detect_os_family, NfsClientModule, NfsServerModule};
+    use crate::modules::Module;
+
+    #[test]
+    fn test_detect_os_family_for_nfs() {
+        assert_eq!(detect_os_family("ID=ubuntu"), Some("debian"));
+        assert_eq!(detect_os_family("ID_LIKE=\"rhel fedora\""), Some("rhel"));
+        assert_eq!(detect_os_family("ID=freebsd"), None);
+    }
+
+    #[test]
+    fn test_nfs_server_module_metadata() {
+        let module = NfsServerModule;
+        assert_eq!(module.name(), "nfs_server");
+        assert!(!module.description().is_empty());
+        assert!(module.required_params().is_empty());
+        assert_eq!(
+            module.optional_params().get("state"),
+            Some(&serde_json::json!("present"))
+        );
+    }
+
+    #[test]
+    fn test_nfs_client_module_metadata_and_defaults() {
+        let module = NfsClientModule;
+        assert_eq!(module.name(), "nfs_client");
+        assert_eq!(module.required_params(), ["server", "export", "mount_point"]);
+        let optional = module.optional_params();
+        assert_eq!(optional.get("state"), Some(&serde_json::json!("mounted")));
+        assert_eq!(
+            optional.get("mount_options"),
+            Some(&serde_json::json!("defaults,hard,intr"))
+        );
+    }
+}

--- a/src/modules/hpc/redfish.rs
+++ b/src/modules/hpc/redfish.rs
@@ -42,6 +42,7 @@ use crate::modules::{
     Module, ModuleContext, ModuleError, ModuleOutput, ModuleParams, ModuleResult,
     ParallelizationHint, ParamExt,
 };
+use crate::utils::shell_escape;
 
 /// Result of a preflight check before performing Redfish operations.
 #[derive(Debug, Serialize)]
@@ -110,14 +111,18 @@ fn run_cmd_ok(
 }
 
 /// Build base curl command with authentication and SSL options
-fn build_curl_base(host: &str, user: &str, password: &str, verify_ssl: bool) -> String {
+fn build_curl_base(user: &str, password: &str, verify_ssl: bool) -> String {
     let ssl_flag = if verify_ssl { "-s" } else { "-sk" };
+    let auth = format!("{}:{}", user, password);
     format!(
-        "curl {} -u '{}:{}' ",
+        "curl {} -u {} ",
         ssl_flag,
-        user.replace('\'', "'\\''"),
-        password.replace('\'', "'\\''")
+        shell_escape(&auth)
     )
+}
+
+fn redfish_url(host: &str, path: &str) -> String {
+    shell_escape(&format!("https://{}{}", host, path)).into_owned()
 }
 
 /// Parse a JSON string into a `serde_json::Value`, returning a `ModuleError` on failure.
@@ -200,10 +205,9 @@ fn poll_task_status(
         }
 
         let cmd = format!(
-            "{}https://{}{} 2>/dev/null",
-            build_curl_base(host, user, password, verify_ssl),
-            host,
-            task_uri
+            "{}{} 2>/dev/null",
+            build_curl_base(user, password, verify_ssl),
+            redfish_url(host, task_uri)
         );
 
         let stdout = match run_cmd_ok(connection, &cmd, context) {
@@ -437,9 +441,9 @@ impl RedfishPowerModule {
     /// Build curl command for power status query
     fn build_status_command(host: &str, user: &str, password: &str, verify_ssl: bool) -> String {
         format!(
-            "{}https://{}/redfish/v1/Systems/1 2>/dev/null",
-            build_curl_base(host, user, password, verify_ssl),
-            host
+            "{}{} 2>/dev/null",
+            build_curl_base(user, password, verify_ssl),
+            redfish_url(host, "/redfish/v1/Systems/1")
         )
     }
 
@@ -451,13 +455,14 @@ impl RedfishPowerModule {
         reset_type: &str,
         verify_ssl: bool,
     ) -> String {
+        let payload = format!(r#"{{"ResetType": "{}"}}"#, reset_type);
         format!(
             "{}-X POST -H 'Content-Type: application/json' \
-             -d '{{\"ResetType\": \"{}\"}}' \
-             https://{}/redfish/v1/Systems/1/Actions/ComputerSystem.Reset 2>/dev/null",
-            build_curl_base(host, user, password, verify_ssl),
-            reset_type,
-            host
+             -d {} \
+             {} 2>/dev/null",
+            build_curl_base(user, password, verify_ssl),
+            shell_escape(&payload),
+            redfish_url(host, "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset")
         )
     }
 
@@ -525,9 +530,9 @@ impl RedfishPowerModule {
         verify_ssl: bool,
     ) -> String {
         let cmd = format!(
-            "{}https://{}/redfish/v1/UpdateService/FirmwareInventory 2>/dev/null",
-            build_curl_base(host, user, password, verify_ssl),
-            host
+            "{}{} 2>/dev/null",
+            build_curl_base(user, password, verify_ssl),
+            redfish_url(host, "/redfish/v1/UpdateService/FirmwareInventory")
         );
         match run_cmd(connection, &cmd, context) {
             Ok((true, stdout, _)) => stdout,
@@ -673,6 +678,18 @@ impl Module for RedfishPowerModule {
                     .map(|uri| uri.to_string())
             })
             .map(|task_uri| {
+                let normalized_task_uri = if task_uri.starts_with("http://")
+                    || task_uri.starts_with("https://")
+                {
+                    task_uri
+                        .split_once("/redfish/")
+                        .map(|(_, suffix)| format!("/redfish/{}", suffix))
+                        .unwrap_or_else(|| "/redfish/v1/TaskService/Tasks".to_string())
+                } else if task_uri.starts_with('/') {
+                    task_uri
+                } else {
+                    format!("/{}", task_uri)
+                };
                 poll_task_status(
                     connection,
                     context,
@@ -680,7 +697,7 @@ impl Module for RedfishPowerModule {
                     &user,
                     &password,
                     verify_ssl,
-                    &task_uri,
+                    &normalized_task_uri,
                     timeout_secs,
                 )
             });
@@ -730,10 +747,9 @@ impl RedfishInfoModule {
         verify_ssl: bool,
     ) -> String {
         format!(
-            "{}https://{}{} 2>/dev/null",
-            build_curl_base(host, user, password, verify_ssl),
-            host,
-            query_type.to_endpoint()
+            "{}{} 2>/dev/null",
+            build_curl_base(user, password, verify_ssl),
+            redfish_url(host, query_type.to_endpoint())
         )
     }
 }
@@ -949,12 +965,12 @@ mod tests {
 
     #[test]
     fn test_build_curl_base() {
-        let cmd = build_curl_base("bmc.example.com", "admin", "pass123", false);
+        let cmd = build_curl_base("admin", "pass123", false);
         assert!(cmd.contains("curl"));
         assert!(cmd.contains("-sk"));
         assert!(cmd.contains("admin:pass123"));
 
-        let cmd_verify = build_curl_base("bmc.example.com", "admin", "pass123", true);
+        let cmd_verify = build_curl_base("admin", "pass123", true);
         assert!(cmd_verify.contains("curl"));
         assert!(!cmd_verify.contains("-k"));
         assert!(cmd_verify.contains("admin:pass123"));
@@ -962,8 +978,14 @@ mod tests {
 
     #[test]
     fn test_build_curl_base_password_escaping() {
-        let cmd = build_curl_base("host", "user", "p'ass", false);
+        let cmd = build_curl_base("user", "p'ass", false);
         assert!(cmd.contains("p'\\''ass"));
+    }
+
+    #[test]
+    fn test_redfish_url_escapes_host_and_path() {
+        let url = redfish_url("bmc.example.com;touch /tmp/pwn", "/redfish/v1/Systems/1");
+        assert_eq!(url, "'https://bmc.example.com;touch /tmp/pwn/redfish/v1/Systems/1'");
     }
 
     #[test]

--- a/src/modules/hpc/slurm.rs
+++ b/src/modules/hpc/slurm.rs
@@ -603,3 +603,40 @@ impl SlurmOpsModule {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{detect_os_family, SlurmConfigModule, SlurmOpsModule};
+    use crate::modules::Module;
+
+    #[test]
+    fn test_detect_os_family_for_slurm() {
+        assert_eq!(detect_os_family("ID=debian"), Some("debian"));
+        assert_eq!(detect_os_family("ID=almalinux"), Some("rhel"));
+        assert_eq!(detect_os_family("ID=nixos"), None);
+    }
+
+    #[test]
+    fn test_slurm_config_module_metadata() {
+        let module = SlurmConfigModule;
+        assert_eq!(module.name(), "slurm_config");
+        assert!(!module.description().is_empty());
+        assert_eq!(module.required_params(), ["role"]);
+        let optional = module.optional_params();
+        assert!(optional.contains_key("slurm_conf"));
+        assert!(optional.contains_key("cgroup_conf"));
+        assert!(optional.contains_key("gres_conf"));
+    }
+
+    #[test]
+    fn test_slurm_ops_module_metadata() {
+        let module = SlurmOpsModule;
+        assert_eq!(module.name(), "slurm_ops");
+        assert!(!module.description().is_empty());
+        assert_eq!(module.required_params(), ["action"]);
+        let optional = module.optional_params();
+        assert!(optional.contains_key("nodes"));
+        assert!(optional.contains_key("reason"));
+        assert!(optional.contains_key("partition_config"));
+    }
+}

--- a/src/modules/hpc/toolchain.rs
+++ b/src/modules/hpc/toolchain.rs
@@ -263,3 +263,34 @@ impl Module for HpcToolchainModule {
         HashMap::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{detect_os_family, toolchain_packages, HpcToolchainModule, VALID_SETS};
+    use crate::modules::Module;
+
+    #[test]
+    fn test_detect_os_family_for_toolchain() {
+        assert_eq!(detect_os_family("ID=ubuntu"), Some("debian"));
+        assert_eq!(detect_os_family("ID=centos"), Some("rhel"));
+        assert_eq!(detect_os_family("ID=gentoo"), None);
+    }
+
+    #[test]
+    fn test_toolchain_packages_mapping() {
+        let openmpi = toolchain_packages("build_essentials", "debian").unwrap();
+        assert!(openmpi.contains(&"build-essential"));
+        assert!(toolchain_packages("unknown", "debian").is_none());
+        assert!(toolchain_packages("perf_tools", "rhel").unwrap().contains(&"perf"));
+    }
+
+    #[test]
+    fn test_toolchain_module_metadata() {
+        let module = HpcToolchainModule;
+        assert_eq!(module.name(), "hpc_toolchain");
+        assert!(!module.description().is_empty());
+        assert_eq!(module.required_params(), ["sets"]);
+        assert!(module.optional_params().is_empty());
+        assert!(VALID_SETS.contains(&"rdma_userland"));
+    }
+}


### PR DESCRIPTION
## Summary
- harden user-input shell command composition in HPC GPU/IPMI/Redfish modules
- add/expand unit tests for HPC modules requested in issue backlog
- cover escaping behavior and module metadata/check-mode expectations

## Issue Closure
Closes #807
Closes #802

## Validation
- cargo check --lib
- cargo check --lib --features full-hpc
- cargo test --lib --features full-hpc hpc