### PR TITLE
🎨 Palette: Add progress spinners to provision commands

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -56,3 +56,7 @@
 ## 2024-05-27 - [Aggregated Summaries in CLI Output]
 **Learning:** In multi-host CLI executions, individual host results can scroll off-screen, making it difficult to assess overall success/failure at a glance. Adding a distinct "TOTALS" row at the bottom provides immediate, high-level feedback that is essential for larger deployments.
 **Action:** For commands that execute across multiple items/hosts, calculate and display an aggregated summary row (e.g., "TOTALS") aligned with the detail columns to allow quick validation of the entire operation.
+
+## 2024-05-24 - [CLI Progress Indicators]
+**Learning:** `indicatif` progress bars in `OutputFormatter` require explicit initialization via `init_progress()` before they can be used. Without this call, `create_spinner()` returns `None` or fails silently, leaving the user staring at a static screen during long operations.
+**Action:** Always call `ctx.output.init_progress()` at the start of any long-running CLI command execution (like `run` or `provision`) to enable visual feedback.

--- a/src/cli/commands/provision.rs
+++ b/src/cli/commands/provision.rs
@@ -455,6 +455,7 @@ impl PlanArgs {
     /// Execute the plan command
     #[cfg(feature = "provisioning")]
     pub async fn execute(&self, ctx: &mut CommandContext) -> Result<i32> {
+        ctx.output.init_progress();
         ctx.output.banner("INFRASTRUCTURE PLAN");
 
         if !self.config_file.exists() {
@@ -526,6 +527,7 @@ impl ApplyArgs {
     /// Execute the apply command
     #[cfg(feature = "provisioning")]
     pub async fn execute(&self, ctx: &mut CommandContext) -> Result<i32> {
+        ctx.output.init_progress();
         ctx.output.banner("INFRASTRUCTURE APPLY");
 
         if !self.config_file.exists() {
@@ -613,6 +615,7 @@ impl DestroyArgs {
     /// Execute the destroy command
     #[cfg(feature = "provisioning")]
     pub async fn execute(&self, ctx: &mut CommandContext) -> Result<i32> {
+        ctx.output.init_progress();
         ctx.output.banner("INFRASTRUCTURE DESTROY");
 
         if !self.config_file.exists() {
@@ -697,6 +700,7 @@ impl ImportArgs {
     /// Execute the import command
     #[cfg(feature = "provisioning")]
     pub async fn execute(&self, ctx: &mut CommandContext) -> Result<i32> {
+        ctx.output.init_progress();
         ctx.output.banner("INFRASTRUCTURE IMPORT");
 
         if !self.config_file.exists() {
@@ -762,6 +766,7 @@ impl ShowArgs {
     /// Execute the show command
     #[cfg(feature = "provisioning")]
     pub async fn execute(&self, ctx: &mut CommandContext) -> Result<i32> {
+        ctx.output.init_progress();
         let project_root = PathBuf::from(".");
         let (backend_config, state_path) = resolve_state_backend(
             self.backend_config.as_ref(),
@@ -823,6 +828,7 @@ impl RefreshArgs {
     /// Execute the refresh command
     #[cfg(feature = "provisioning")]
     pub async fn execute(&self, ctx: &mut CommandContext) -> Result<i32> {
+        ctx.output.init_progress();
         ctx.output.banner("INFRASTRUCTURE REFRESH");
 
         if !self.config_file.exists() {
@@ -872,6 +878,7 @@ impl MigrateArgs {
     /// Execute the migrate command
     #[cfg(feature = "provisioning")]
     pub async fn execute(&self, ctx: &mut CommandContext) -> Result<i32> {
+        ctx.output.init_progress();
         ctx.output.banner("INFRASTRUCTURE STATE MIGRATE");
 
         let project_root = project_root_for_config(&self.config_file);
@@ -918,6 +925,7 @@ impl ImportTerraformArgs {
     /// Execute the import-terraform command
     #[cfg(feature = "provisioning")]
     pub async fn execute(&self, ctx: &mut CommandContext) -> Result<i32> {
+        ctx.output.init_progress();
         ctx.output.banner("IMPORT TERRAFORM STATE");
 
         let project_root = project_root_for_config(&self.config_file);

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -103,7 +103,6 @@ pub mod host_metrics;
 pub mod work_stealing;
 
 // Re-exports for commonly used types from enhancement modules
-use dialoguer::theme::ColorfulTheme;
 pub use async_runtime::{RuntimeConfig, RuntimeMetrics, SpawnOptions, TaskSpawner};
 pub use async_task::{AsyncConfig, AsyncJobInfo, AsyncJobStatus, AsyncTaskManager};
 pub use batch_processor::{BatchConfig, BatchProcessor, BatchResult, BatchStrategy};
@@ -139,7 +138,6 @@ use crate::recovery::{RecoveryManager, TaskOutcome, TransactionId};
 
 use console::Term;
 use colored::Colorize;
-use dialoguer::theme::ColorfulTheme;
 
 /// Errors that can occur during playbook and task execution.
 ///


### PR DESCRIPTION
💡 What: Added `ctx.output.init_progress();` to the beginning of all long-running `provision` subcommands (plan, apply, destroy, import, show, refresh, migrate, import-terraform).
🎯 Why: `indicatif` progress bars require explicit initialization. Without this, `ctx.output.create_spinner()` silently returns `None`, leaving the user staring at a frozen terminal with no visual feedback during slow operations (like creating/destroying cloud resources).
📸 Before: Frozen CLI during `rustible provision apply`.
📸 After: A nice smooth spinner ⠋ indicating work is happening.

---
*PR created automatically by Jules for task [10745041375162319066](https://jules.google.com/task/10745041375162319066) started by @dolagoartur*