### PR TITLE
fix(windows,aws): audit hardening for runtime safety

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -1431,6 +1431,21 @@ impl ConnectionBuilder {
                     ))
                 }
             }
+            #[cfg(feature = "aws")]
+            ConnectionType::Ssm {
+                instance_id,
+                region,
+                profile,
+            } => {
+                let mut conn = ssm::SsmConnection::new(instance_id);
+                if let Some(region) = region {
+                    conn = conn.with_region(region);
+                }
+                if let Some(profile) = profile {
+                    conn = conn.with_profile(profile);
+                }
+                Ok(Arc::new(conn))
+            }
             #[cfg(feature = "winrm")]
             ConnectionType::WinRm { host, port, user } => {
                 let conn = winrm::WinRmConnectionBuilder::new(&host)

--- a/src/modules/cloud/aws/ec2.rs
+++ b/src/modules/cloud/aws/ec2.rs
@@ -95,6 +95,30 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::time::Duration;
 
+fn serialize_output_data<T: Serialize + ?Sized>(
+    field: &str,
+    value: &T,
+) -> ModuleResult<serde_json::Value> {
+    serde_json::to_value(value).map_err(|e| {
+        ModuleError::ExecutionFailed(format!(
+            "Failed to serialize '{}' output data: {}",
+            field, e
+        ))
+    })
+}
+
+fn join_scoped_module_thread(
+    result: std::thread::Result<ModuleResult<ModuleOutput>>,
+    module_name: &str,
+) -> ModuleResult<ModuleOutput> {
+    result.map_err(|_| {
+        ModuleError::ExecutionFailed(format!(
+            "{} worker thread panicked during execution",
+            module_name
+        ))
+    })?
+}
+
 /// Represents the desired state of an EC2 instance
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -1104,7 +1128,7 @@ impl Ec2InstanceModule {
                 final_instances.len(),
                 config.name
             ))
-            .with_data("instances", serde_json::to_value(&final_instances).unwrap())
+            .with_data("instances", serialize_output_data("instances", &final_instances)?)
             .with_data("instance_ids", serde_json::json!(instance_ids)))
         } else {
             // Check if any instances need to be started
@@ -1122,7 +1146,7 @@ impl Ec2InstanceModule {
                     existing.len(),
                     config.name
                 ))
-                .with_data("instances", serde_json::to_value(existing).unwrap())
+                .with_data("instances", serialize_output_data("instances", existing)?)
                 .with_data("instance_ids", serde_json::json!(instance_ids)));
             }
 
@@ -1151,7 +1175,7 @@ impl Ec2InstanceModule {
 
             Ok(
                 ModuleOutput::changed(format!("Started {} instance(s)", stopped.len()))
-                    .with_data("instances", serde_json::to_value(&final_instances).unwrap())
+                    .with_data("instances", serialize_output_data("instances", &final_instances)?)
                     .with_data("started_instance_ids", serde_json::json!(stopped)),
             )
         }
@@ -1184,7 +1208,7 @@ impl Ec2InstanceModule {
                 existing.len(),
                 config.name
             ))
-            .with_data("instances", serde_json::to_value(existing).unwrap())
+            .with_data("instances", serialize_output_data("instances", existing)?)
             .with_data("instance_ids", serde_json::json!(instance_ids)));
         }
 
@@ -1213,7 +1237,7 @@ impl Ec2InstanceModule {
 
         Ok(
             ModuleOutput::changed(format!("Stopped {} instance(s)", running.len()))
-                .with_data("instances", serde_json::to_value(&final_instances).unwrap())
+                .with_data("instances", serialize_output_data("instances", &final_instances)?)
                 .with_data("stopped_instance_ids", serde_json::json!(running)),
         )
     }
@@ -1356,9 +1380,11 @@ impl Module for Ec2InstanceModule {
         let module = self;
 
         std::thread::scope(|s| {
-            s.spawn(|| handle.block_on(module.execute_async(&params, &context)))
-                .join()
-                .unwrap()
+            join_scoped_module_thread(
+                s.spawn(|| handle.block_on(module.execute_async(&params, &context)))
+                    .join(),
+                module.name(),
+            )
         })
     }
 
@@ -1705,7 +1731,10 @@ impl Ec2SecurityGroupModule {
                             "Security group '{}' already exists",
                             config.name
                         ))
