### PR TITLE
⚡ Bolt: Replace Regex::new with cached get_regex in SecurityAnalyzer

### DIFF
--- a/src/analysis/security.rs
+++ b/src/analysis/security.rs
@@ -121,7 +121,7 @@ impl SecurityAnalyzer {
     pub fn new() -> Self {
         Self {
             secret_patterns: Self::default_secret_patterns(),
-            url_pattern: Regex::new(r#"https?://[^\s"']+"#).unwrap(),
+            url_pattern: crate::utils::get_regex(r#"https?://[^\s"']+"#).unwrap(),
             sensitive_var_patterns: Self::default_sensitive_var_patterns(),
         }
     }
@@ -130,40 +130,42 @@ impl SecurityAnalyzer {
     fn default_secret_patterns() -> Vec<Regex> {
         vec![
             // AWS keys
-            Regex::new(r"AKIA[0-9A-Z]{16}").unwrap(),
+            crate::utils::get_regex(r"AKIA[0-9A-Z]{16}").unwrap(),
             // AWS secret (usually 40 chars base64)
-            Regex::new(r#"(?i)aws.{0,20}['"][0-9a-zA-Z/+]{40}['"]"#).unwrap(),
+            crate::utils::get_regex(r#"(?i)aws.{0,20}['"][0-9a-zA-Z/+]{40}['"]"#).unwrap(),
             // Private keys
-            Regex::new(r"-----BEGIN (?:RSA |DSA |EC |OPENSSH )?PRIVATE KEY-----").unwrap(),
+            crate::utils::get_regex(r"-----BEGIN (?:RSA |DSA |EC |OPENSSH )?PRIVATE KEY-----")
+                .unwrap(),
             // Generic API key patterns
-            Regex::new(r#"(?i)api[_-]?key\s*[:=]\s*['"][a-zA-Z0-9]{16,}['"]"#).unwrap(),
+            crate::utils::get_regex(r#"(?i)api[_-]?key\s*[:=]\s*['"][a-zA-Z0-9]{16,}['"]"#)
+                .unwrap(),
             // Bearer tokens
-            Regex::new(r"(?i)bearer\s+[a-zA-Z0-9\-_=]{20,}").unwrap(),
+            crate::utils::get_regex(r"(?i)bearer\s+[a-zA-Z0-9\-_=]{20,}").unwrap(),
             // Password in common formats
-            Regex::new(r#"(?i)password\s*[:=]\s*['"][^'"]{8,}['"]"#).unwrap(),
+            crate::utils::get_regex(r#"(?i)password\s*[:=]\s*['"][^'"]{8,}['"]"#).unwrap(),
             // GitHub tokens
-            Regex::new(r"ghp_[a-zA-Z0-9]{36}").unwrap(),
-            Regex::new(r"gho_[a-zA-Z0-9]{36}").unwrap(),
+            crate::utils::get_regex(r"ghp_[a-zA-Z0-9]{36}").unwrap(),
+            crate::utils::get_regex(r"gho_[a-zA-Z0-9]{36}").unwrap(),
             // Generic secret patterns
-            Regex::new(r#"(?i)secret\s*[:=]\s*['"][^'"]{8,}['"]"#).unwrap(),
+            crate::utils::get_regex(r#"(?i)secret\s*[:=]\s*['"][^'"]{8,}['"]"#).unwrap(),
         ]
     }
 
     /// Default patterns for sensitive variable names
     fn default_sensitive_var_patterns() -> Vec<Regex> {
         vec![
-            Regex::new(r"(?i)^password$").unwrap(),
-            Regex::new(r"(?i)^passwd$").unwrap(),
-            Regex::new(r"(?i)^secret$").unwrap(),
-            Regex::new(r"(?i)^api[_-]?key$").unwrap(),
-            Regex::new(r"(?i)^token$").unwrap(),
-            Regex::new(r"(?i)^private[_-]?key$").unwrap(),
-            Regex::new(r"(?i)^access[_-]?key$").unwrap(),
-            Regex::new(r"(?i)^auth[_-]?token$").unwrap(),
-            Regex::new(r"(?i).*_password$").unwrap(),
-            Regex::new(r"(?i).*_secret$").unwrap(),
-            Regex::new(r"(?i).*_token$").unwrap(),
-            Regex::new(r"(?i).*_key$").unwrap(),
+            crate::utils::get_regex(r"(?i)^password$").unwrap(),
+            crate::utils::get_regex(r"(?i)^passwd$").unwrap(),
+            crate::utils::get_regex(r"(?i)^secret$").unwrap(),
+            crate::utils::get_regex(r"(?i)^api[_-]?key$").unwrap(),
+            crate::utils::get_regex(r"(?i)^token$").unwrap(),
+            crate::utils::get_regex(r"(?i)^private[_-]?key$").unwrap(),
+            crate::utils::get_regex(r"(?i)^access[_-]?key$").unwrap(),
+            crate::utils::get_regex(r"(?i)^auth[_-]?token$").unwrap(),
+            crate::utils::get_regex(r"(?i).*_password$").unwrap(),
+            crate::utils::get_regex(r"(?i).*_secret$").unwrap(),
+            crate::utils::get_regex(r"(?i).*_token$").unwrap(),
+            crate::utils::get_regex(r"(?i).*_key$").unwrap(),
         ]
     }
 
@@ -399,10 +401,11 @@ impl SecurityAnalyzer {
 
         if let Some(cmd) = cmd {
             // Check for unquoted variable expansion
-            let var_pattern = Regex::new(r"\$\{\{|\{\{[^}]*\}\}").unwrap();
+            let var_pattern = crate::utils::get_regex(r"\$\{\{|\{\{[^}]*\}\}").unwrap();
             if var_pattern.is_match(cmd) {
                 // Check if the variable is properly quoted
-                let quoted_var = Regex::new(r#"["'][^"']*\{\{[^}]*\}\}[^"']*["']"#).unwrap();
+                let quoted_var =
+                    crate::utils::get_regex(r#"["'][^"']*\{\{[^}]*\}\}[^"']*["']"#).unwrap();
                 if !quoted_var.is_match(cmd) {
                     findings.push(
                         AnalysisFinding::new(


### PR DESCRIPTION
💡 What: Replaced 14 instances of `Regex::new(...).unwrap()` with `crate::utils::get_regex(...).unwrap()` in `src/analysis/security.rs`.
🎯 Why: `SecurityAnalyzer::new` and command injection checks were recompiling regular expressions on every invocation. Compiling a regular expression in Rust is a CPU-heavy operation. Using the thread-safe regex cache eliminates this overhead for repeated calls during playbook security analysis.
📊 Impact: Eliminates redundant regex compilations in `SecurityAnalyzer`, significantly speeding up security analysis passes across multiple playbooks and tasks without altering any detection logic.
🔬 Measurement: Run `cargo test --lib -- tests::` to verify all playbook functionality and security analyses pass cleanly. No new journal entry needed as caching regexes is an established known optimization in the Bolt journal.

---
*PR created automatically by Jules for task [3648944824820692718](https://jules.google.com/task/3648944824820692718) started by @dolagoartur*