### PR TITLE
🎨 Palette: Standardize secure input prompts with locked emoji

### DIFF
--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -726,7 +726,7 @@ impl RunArgs {
             if std::io::stdin().is_terminal() {
                 Some(
                     dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("🔐 BECOME password")
+                        .with_prompt("🔒 BECOME password")
                         .interact()?,
                 )
             } else {

--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -358,7 +358,7 @@ fn get_password(password_file: Option<&PathBuf>, ctx: &CommandContext) -> Result
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 Vault password")
+        .with_prompt("🔒 Vault password")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -376,8 +376,8 @@ fn get_password_with_confirm(
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 New Vault password")
-        .with_confirmation("🔐 Confirm Vault password", "Passwords do not match")
+        .with_prompt("🔒 New Vault password")
+        .with_confirmation("🔒 Confirm Vault password", "Passwords do not match")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -634,8 +634,8 @@ impl VaultArgs {
                     s.as_bytes().to_vec()
                 } else if std::io::stdin().is_terminal() {
                     let input = dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("📝 Enter text to encrypt (hidden)")
-                        .with_confirmation("🔐 Confirm text to encrypt", "Inputs do not match")
+                        .with_prompt("🔒 Enter text to encrypt (hidden)")
+                        .with_confirmation("🔒 Confirm text to encrypt", "Inputs do not match")
                         .interact()?;
                     input.as_bytes().to_vec()
                 } else {


### PR DESCRIPTION
💡 What: Replaced inconsistent `"🔐"` (Closed Lock with Key) and `"📝"` (Memo) emojis with a standard `"🔒"` (Lock) emoji in `dialoguer::Password` prompts within the CLI application (specifically `src/cli/commands/run.rs` and `src/cli/commands/vault.rs`).
🎯 Why: A memo icon `"📝"` does not communicate that user input will be hidden/secured. Using a standard lock `"🔒"` emoji across all secure input prompts improves visual scannability and builds user trust by clearly setting expectations for masked input fields.
📸 Before/After:
Before: `"🔐 Vault password"` and `"📝 Enter text to encrypt (hidden)"`
After: `"🔒 Vault password"` and `"🔒 Enter text to encrypt (hidden)"`
♿ Accessibility: Ensures clearer intent for visual users when scanning the CLI for input boundaries.

---
*PR created automatically by Jules for task [4152551255990614613](https://jules.google.com/task/4152551255990614613) started by @dolagoartur*