### PR TITLE
🎨 Palette: Fix inconsistent emoji in vault password prompt

### DIFF
--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -634,7 +634,7 @@ impl VaultArgs {
                     s.as_bytes().to_vec()
                 } else if std::io::stdin().is_terminal() {
                     let input = dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("📝 Enter text to encrypt (hidden)")
+                        .with_prompt("🔐 Enter text to encrypt (hidden)")
                         .with_confirmation("🔐 Confirm text to encrypt", "Inputs do not match")
                         .interact()?;
                     input.as_bytes().to_vec()


### PR DESCRIPTION
💡 What: Changed the emoji in the interactive prompt for `VaultAction::EncryptString` from `📝` to `🔐`.
🎯 Why: To maintain visual consistency with the confirmation prompt (`🔐 Confirm text to encrypt`) and the rest of the vault commands, which consistently use the `🔐` icon to signify secure input.
📸 Before/After:
Before: `📝 Enter text to encrypt (hidden)`
After: `🔐 Enter text to encrypt (hidden)`
♿ Accessibility: Ensures consistent semantic symbols are used for secure text inputs, helping users immediately recognize they are typing sensitive information.

---
*PR created automatically by Jules for task [1114276529241243619](https://jules.google.com/task/1114276529241243619) started by @dolagoartur*