### PR TITLE
🎨 Palette: Fix inconsistent emojis in interactive menus and password prompts

### DIFF
--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -726,7 +726,7 @@ impl RunArgs {
             if std::io::stdin().is_terminal() {
                 Some(
                     dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("🔐 BECOME password")
+                        .with_prompt("🔒 BECOME password")
                         .interact()?,
                 )
             } else {

--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -358,7 +358,7 @@ fn get_password(password_file: Option<&PathBuf>, ctx: &CommandContext) -> Result
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 Vault password")
+        .with_prompt("🔒 Vault password")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -376,8 +376,8 @@ fn get_password_with_confirm(
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 New Vault password")
-        .with_confirmation("🔐 Confirm Vault password", "Passwords do not match")
+        .with_prompt("🔒 New Vault password")
+        .with_confirmation("🔒 Confirm Vault password", "Passwords do not match")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -634,8 +634,8 @@ impl VaultArgs {
                     s.as_bytes().to_vec()
                 } else if std::io::stdin().is_terminal() {
                     let input = dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("📝 Enter text to encrypt (hidden)")
-                        .with_confirmation("🔐 Confirm text to encrypt", "Inputs do not match")
+                        .with_prompt("🔒 Enter text to encrypt (hidden)")
+                        .with_confirmation("🔒 Confirm text to encrypt", "Inputs do not match")
                         .interact()?;
                     input.as_bytes().to_vec()
                 } else {

--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -79,7 +79,7 @@ impl InteractiveSession {
             "🔍 Check playbook (dry-run)",
             "📋 List hosts",
             "📝 List tasks",
-            "🔐 Vault operations",
+            "🔒 Vault operations",
             "✨ Initialize project",
             "✅ Validate playbook",
             "⚙️ Settings",
@@ -87,7 +87,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("What would you like to do?")
+            .with_prompt("🎯 What would you like to do?")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;
@@ -382,7 +382,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("🔐 Vault operation")
+            .with_prompt("🔒 Vault operation")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;


### PR DESCRIPTION
**💡 What**
Replaced mixed 🔐 and 📝 emojis with a consistent 🔒 emoji for all `dialoguer::Password` prompts in `src/cli/commands/run.rs` and `src/cli/commands/vault.rs` to clearly indicate secure input. Additionally, replaced `🔐` with `🔒` for Vault operations in the main menu and added the `🎯` emoji to the main menu prompt to match the application's overall visual style in `src/cli/interactive.rs`.

**🎯 Why**
Visual consistency is key to a polished user experience. Using a single, standard icon (🔒) universally signals to the user that they are entering sensitive, hidden information. Mixing different icons for the same concept can cause subtle cognitive load. Adding `🎯` to the main menu prompt establishes a friendly, unified look across all top-level selections.

**📸 Before/After**
*Before:*
- Password prompts used a mix of `🔐` and `📝` (e.g., `"🔐 BECOME password"`, `"📝 Enter text to encrypt"`).
- Vault operations menu item used `🔐`.
- Main menu prompt was `"What would you like to do?"`.

*After:*
- All password prompts universally use `🔒` (e.g., `"🔒 BECOME password"`, `"🔒 Enter text to encrypt"`).
- Vault operations menu item uses `🔒`.
- Main menu prompt is `"🎯 What would you like to do?"`.

**♿ Accessibility**
No strict ARIA accessibility changes, but using consistent, semantic icons reduces cognitive load for all users, improving overall usability and visual parsing of the interface.

---
*PR created automatically by Jules for task [14927979261758809052](https://jules.google.com/task/14927979261758809052) started by @dolagoartur*