### PR TITLE
🎨 Palette: Fix emoji prefixes for sensitive data prompts

### DIFF
--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -634,7 +634,7 @@ impl VaultArgs {
                     s.as_bytes().to_vec()
                 } else if std::io::stdin().is_terminal() {
                     let input = dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("📝 Enter text to encrypt (hidden)")
+                        .with_prompt("🔐 Enter text to encrypt (hidden)")
                         .with_confirmation("🔐 Confirm text to encrypt", "Inputs do not match")
                         .interact()?;
                     input.as_bytes().to_vec()
@@ -672,7 +672,7 @@ impl VaultArgs {
                 } else if std::io::stdin().is_terminal() {
                     println!(
                         "{}",
-                        "📝 Enter encrypted string (press Enter twice to finish):".bold()
+                        "🔐 Enter encrypted string (press Enter twice to finish):".bold()
                     );
                     let mut lines = Vec::new();
                     let stdin = io::stdin();


### PR DESCRIPTION
💡 What: Updated the emoji prefix from `📝` (memo) to `🔐` (lock with key) for the `EncryptString` and `DecryptString` interactive CLI prompts in `src/cli/commands/vault.rs`.
🎯 Why: To visually distinguish sensitive data input from regular text input and align with existing UX conventions for vault and password-related prompts in the application.
📸 Before/After: Before: "📝 Enter text to encrypt (hidden)" / After: "🔐 Enter text to encrypt (hidden)"
♿ Accessibility: N/A - The emoji swap improves visual scannability and does not impact screen reader text content.

---
*PR created automatically by Jules for task [6724287914138700526](https://jules.google.com/task/6724287914138700526) started by @dolagoartur*