### PR TITLE
🛡️ Sentinel: [HIGH] Fix predictable temporary file creation in vault command

### DIFF
--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -489,9 +489,11 @@ impl VaultArgs {
                     content.into_bytes()
                 };
 
-                // Create temporary file
-                let temp_dir = std::env::temp_dir();
-                let temp_file = temp_dir.join(format!(".rustible_vault_{}", std::process::id()));
+                // Create secure temporary file
+                let temp_file = tempfile::Builder::new()
+                    .prefix(".rustible_vault_")
+                    .tempfile()?
+                    .into_temp_path();
 
                 fs::write(&temp_file, &plaintext)?;
 
@@ -502,13 +504,11 @@ impl VaultArgs {
                     .with_context(|| format!("Failed to open editor: {}", args.editor))?;
 
                 if !status.success() {
-                    fs::remove_file(&temp_file).ok();
                     bail!("Editor exited with error");
                 }
 
                 // Read edited content
                 let edited = fs::read(&temp_file)?;
-                fs::remove_file(&temp_file)?;
 
                 // Re-encrypt if it was encrypted
                 if was_encrypted {
@@ -536,9 +536,11 @@ impl VaultArgs {
                 let password = get_password_with_confirm(args.vault_password_file.as_ref(), ctx)?;
                 let engine = VaultEngine::new(password);
 
-                // Create temporary file
-                let temp_dir = std::env::temp_dir();
-                let temp_file = temp_dir.join(format!(".rustible_vault_{}", std::process::id()));
+                // Create secure temporary file
+                let temp_file = tempfile::Builder::new()
+                    .prefix(".rustible_vault_")
+                    .tempfile()?
+                    .into_temp_path();
 
                 fs::write(&temp_file, "")?;
 
@@ -549,13 +551,11 @@ impl VaultArgs {
                     .with_context(|| format!("Failed to open editor: {}", args.editor))?;
 
                 if !status.success() {
-                    fs::remove_file(&temp_file).ok();
                     bail!("Editor exited with error");
                 }
 
                 // Read content
                 let content = fs::read(&temp_file)?;
-                fs::remove_file(&temp_file)?;
 
                 if content.is_empty() {
                     ctx.output.warning("No content entered, file not created");


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `rustible vault` command used `std::env::temp_dir().join(...)` with a predictable file name (using `std::process::id()`) to create temporary files for decrypted vault contents before opening them in an editor.
🎯 Impact: This can lead to local file exposure, predictable temp file vulnerabilities, race conditions, or symlink attacks if the temporary directory is shared or world-writable.
🔧 Fix: Replaced predictable temporary file creation with cryptographically secure temporary files using the `tempfile` crate (`tempfile::Builder::new().tempfile()?.into_temp_path()`). Leveraged `TempPath`'s automatic `Drop` implementation for safe and reliable cleanup.
✅ Verification: Ran `cargo fmt`, `cargo clippy`, `cargo check`, and `cargo test --lib -- tests` to ensure code quality and no regressions.

---
*PR created automatically by Jules for task [4377806413514601477](https://jules.google.com/task/4377806413514601477) started by @dolagoartur*