### PR TITLE
🎨 Palette: Add keyboard navigation hint to interactive banner

### DIFF
--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -63,6 +63,13 @@ impl InteractiveSession {
                 .bold()
         );
         println!();
+        let _ = self.term.write_line(&format!(
+            "  {}",
+            "Tip: Use arrow keys to navigate menus, Space to select multiple items, Enter to confirm"
+                .cyan()
+                .dimmed()
+        ));
+        println!();
     }
 
     /// Prompt for main menu action


### PR DESCRIPTION
💡 What: Added a keyboard navigation hint to the main welcome banner for the interactive CLI mode.
🎯 Why: To provide unified guidance for `dialoguer` menus up-front, avoiding confusion without repeating instructions on every prompt.
📸 Before/After: N/A
♿ Accessibility: Improves usability by clarifying keyboard-only navigation controls (arrow keys, Space, Enter) for interactive terminal interfaces.

---
*PR created automatically by Jules for task [2596171144077992168](https://jules.google.com/task/2596171144077992168) started by @dolagoartur*