### PR TITLE
🎨 Palette: Standardize semantic emojis in interactive CLI prompts

### DIFF
--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -634,7 +634,7 @@ impl VaultArgs {
                     s.as_bytes().to_vec()
                 } else if std::io::stdin().is_terminal() {
                     let input = dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("📝 Enter text to encrypt (hidden)")
+                        .with_prompt("🔐 Enter text to encrypt (hidden)")
                         .with_confirmation("🔐 Confirm text to encrypt", "Inputs do not match")
                         .interact()?;
                     input.as_bytes().to_vec()

--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -87,7 +87,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("What would you like to do?")
+            .with_prompt("🎯 What would you like to do?")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;


### PR DESCRIPTION
💡 What: Standardized emoji usage across interactive prompts in the CLI, adding `🎯` to the main menu prompt and changing the text encryption prompt from `📝` to the secure `🔐` emoji.
🎯 Why: To improve scannability and visual consistency, especially for sensitive input fields which should universally use the lock symbol.
📸 Before/After: N/A
♿ Accessibility: Improves visual recognition of interactive components and secure fields.

---
*PR created automatically by Jules for task [12087869313790302136](https://jules.google.com/task/12087869313790302136) started by @dolagoartur*