### PR TITLE
🎨 Palette: Update vault prompt to use consistent secure input emoji

### DIFF
--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -634,7 +634,7 @@ impl VaultArgs {
                     s.as_bytes().to_vec()
                 } else if std::io::stdin().is_terminal() {
                     let input = dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("📝 Enter text to encrypt (hidden)")
+                        .with_prompt("🔐 Enter text to encrypt (hidden)")
                         .with_confirmation("🔐 Confirm text to encrypt", "Inputs do not match")
                         .interact()?;
                     input.as_bytes().to_vec()


### PR DESCRIPTION
💡 What: Updated the emoji for the "Enter text to encrypt" prompt in `src/cli/commands/vault.rs` from `📝` to `🔐`.
🎯 Why: To maintain visual consistency across secure input prompts. Previously, the confirmation prompt used `🔐` while the initial input used `📝`. Now they both use `🔐`, matching other password prompts.
📸 Before/After: Visual change in the CLI prompt icon.
♿ Accessibility: Improves scannability and context for visually identifying secure input fields.

---
*PR created automatically by Jules for task [17953361381181346072](https://jules.google.com/task/17953361381181346072) started by @dolagoartur*