### PR TITLE
⚡ Bolt: Cache regex in slurm_partition validation

### DIFF
--- a/src/modules/hpc/slurm_partition.rs
+++ b/src/modules/hpc/slurm_partition.rs
@@ -17,6 +17,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use once_cell::sync::Lazy;
 use regex::Regex;
 use tokio::runtime::Handle;
 
@@ -498,14 +499,16 @@ fn validate_partition_properties(params: &ModuleParams) -> ModuleResult<Prefligh
 ///   minutes, minutes:seconds, hours:minutes:seconds,
 ///   days-hours, days-hours:minutes, days-hours:minutes:seconds
 fn is_valid_max_time(s: &str) -> bool {
+    static MAX_TIME_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"^(\d+(-\d+(:\d+(:\d+)?)?)?|\d+(:\d+(:\d+)?)?)$").unwrap());
+
     let upper = s.to_uppercase();
     if upper == "INFINITE" || upper == "UNLIMITED" {
         return true;
     }
     // Match Slurm time formats:
     //   D-HH:MM:SS, D-HH:MM, D-HH, HH:MM:SS, MM:SS, MM
-    let re = Regex::new(r"^(\d+(-\d+(:\d+(:\d+)?)?)?|\d+(:\d+(:\d+)?)?)$").unwrap();
-    re.is_match(s)
+    MAX_TIME_RE.is_match(s)
 }
 
 /// Check if a string is valid Slurm hostlist notation.
@@ -513,12 +516,13 @@ fn is_valid_max_time(s: &str) -> bool {
 /// Valid: alphanumeric node names, bracket ranges like node[01-10],
 /// comma-separated lists, and combinations thereof.
 fn is_valid_hostlist(s: &str) -> bool {
+    static HOSTLIST_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[a-zA-Z0-9\[\]\-_,]+$").unwrap());
+
     if s.is_empty() {
         return false;
     }
     // Slurm hostlists: alphanumeric, hyphens, brackets, commas, underscores
-    let re = Regex::new(r"^[a-zA-Z0-9\[\]\-_,]+$").unwrap();
-    re.is_match(s)
+    HOSTLIST_RE.is_match(s)
 }
 
 /// Build a map of desired partition properties from params for drift comparison.


### PR DESCRIPTION
💡 What
Refactored the `is_valid_max_time` and `is_valid_hostlist` validation functions in `src/modules/hpc/slurm_partition.rs` to statically cache their regular expressions using `once_cell::sync::Lazy`.

🎯 Why
Regular expressions are expensive to compile. By recompiling the regex on every function call (`Regex::new().unwrap()`), we were incurring significant and unnecessary overhead, especially if these validators are invoked in tight loops (e.g., verifying multiple nodes or parameters). Caching them statically avoids this penalty.

📊 Impact
Improves execution speed of the `is_valid_max_time` and `is_valid_hostlist` validation checks by ensuring regex compilation only happens exactly once during the application's lifecycle, rather than on every invocation.

🔬 Measurement
Tests were successfully executed with `cargo test --lib hpc::slurm_partition`. Since we didn't run an explicit benchmark comparing the micro-optimization, we rely on the established Rust best practice that avoiding repeated `Regex::new` inside hot paths is a quantifiable performance optimization.

---
*PR created automatically by Jules for task [309945648351403657](https://jules.google.com/task/309945648351403657) started by @dolagoartur*