### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix predictable temp file vulnerability in Vault

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -103,3 +103,7 @@
 **Vulnerability:** A refactoring error in `validate_command_args` introduced a logic flaw where input containing any unsafe character would bypass the dangerous pattern check and incorrectly be considered valid, enabling potential command injection.
 **Learning:** Security validation functions must be thoroughly tested, especially when refactoring for performance optimizations (like adding fast-paths). Boolean logic errors in early returns can completely neutralize subsequent security checks.
 **Prevention:** Always maintain comprehensive unit tests covering both positive (safe) and negative (malicious) inputs for security validation routines. Ensure fast-path logic correctly falls through to more exhaustive checks when necessary.
+## 2026-06-21 - Insecure Temporary File Creation in Vault Edit/Create
+**Vulnerability:** The `VaultAction::Edit` and `VaultAction::Create` subcommands used `std::env::temp_dir().join(format!(".rustible_vault_{}", std::process::id()))` to store plaintext secrets temporarily. This predictable naming convention makes it vulnerable to local file exposure or Time-of-Check to Time-of-Use (TOCTOU) attacks.
+**Learning:** `std::env::temp_dir` with predictable file names is dangerous for sensitive contents like unencrypted passwords or secrets.
+**Prevention:** Use the `tempfile` crate (e.g., `tempfile::Builder::new().tempfile()`) to generate secure, atomic temporary files with random names. For external tools, `.into_temp_path()` drops the lock but ensures the file is automatically removed.

--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -490,8 +490,10 @@ impl VaultArgs {
                 };
 
                 // Create temporary file
-                let temp_dir = std::env::temp_dir();
-                let temp_file = temp_dir.join(format!(".rustible_vault_{}", std::process::id()));
+                let temp_file = tempfile::Builder::new()
+                    .prefix(".rustible_vault_")
+                    .tempfile()?
+                    .into_temp_path();
 
                 fs::write(&temp_file, &plaintext)?;
 
@@ -502,13 +504,11 @@ impl VaultArgs {
                     .with_context(|| format!("Failed to open editor: {}", args.editor))?;
 
                 if !status.success() {
-                    fs::remove_file(&temp_file).ok();
                     bail!("Editor exited with error");
                 }
 
                 // Read edited content
                 let edited = fs::read(&temp_file)?;
-                fs::remove_file(&temp_file)?;
 
                 // Re-encrypt if it was encrypted
                 if was_encrypted {
@@ -537,8 +537,10 @@ impl VaultArgs {
                 let engine = VaultEngine::new(password);
 
                 // Create temporary file
-                let temp_dir = std::env::temp_dir();
-                let temp_file = temp_dir.join(format!(".rustible_vault_{}", std::process::id()));
+                let temp_file = tempfile::Builder::new()
+                    .prefix(".rustible_vault_")
+                    .tempfile()?
+                    .into_temp_path();
 
                 fs::write(&temp_file, "")?;
 
@@ -549,13 +551,11 @@ impl VaultArgs {
                     .with_context(|| format!("Failed to open editor: {}", args.editor))?;
 
                 if !status.success() {
-                    fs::remove_file(&temp_file).ok();
                     bail!("Editor exited with error");
                 }
 
                 // Read content
                 let content = fs::read(&temp_file)?;
-                fs::remove_file(&temp_file)?;
 
                 if content.is_empty() {
                     ctx.output.warning("No content entered, file not created");


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `VaultAction::Edit` and `VaultAction::Create` subcommands used `std::env::temp_dir().join(format!(".rustible_vault_{}", std::process::id()))` to store plaintext secrets temporarily. This predictable naming convention makes it vulnerable to local file exposure or Time-of-Check to Time-of-Use (TOCTOU) attacks.
🎯 Impact: Attackers could potentially read or manipulate unencrypted vault contents during an edit session by pre-creating or racing to open the predictable temporary file name.
🔧 Fix: Replaced predictable temporary file paths with the `tempfile` crate (`tempfile::Builder::new().tempfile()`). This generates random file names atomically and sets secure permissions (`0600` on unix). The `into_temp_path()` method is used to release the lock for external editors while preserving automatic cleanup on drop.
✅ Verification: Ran `cargo fmt && cargo clippy`, `cargo check`, and `cargo test --lib -- tests` locally, ensuring no regressions. The `rustible vault edit` feature remains functionally identical but with secure temporary file semantics.

---
*PR created automatically by Jules for task [14870831759099605171](https://jules.google.com/task/14870831759099605171) started by @dolagoartur*