-                        .with_data("security_group", serde_json::to_value(&sg).unwrap()));
+                        .with_data(
+                            "security_group",
+                            serialize_output_data("security_group", &sg)?,
+                        ));
                     }
 
                     let mut changed = false;
@@ -1741,13 +1770,19 @@ impl Ec2SecurityGroupModule {
                             "Updated security group '{}'",
                             config.name
                         ))
-                        .with_data("security_group", serde_json::to_value(&sg).unwrap()))
+                        .with_data(
+                            "security_group",
+                            serialize_output_data("security_group", &sg)?,
+                        ))
                     } else {
                         Ok(ModuleOutput::ok(format!(
                             "Security group '{}' is up to date",
                             config.name
                         ))
-                        .with_data("security_group", serde_json::to_value(&sg).unwrap()))
+                        .with_data(
+                            "security_group",
+                            serialize_output_data("security_group", &sg)?,
+                        ))
                     }
                 } else {
                     // Create new security group
@@ -1781,7 +1816,10 @@ impl Ec2SecurityGroupModule {
 
                     Ok(
                         ModuleOutput::changed(format!("Created security group '{}'", config.name))
-                            .with_data("security_group", serde_json::to_value(&sg).unwrap()),
+                            .with_data(
+                                "security_group",
+                                serialize_output_data("security_group", &sg)?,
+                            ),
                     )
                 }
             }
@@ -1847,9 +1885,11 @@ impl Module for Ec2SecurityGroupModule {
         let module = self;
 
         std::thread::scope(|s| {
-            s.spawn(|| handle.block_on(module.execute_async(&params, &context)))
-                .join()
-                .unwrap()
+            join_scoped_module_thread(
+                s.spawn(|| handle.block_on(module.execute_async(&params, &context)))
+                    .join(),
+                module.name(),
+            )
         })
     }
 }
@@ -2114,7 +2154,7 @@ impl Ec2VpcModule {
                     // VPC exists - check if configuration matches
                     Ok(
                         ModuleOutput::ok(format!("VPC '{}' already exists", config.name))
-                            .with_data("vpc", serde_json::to_value(&vpc).unwrap()),
+                            .with_data("vpc", serialize_output_data("vpc", &vpc)?),
                     )
                 } else {
                     // Create new VPC
@@ -2129,7 +2169,7 @@ impl Ec2VpcModule {
 
                     Ok(
                         ModuleOutput::changed(format!("Created VPC '{}'", config.name))
-                            .with_data("vpc", serde_json::to_value(&vpc).unwrap()),
+                            .with_data("vpc", serialize_output_data("vpc", &vpc)?),
                     )
                 }
             }
@@ -2195,9 +2235,11 @@ impl Module for Ec2VpcModule {
         let module = self;
 
         std::thread::scope(|s| {
-            s.spawn(|| handle.block_on(module.execute_async(&params, &context)))
-                .join()
-                .unwrap()
+            join_scoped_module_thread(
+                s.spawn(|| handle.block_on(module.execute_async(&params, &context)))
+                    .join(),
+                module.name(),
+            )
         })
     }
 }
@@ -2424,5 +2466,44 @@ mod tests {
         assert_eq!(permission.ip_protocol(), Some("tcp"));
         assert_eq!(permission.from_port(), Some(443));
         assert_eq!(permission.to_port(), Some(443));
+    }
+
+    #[test]
+    fn test_serialize_output_data_success() {
+        let value = vec!["i-123".to_string(), "i-456".to_string()];
+        let serialized = serialize_output_data("instance_ids", &value).unwrap();
+        assert_eq!(serialized, serde_json::json!(["i-123", "i-456"]));
+    }
+
+    #[test]
+    fn test_serialize_output_data_reports_serialization_error() {
+        struct BadPayload;
+
+        impl Serialize for BadPayload {
+            fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                Err(serde::ser::Error::custom("intentional serialization failure"))
+            }
+        }
+
+        let bad = BadPayload;
+        let err = serialize_output_data("bad_payload", &bad).unwrap_err();
+        assert!(format!("{}", err).contains("Failed to serialize"));
+        assert!(format!("{}", err).contains("bad_payload"));
+    }
+
+    #[test]
+    fn test_join_scoped_module_thread_maps_panic_to_module_error() {
+        let join_result: std::thread::Result<ModuleResult<ModuleOutput>> = std::thread::scope(|s| {
+            s.spawn(|| -> ModuleResult<ModuleOutput> {
+                panic!("simulated panic");
+            })
+            .join()
+        });
+
+        let err = join_scoped_module_thread(join_result, "aws_ec2_instance").unwrap_err();
+        assert!(format!("{}", err).contains("worker thread panicked"));
     }
 }

