### PR TITLE
🎨 Palette: Standardize secure input prompts with 🔒 emoji

### DIFF
--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -726,7 +726,7 @@ impl RunArgs {
             if std::io::stdin().is_terminal() {
                 Some(
                     dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("🔐 BECOME password")
+                        .with_prompt("🔒 BECOME password")
                         .interact()?,
                 )
             } else {

--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -358,7 +358,7 @@ fn get_password(password_file: Option<&PathBuf>, ctx: &CommandContext) -> Result
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 Vault password")
+        .with_prompt("🔒 Vault password")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -376,8 +376,8 @@ fn get_password_with_confirm(
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 New Vault password")
-        .with_confirmation("🔐 Confirm Vault password", "Passwords do not match")
+        .with_prompt("🔒 New Vault password")
+        .with_confirmation("🔒 Confirm Vault password", "Passwords do not match")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -634,8 +634,8 @@ impl VaultArgs {
                     s.as_bytes().to_vec()
                 } else if std::io::stdin().is_terminal() {
                     let input = dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("📝 Enter text to encrypt (hidden)")
-                        .with_confirmation("🔐 Confirm text to encrypt", "Inputs do not match")
+                        .with_prompt("🔒 Enter text to encrypt (hidden)")
+                        .with_confirmation("🔒 Confirm text to encrypt", "Inputs do not match")
                         .interact()?;
                     input.as_bytes().to_vec()
                 } else {


### PR DESCRIPTION
## 💡 What
Standardized the emojis used for secure inputs in the CLI prompts. Replaced `🔐` and `📝` with `🔒` for password and encryption prompts.

## 🎯 Why
To provide a consistent and intuitive visual cue that an input is secure and hidden. Using a single, universally recognized lock emoji (🔒) improves the micro-UX and aligns with user expectations for secure fields.

## 📸 Before/After
**Before:**
- `🔐 BECOME password`
- `🔐 Vault password`
- `📝 Enter text to encrypt (hidden)`

**After:**
- `🔒 BECOME password`
- `🔒 Vault password`
- `🔒 Enter text to encrypt (hidden)`

## ♿ Accessibility
Improves scannability and visual consistency for users relying on visual cues to identify secure input fields.

---
*PR created automatically by Jules for task [11650772206235141515](https://jules.google.com/task/11650772206235141515) started by @dolagoartur*