### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure temporary file creation in Vault commands

### DIFF
--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -490,8 +490,11 @@ impl VaultArgs {
                 };
 
                 // Create temporary file
-                let temp_dir = std::env::temp_dir();
-                let temp_file = temp_dir.join(format!(".rustible_vault_{}", std::process::id()));
+                let temp_file = tempfile::Builder::new()
+                    .prefix(".rustible_vault_")
+                    .tempfile()
+                    .context("Failed to create temporary file")?
+                    .into_temp_path();
 
                 fs::write(&temp_file, &plaintext)?;
 
@@ -502,13 +505,11 @@ impl VaultArgs {
                     .with_context(|| format!("Failed to open editor: {}", args.editor))?;
 
                 if !status.success() {
-                    fs::remove_file(&temp_file).ok();
                     bail!("Editor exited with error");
                 }
 
                 // Read edited content
                 let edited = fs::read(&temp_file)?;
-                fs::remove_file(&temp_file)?;
 
                 // Re-encrypt if it was encrypted
                 if was_encrypted {
@@ -537,8 +538,11 @@ impl VaultArgs {
                 let engine = VaultEngine::new(password);
 
                 // Create temporary file
-                let temp_dir = std::env::temp_dir();
-                let temp_file = temp_dir.join(format!(".rustible_vault_{}", std::process::id()));
+                let temp_file = tempfile::Builder::new()
+                    .prefix(".rustible_vault_")
+                    .tempfile()
+                    .context("Failed to create temporary file")?
+                    .into_temp_path();
 
                 fs::write(&temp_file, "")?;
 
@@ -549,13 +553,11 @@ impl VaultArgs {
                     .with_context(|| format!("Failed to open editor: {}", args.editor))?;
 
                 if !status.success() {
-                    fs::remove_file(&temp_file).ok();
                     bail!("Editor exited with error");
                 }
 
                 // Read content
                 let content = fs::read(&temp_file)?;
-                fs::remove_file(&temp_file)?;
 
                 if content.is_empty() {
                     ctx.output.warning("No content entered, file not created");


### PR DESCRIPTION
## 🚨 Severity
CRITICAL

## 💡 Vulnerability
The `vault edit` and `vault create` commands were using `std::env::temp_dir().join(...)` to generate predictable temporary file paths (`.rustible_vault_<PID>`) for storing decrypted secret data while editing. This created a severe Time-of-Check to Time-of-Use (TOCTOU) vulnerability where an attacker could create a symlink at the predictable path to steal data or overwrite sensitive system files. Furthermore, `fs::write` would create these files with the default user umask (typically 644 world-readable), temporarily exposing sensitive decrypted vault data to other local users. The files were also manually removed via `fs::remove_file` which could fail or be bypassed on early errors or panics, leaving decrypted data on disk.

## 🎯 Impact
Local users could read decrypted secrets intended to be edited in the vault. A malicious local user could execute symlink attacks to overwrite system files or steal secrets.

## 🔧 Fix
Replaced the manual temporary file path construction and creation with the `tempfile` crate (`tempfile::Builder::new().tempfile()?.into_temp_path()`). This safely creates an unpredictable temporary file with secure (`0600`) permissions by default. It also uses Rust's RAII pattern via `TempPath`, which automatically unlinks the temporary file when it drops out of scope, guaranteeing that the plain-text secret is never leaked or left on disk even on errors, panics, or early returns. Replaced explicit calls to `fs::remove_file()` with this automated drop.

## ✅ Verification
1. `cargo test --lib cli::commands::vault` and all tests pass.
2. Verified via code review that `tempfile` ensures secure, atomic file creation and reliable deletion across all edge cases in `VaultAction::Edit` and `VaultAction::Create`.

---
*PR created automatically by Jules for task [7950201580187330172](https://jules.google.com/task/7950201580187330172) started by @dolagoartur*