### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in audit file logger

### DIFF
--- a/src/audit/logger.rs
+++ b/src/audit/logger.rs
@@ -100,7 +100,14 @@ impl FileLogger {
             }
         }
 
-        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        let mut options = OpenOptions::new();
+        options.create(true).append(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options.open(&path)?;
 
         Ok(Self {
             path,
@@ -159,10 +166,14 @@ impl FileLogger {
         std::fs::rename(&self.path, &rotated)?;
 
         // Open new file
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.path)?;
+        let mut options = OpenOptions::new();
+        options.create(true).append(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options.open(&self.path)?;
 
         let mut writer = self.writer.lock().unwrap();
         *writer = BufWriter::new(file);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The audit file logger in `src/audit/logger.rs` created log files using `OpenOptions::new().create(true)` without specifying file permissions. On Unix systems, this can lead to a Time-of-Check to Time-of-Use (TOCTOU) race condition where the file is created with default, potentially world-readable permissions before any later restriction could be applied. Since audit logs contain highly sensitive information (commands executed, usernames, escalate passwords redacted paths), exposing them is a significant risk.
🎯 Impact: Attackers or unprivileged users on the system could potentially read sensitive audit events from newly created or rotated log files.
🔧 Fix: Used `std::os::unix::fs::OpenOptionsExt` inside a `#[cfg(unix)]` block to explicitly set the file mode to `0o600` (read/write by owner only) during creation. This ensures atomic creation with secure permissions.
✅ Verification: Ran `cargo test --lib -- tests` and all unit tests passed. Pre-commit linters and formatting successfully applied.

---
*PR created automatically by Jules for task [934629923755269245](https://jules.google.com/task/934629923755269245) started by @dolagoartur*