### PR TITLE
⚡ Bolt: [performance] Use cached regex in template filters

### DIFF
--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -123,7 +123,6 @@ pub use work_stealing::{WorkItem, WorkStealingConfig, WorkStealingScheduler, Wor
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use dialoguer::theme::ColorfulTheme;
 use futures::future::join_all;
 use indexmap::IndexMap;
 use thiserror::Error;
@@ -139,7 +138,6 @@ use crate::recovery::{RecoveryManager, TaskOutcome, TransactionId};
 
 use console::Term;
 use colored::Colorize;
-use dialoguer::theme::ColorfulTheme;
 
 /// Errors that can occur during playbook and task execution.
 ///

--- a/src/plugins/filter/regex.rs
+++ b/src/plugins/filter/regex.rs
@@ -21,7 +21,6 @@
 //! ```
 
 use minijinja::{Environment, Value};
-use regex::Regex;
 
 /// Register all regex filters with the given environment.
 pub fn register_filters(env: &mut Environment<'static>) {
@@ -63,7 +62,7 @@ fn regex_search(
         multiline.unwrap_or(false),
     );
 
-    match Regex::new(&pattern) {
+    match crate::utils::get_regex(&pattern) {
         Ok(re) => {
             if let Some(caps) = re.captures(&input) {
                 // If there are capture groups, return the first one
@@ -89,7 +88,7 @@ fn regex_search(
 fn regex_match(input: String, pattern: String, ignorecase: Option<bool>) -> bool {
     let pattern = build_pattern(&pattern, ignorecase.unwrap_or(false), false);
 
-    match Regex::new(&pattern) {
+    match crate::utils::get_regex(&pattern) {
         Ok(re) => re.is_match(&input),
         Err(_) => false,
     }
@@ -130,7 +129,7 @@ fn regex_replace(
         .replace("\\8", "$8")
         .replace("\\9", "$9");
 
-    match Regex::new(&pattern) {
+    match crate::utils::get_regex(&pattern) {
         Ok(re) => match count {
             Some(n) if n > 0 => {
                 let mut result = input.clone();
@@ -181,7 +180,7 @@ fn regex_findall(
         multiline.unwrap_or(false),
     );
 
-    match Regex::new(&pattern) {
+    match crate::utils::get_regex(&pattern) {
         Ok(re) => {
             // Check if pattern has capture groups
             let has_groups = re.captures_len() > 1;
@@ -243,7 +242,7 @@ fn regex_escape(input: String) -> String {
 ///
 /// A list of substrings.
 fn regex_split(input: String, pattern: String, maxsplit: Option<usize>) -> Vec<String> {
-    match Regex::new(&pattern) {
+    match crate::utils::get_regex(&pattern) {
         Ok(re) => {
             let splits: Vec<&str> = match maxsplit {
                 Some(n) if n > 0 => re.splitn(&input, n + 1).collect(),


### PR DESCRIPTION
💡 **What**: Replaced dynamic regex compilation (`Regex::new()`) with cached lookups (`crate::utils::get_regex()`) in all template regex filters (`regex_search`, `regex_replace`, `regex_match`, `regex_findall`, `regex_split`). Also cleaned up two duplicate unused imports in `src/executor/mod.rs` caught by tests.

🎯 **Why**: Instantiating a new `Regex` object is a known performance bottleneck in Rust as compilation is an expensive $O(pattern\_length)$ operation. When a playbook renders a template, these filters might be evaluated hundreds or thousands of times in a loop. Recompiling the exact same regular expression every time wastes CPU cycles.

📊 **Impact**: Transforms an $O(pattern\_length)$ compilation step into an amortized $O(1)$ lock-free `DashMap` cache lookup. Expected to significantly reduce template rendering overhead, especially for playbooks using regex filters heavily in tight loops or large configurations.

🔬 **Measurement**: Validated by running the core, module, and templating test suites (`cargo test modules::` and `cargo test template_tests`). The cache logic uses the application's existing safe thread-safe caching module, preserving 100% functional parity.

---
*PR created automatically by Jules for task [14011533710358042002](https://jules.google.com/task/14011533710358042002) started by @dolagoartur*