--- a/src/modules/windows/win_feature.rs
+++ b/src/modules/windows/win_feature.rs
@@ -508,4 +508,21 @@ mod tests {
         assert!(script.contains("IIS-WebServerRole"));
         assert!(script.contains("NetFx4-AdvSrvs"));
     }
+
+    #[test]
+    fn test_build_install_script_escapes_source_path() {
+        let config = WinFeatureConfig {
+            names: vec!["IIS-WebServerRole".to_string()],
+            state: WinFeatureState::Present,
+            include_management_tools: true,
+            include_sub_features: false,
+            source: Some("D:\\sources\\win'sxs".to_string()),
+            restart: false,
+        };
+
+        let script = WinFeatureModule::build_install_script(&config);
+        assert!(script.contains("Install-WindowsFeature"));
+        assert!(script.contains("win''sxs"));
+        assert!(script.contains("-IncludeManagementTools"));
+    }
 }

--- a/src/modules/windows/win_service.rs
+++ b/src/modules/windows/win_service.rs
@@ -43,7 +43,9 @@
 //!     password: "{{ service_password }}"
 //! ```
 
-use crate::modules::windows::{execute_powershell_sync, powershell_escape, validate_service_name};
+use crate::modules::windows::{
+    execute_powershell_sync, powershell_escape, validate_service_name, validate_windows_path,
+};
 use crate::modules::{
     Module, ModuleClassification, ModuleContext, ModuleError, ModuleOutput, ModuleParams,
     ModuleResult, ParamExt,
@@ -440,6 +442,7 @@ impl Module for WinServiceModule {
             .as_str()
             .unwrap_or("")
             .to_lowercase();
+        let current_username = current_state["username"].as_str().unwrap_or("").to_string();
 
         // Handle service removal
         if let Some(ServiceState::Absent) = state {
@@ -472,11 +475,10 @@ impl Module for WinServiceModule {
 
         // Handle service creation
         if !service_exists {
-            if path.is_none() {
-                return Err(ModuleError::MissingParameter(
-                    "path is required to create a new service".to_string(),
-                ));
-            }
+            let service_path = path.as_deref().ok_or_else(|| {
+                ModuleError::MissingParameter("path is required to create a new service".to_string())
+            })?;
+            validate_windows_path(service_path)?;
 
             if context.check_mode {
                 return Ok(ModuleOutput::changed(format!(
@@ -488,7 +490,7 @@ impl Module for WinServiceModule {
             let mode = start_mode.clone().unwrap_or(ServiceStartMode::Manual);
             let create_script = Self::generate_create_service_script(
                 &name,
-                path.as_ref().unwrap(),
+                service_path,
                 display_name.as_deref(),
                 description.as_deref(),
                 &mode,
@@ -541,25 +543,27 @@ impl Module for WinServiceModule {
 
         // Handle service account change
         if let Some(ref user) = username {
-            if context.check_mode {
-                messages.push(format!("Would change service account to '{}'", user));
-                changed = true;
-            } else {
-                let script =
-                    Self::generate_set_service_account_script(&name, user, password.as_deref());
-                let (success, stdout, stderr) = execute_powershell_sync(connection, &script)?;
-
-                if !success {
-                    return Err(ModuleError::ExecutionFailed(format!(
-                        "Failed to set service account: {}",
-                        stderr
-                    )));
-                }
-
-                let result = Self::parse_json_result(&stdout)?;
-                if result["changed"].as_bool().unwrap_or(false) {
-                    messages.push(format!("Changed service account to '{}'", user));
+            if !current_username.eq_ignore_ascii_case(user) {
+                if context.check_mode {
+                    messages.push(format!("Would change service account to '{}'", user));
                     changed = true;
+                } else {
+                    let script =
+                        Self::generate_set_service_account_script(&name, user, password.as_deref());
+                    let (success, stdout, stderr) = execute_powershell_sync(connection, &script)?;
+
+                    if !success {
+                        return Err(ModuleError::ExecutionFailed(format!(
+                            "Failed to set service account: {}",
+                            stderr
+                        )));
+                    }
+
+                    let result = Self::parse_json_result(&stdout)?;
+                    if result["changed"].as_bool().unwrap_or(false) {
+                        messages.push(format!("Changed service account to '{}'", user));
+                        changed = true;
+                    }
                 }
             }
         }
@@ -778,5 +782,39 @@ mod tests {
         assert!(script.contains("Get-Service"));
         assert!(script.contains("wuauserv"));
         assert!(script.contains("ConvertTo-Json"));
+    }
+
+    #[test]
+    fn test_generate_create_service_script_escapes_path() {
+        let script = WinServiceModule::generate_create_service_script(
+            "svc",
+            "C:\\Program Files\\App\\service'svc.exe",
+            Some("Svc Display"),
+            None,
+            &ServiceStartMode::Manual,
+        );
+
+        assert!(script.contains("New-Service"));
+        assert!(script.contains("service''svc.exe"));
+        assert!(script.contains("Svc Display"));
+    }
+
+    #[test]
+    fn test_validate_windows_path_blocks_shell_metacharacters() {
+        assert!(validate_windows_path("C:\\Windows\\System32\\svchost.exe").is_ok());
+        assert!(validate_windows_path("C:\\tmp\\evil;calc.exe").is_err());
+    }
+
+    #[test]
+    fn test_generate_set_service_account_script_escapes_credentials() {
+        let script = WinServiceModule::generate_set_service_account_script(
+            "svc_name",
+            r#".\domain\svc'user"#,
+            Some("p'ass\"word"),
+        );
+
+        assert!(script.contains("svc''user"));
+        assert!(script.contains("p''ass"));
+        assert!(script.contains("ConvertTo-SecureString"));
     }
 }

--- a/src/modules/windows/win_user.rs
+++ b/src/modules/windows/win_user.rs
@@ -107,6 +107,23 @@ impl GroupsAction {
 pub struct WinUserModule;
 
 impl WinUserModule {
+    fn validate_local_group_name(name: &str) -> ModuleResult<()> {
+        if name.is_empty() {
+            return Err(ModuleError::InvalidParameter(
+                "Group names cannot be empty".to_string(),
+            ));
+        }
+
+        if name.contains('\0') || name.contains('\n') || name.contains('\r') {
+            return Err(ModuleError::InvalidParameter(format!(
+                "Invalid group name '{}': contains control characters",
+                name
+            )));
+        }
+
+        Ok(())
+    }
+
     /// Generate PowerShell script to get user information
     fn generate_get_user_script(name: &str) -> String {
         format!(
@@ -345,7 +362,7 @@ $result | ConvertTo-Json -Compress
     ) -> String {
         let groups_json: Vec<String> = groups
             .iter()
-            .map(|g| format!("'{}'", g.replace('\'', "''")))
+            .map(|g| powershell_escape(g).into_owned())
             .collect();
 
         match action {
@@ -650,6 +667,10 @@ impl Module for WinUserModule {
         // Handle group membership
         if let Some(ref group_list) = groups {
             if !group_list.is_empty() {
+                for group in group_list {
+                    Self::validate_local_group_name(group)?;
+                }
+
                 if context.check_mode {
                     messages.push("Would update group membership".to_string());
                     changed = true;
@@ -767,5 +788,25 @@ mod tests {
         assert!(script.contains("Get-LocalUser"));
         assert!(script.contains("testuser"));
         assert!(script.contains("ConvertTo-Json"));
+    }
+
+    #[test]
+    fn test_validate_local_group_name_rejects_control_chars() {
+        assert!(WinUserModule::validate_local_group_name("Users").is_ok());
+        assert!(WinUserModule::validate_local_group_name("Admins\nInjected").is_err());
+    }
+
+    #[test]
+    fn test_generate_manage_groups_script_escapes_group_names() {
+        let groups = vec!["Domain Users".to_string(), "O'Hare Admins".to_string()];
+        let script = WinUserModule::generate_manage_groups_script(
+            "svc_user",
+            &groups,
+            &GroupsAction::Add,
+        );
+
+        assert!(script.contains("Domain Users"));
+        assert!(script.contains("O''Hare Admins"));
+        assert!(script.contains("Add-LocalGroupMember"));
     }
 }


### PR DESCRIPTION
## Summary
- harden Windows service/user/feature module script safety and parameter validation
- improve check-mode consistency for Windows service account changes
- remove panic-prone runtime paths in AWS EC2 module output serialization/thread joins
- add targeted regression tests for hardened behavior

## Issue Closure
Closes #805
Closes #806

## Validation
- cargo check --lib
- cargo test --lib win_service
- cargo test --lib win_user
- cargo test --lib win_feature