### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in file logger

### DIFF
--- a/src/audit/logger.rs
+++ b/src/audit/logger.rs
@@ -100,7 +100,14 @@ impl FileLogger {
             }
         }
 
-        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        let mut options = OpenOptions::new();
+        options.create(true).append(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options.open(&path)?;
 
         Ok(Self {
             path,
@@ -159,10 +166,14 @@ impl FileLogger {
         std::fs::rename(&self.path, &rotated)?;
 
         // Open new file
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.path)?;
+        let mut options = OpenOptions::new();
+        options.create(true).append(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options.open(&self.path)?;
 
         let mut writer = self.writer.lock().unwrap();
         *writer = BufWriter::new(file);


### PR DESCRIPTION
## 🚨 Severity
CRITICAL

## 💡 Vulnerability
The `FileLogger` in `src/audit/logger.rs` was creating sensitive audit log files and rotated log files using `OpenOptions::new().create(true).append(true)` without specifying file permissions. On Unix systems, this defaults to the process's umask (typically `0o644`), leaving these files world-readable for a period of time before external measures (if any) could lock them down. This is a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where sensitive data (e.g., commands executed, paths accessed) is briefly exposed.

## 🎯 Impact
An attacker with local read access to the system could monitor the audit log files during creation or rotation and extract sensitive information like file paths, commands, and potentially secrets if they are inadvertently logged, violating confidentiality.

## 🔧 Fix
Updated both file creation instances in `FileLogger::with_options` and `FileLogger::rotate` to use `std::os::unix::fs::OpenOptionsExt::mode(0o600)` under `#[cfg(unix)]`. This ensures that the files are atomically created with read/write permissions exclusively for the owner, preventing the TOCTOU window.

## ✅ Verification
1. Run `cargo fmt` and `cargo clippy` to ensure code quality.
2. Run `cargo check` to ensure the project still compiles safely across platforms.
3. Run `cargo test --lib -- tests` to confirm that the changes do not break any existing functionality and that the audit tests still pass.

---
*PR created automatically by Jules for task [11043319388639591844](https://jules.google.com/task/11043319388639591844) started by @dolagoartur*