### PR TITLE
🎨 Palette: Add emoji to main menu prompt

### DIFF
--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -87,7 +87,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("What would you like to do?")
+            .with_prompt("🎯 What would you like to do?")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;


### PR DESCRIPTION
💡 What: Added the 🎯 emoji prefix to the "What would you like to do?" main menu prompt.
🎯 Why: To maintain visual consistency with other interactive CLI prompts which all use semantic emoji prefixes (e.g., 📖 Playbook, 📋 Inventory, 🔐 Vault). This makes the interface more scannable and pleasant to use.
📸 Before/After: Before: `What would you like to do?`, After: `🎯 What would you like to do?`
♿ Accessibility: Improves visual scanning and pattern recognition for users navigating the CLI menus.

---
*PR created automatically by Jules for task [1402076738991494835](https://jules.google.com/task/1402076738991494835) started by @dolagoartur*