### PR TITLE
⚡ Bolt: Cache static regexes in HPC modules using OnceLock

### DIFF
--- a/src/modules/hpc/opensm.rs
+++ b/src/modules/hpc/opensm.rs
@@ -144,7 +144,8 @@ fn validate_opensm_config(
     let mut warnings = Vec::new();
 
     if let Some(ref prefix) = subnet_prefix {
-        let re = Regex::new(r"^0x[0-9a-fA-F]{16}$").unwrap();
+        static RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+        let re = RE.get_or_init(|| Regex::new(r"^0x[0-9a-fA-F]{16}$").unwrap());
         if !re.is_match(prefix) {
             errors.push(format!(
                 "Invalid subnet_prefix '{}': must match 0x followed by 16 hex digits \
@@ -311,7 +312,9 @@ fn parse_sm_role(sminfo_output: &str) -> &'static str {
         return "standby";
     }
     // Check for numeric state
-    if let Some(caps) = Regex::new(r"state\s+(\d+)").unwrap().captures(&lower) {
+    static RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    let re = RE.get_or_init(|| Regex::new(r"state\s+(\d+)").unwrap());
+    if let Some(caps) = re.captures(&lower) {
         if let Some(m) = caps.get(1) {
             match m.as_str() {
                 "4" => return "master",

--- a/src/modules/hpc/slurm_account.rs
+++ b/src/modules/hpc/slurm_account.rs
@@ -702,7 +702,9 @@ fn validate_policies(params: &ModuleParams) -> ModuleResult<PreflightResult> {
         if val != "-1" {
             // Slurm time formats: minutes, minutes:seconds, hours:minutes:seconds,
             // days-hours, days-hours:minutes, days-hours:minutes:seconds
-            let wall_re = Regex::new(r"^\d+(-\d+:\d+(:\d+)?)?$").expect("invalid regex");
+            static WALL_RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+            let wall_re = WALL_RE
+                .get_or_init(|| Regex::new(r"^\d+(-\d+:\d+(:\d+)?)?$").expect("invalid regex"));
             if !wall_re.is_match(val) {
                 errors.push(format!(
                     "max_wall must match time format (e.g. '60', '7-00:00:00') or '-1' for unlimited, got '{}'",

--- a/src/modules/hpc/slurm_partition.rs
+++ b/src/modules/hpc/slurm_partition.rs
@@ -504,7 +504,9 @@ fn is_valid_max_time(s: &str) -> bool {
     }
     // Match Slurm time formats:
     //   D-HH:MM:SS, D-HH:MM, D-HH, HH:MM:SS, MM:SS, MM
-    let re = Regex::new(r"^(\d+(-\d+(:\d+(:\d+)?)?)?|\d+(:\d+(:\d+)?)?)$").unwrap();
+    static RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    let re =
+        RE.get_or_init(|| Regex::new(r"^(\d+(-\d+(:\d+(:\d+)?)?)?|\d+(:\d+(:\d+)?)?)$").unwrap());
     re.is_match(s)
 }
 
@@ -517,7 +519,8 @@ fn is_valid_hostlist(s: &str) -> bool {
         return false;
     }
     // Slurm hostlists: alphanumeric, hyphens, brackets, commas, underscores
-    let re = Regex::new(r"^[a-zA-Z0-9\[\]\-_,]+$").unwrap();
+    static RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    let re = RE.get_or_init(|| Regex::new(r"^[a-zA-Z0-9\[\]\-_,]+$").unwrap());
     re.is_match(s)
 }
 


### PR DESCRIPTION
💡 What: Replaced inline `Regex::new` calls inside hot functions in `src/modules/hpc/slurm_partition.rs`, `src/modules/hpc/slurm_account.rs`, and `src/modules/hpc/opensm.rs` with `std::sync::OnceLock`.
🎯 Why: `Regex::new` is an expensive operation in Rust that compiles the regular expression into an NFA/DFA graph. Doing this inline within frequently called functions (like configuration and property validators) causes substantial unnecessary CPU overhead. 
📊 Impact: Compiles the regex exactly once for the entire lifetime of the process, reducing the overhead of validation logic down to near-zero time (virtually O(1) matching vs O(Regex Size) compilation repeatedly).
🔬 Measurement: Verify compilation and tests with `cargo test --lib -- tests`, which ensure that the HPC configuration logic correctly enforces limits and constraints without regressions in validation semantics.

---
*PR created automatically by Jules for task [4577687796806162597](https://jules.google.com/task/4577687796806162597) started by @dolagoartur*