### PR TITLE
⚡ Bolt: Replace Regex::new with cached get_regex in inventory matching

### DIFF
--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -141,7 +141,6 @@ pub use plugins::{
 };
 
 use indexmap::IndexMap;
-use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::process::Command;
@@ -1070,7 +1069,9 @@ impl Inventory {
 
         // Handle regex pattern
         if let Some(regex_str) = pattern.strip_prefix('~') {
-            let regex = Regex::new(regex_str)
+            // OPTIMIZATION (Bolt): Use cached get_regex instead of Regex::new to prevent
+            // expensive recompilation on every evaluation.
+            let regex = crate::utils::get_regex(regex_str)
                 .map_err(|_| InventoryError::InvalidPattern(pattern.to_string()))?;
 
             return Ok(self
@@ -1083,7 +1084,9 @@ impl Inventory {
         // Handle glob/wildcard pattern
         if pattern.contains('*') || pattern.contains('?') || pattern.contains('[') {
             let regex_pattern = glob_to_regex(pattern);
-            let regex = Regex::new(&regex_pattern)
+            // OPTIMIZATION (Bolt): Use cached get_regex instead of Regex::new to prevent
+            // expensive recompilation of the converted glob pattern.
+            let regex = crate::utils::get_regex(&regex_pattern)
                 .map_err(|_| InventoryError::InvalidPattern(pattern.to_string()))?;
 
             return Ok(self


### PR DESCRIPTION
### 💡 What
Replaced `Regex::new` with `crate::utils::get_regex` in `src/inventory/mod.rs` for handling regex and glob pattern matching for hosts. Also removed the unused `regex::Regex` import.

### 🎯 Why
`Regex::new` compiles a regular expression from a string, which is an expensive operation. Calling this repeatedly inside loops or hot paths (like host matching logic) is a well-known performance anti-pattern. `crate::utils::get_regex` provides a thread-safe cache for compiled regexes, reusing them and drastically reducing execution time.

### 📊 Impact
Eliminates repeated compilation of the same regular expressions during inventory pattern resolution. Expected to significantly speed up host matching and pattern resolution, particularly when filtering through large inventories with many regex/glob patterns.

### 🔬 Measurement
Run `cargo test --lib -- tests` to verify existing functionality is preserved. Performance improvement can be observed in inventory load times and execution of large playbooks using regex patterns for host selection.

---
*PR created automatically by Jules for task [6633042046572521342](https://jules.google.com/task/6633042046572521342) started by @dolagoartur*