### PR TITLE
🎨 Palette: Standardize secure input emojis and keyboard hints

### DIFF
--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -726,7 +726,7 @@ impl RunArgs {
             if std::io::stdin().is_terminal() {
                 Some(
                     dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("🔐 BECOME password")
+                        .with_prompt("🔒 BECOME password")
                         .interact()?,
                 )
             } else {

--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -358,7 +358,7 @@ fn get_password(password_file: Option<&PathBuf>, ctx: &CommandContext) -> Result
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 Vault password")
+        .with_prompt("🔒 Vault password")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -376,8 +376,8 @@ fn get_password_with_confirm(
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 New Vault password")
-        .with_confirmation("🔐 Confirm Vault password", "Passwords do not match")
+        .with_prompt("🔒 New Vault password")
+        .with_confirmation("🔒 Confirm Vault password", "Passwords do not match")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -634,8 +634,8 @@ impl VaultArgs {
                     s.as_bytes().to_vec()
                 } else if std::io::stdin().is_terminal() {
                     let input = dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("📝 Enter text to encrypt (hidden)")
-                        .with_confirmation("🔐 Confirm text to encrypt", "Inputs do not match")
+                        .with_prompt("🔒 Enter text to encrypt (hidden)")
+                        .with_confirmation("🔒 Confirm text to encrypt", "Inputs do not match")
                         .interact()?;
                     input.as_bytes().to_vec()
                 } else {
@@ -672,7 +672,7 @@ impl VaultArgs {
                 } else if std::io::stdin().is_terminal() {
                     println!(
                         "{}",
-                        "📝 Enter encrypted string (press Enter twice to finish):".bold()
+                        "🔒 Enter encrypted string (press Enter twice to finish):".bold()
                     );
                     let mut lines = Vec::new();
                     let stdin = io::stdin();

--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -65,7 +65,7 @@ impl InteractiveSession {
         println!();
         let _ = self.term.write_line(&format!(
             "  {}",
-            "Tip: Use arrow keys to navigate menus, Space to select multiple items, Enter to confirm"
+            "Tip: Use arrow keys to navigate menus, Enter to confirm"
                 .cyan()
                 .dimmed()
         ));
@@ -79,7 +79,7 @@ impl InteractiveSession {
             "🔍 Check playbook (dry-run)",
             "📋 List hosts",
             "📝 List tasks",
-            "🔐 Vault operations",
+            "🔒 Vault operations",
             "✨ Initialize project",
             "✅ Validate playbook",
             "⚙️ Settings",
@@ -87,7 +87,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("What would you like to do?")
+            .with_prompt("🎯 What would you like to do?")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;
@@ -382,7 +382,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("🔐 Vault operation")
+            .with_prompt("🔒 Vault operation")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;


### PR DESCRIPTION
💡 What: Standardized secure input prompts (passwords/encryption) to use the `🔒` emoji, added a `🎯` emoji to the main menu prompt, and corrected the global navigation hint which misleadingly suggested users could use 'Space' to select multiple items in single-choice menus.
🎯 Why: Inconsistent emojis in CLI prompts cause cognitive load, and incorrect keyboard navigation instructions (`Space to select multiple items` for a single-choice `Select` menu) lead to user frustration.
📸 Before/After: Before, secure inputs used a mix of `🔐` and `📝`, and the global hint read `Tip: Use arrow keys to navigate menus, Space to select multiple items, Enter to confirm`. After, secure inputs consistently use `🔒`, and the global hint correctly reads `Tip: Use arrow keys to navigate menus, Enter to confirm`.
♿ Accessibility: Clear, consistent visual cues and accurate keyboard navigation instructions improve the usability of the interactive CLI session.

---
*PR created automatically by Jules for task [3543303387935837589](https://jules.google.com/task/3543303387935837589) started by @dolagoartur*