### PR TITLE
⚡ Bolt: Use cached Regex in parse_array_access for performance

### DIFF
--- a/src/provisioning/resolver.rs
+++ b/src/provisioning/resolver.rs
@@ -589,9 +589,11 @@ impl ProvisionerContext {
 
 /// Parse array access pattern: "type.name[index].attr" -> (type, name, index, attr)
 fn parse_array_access(path: &str) -> Option<(String, String, usize, String)> {
-    let array_re =
-        Regex::new(r"^([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_][a-zA-Z0-9_-]*)\[(\d+)\](?:\.(.+))?$")
-            .ok()?;
+    // Optimization: Use cached regex to avoid recompiling on every template evaluation
+    let array_re = crate::utils::get_regex(
+        r"^([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_][a-zA-Z0-9_-]*)\[(\d+)\](?:\.(.+))?$",
+    )
+    .ok()?;
 
     let caps = array_re.captures(path)?;
     let resource_type = caps.get(1)?.as_str().to_string();


### PR DESCRIPTION
💡 What: Replaced the dynamic instantiation of `Regex::new` with the cached `crate::utils::get_regex` inside `parse_array_access` in `src/provisioning/resolver.rs`.

🎯 Why: `Regex::new` is an expensive operation that compiles the regular expression pattern. `parse_array_access` is called frequently during template resolution when evaluating resource cross-references. Recompiling the regex on every call creates a significant performance bottleneck.

📊 Impact: Reduces template resolution overhead by avoiding redundant regex compilations. Expect faster execution of playbooks that rely heavily on array indexing and resource referencing in templates.

🔬 Measurement: Verified via `cargo test --lib -- tests` that the substitution behaves identically to the original implementation. A benchmark profiling template resolution with deep array references would show a noticeable reduction in regex compilation time.

---
*PR created automatically by Jules for task [6360777705819960979](https://jules.google.com/task/6360777705819960979) started by @dolagoartur*