### PR TITLE
🎨 Palette: Add semantic emoji to main menu prompt

### DIFF
--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -80,7 +80,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("What would you like to do?")
+            .with_prompt("🎯 What would you like to do?")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;


### PR DESCRIPTION
💡 **What:** 
Added the `🎯` emoji to the main menu prompt in `src/cli/interactive.rs`.

🎯 **Why:** 
To maintain visual consistency across the CLI tool. Most other interactive prompts in the application (like playbook selection, inventory selection, and vault operations) use semantic emoji prefixes. The main menu prompt was missing one, making it slightly inconsistent and text-heavy.

📸 **Before/After:**
*   **Before:** `What would you like to do?`
*   **After:** `🎯 What would you like to do?`

♿ **Accessibility:**
Improves cognitive accessibility by providing a clear, visually distinct anchor point for the most important prompt in the application, making it easier to scan quickly in a dense terminal environment.

---
*PR created automatically by Jules for task [13003101005692109506](https://jules.google.com/task/13003101005692109506) started by @dolagoartur*