### PR TITLE
🎨 Palette: Standardize CLI prompt emojis and navigation hints

### DIFF
--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -726,7 +726,7 @@ impl RunArgs {
             if std::io::stdin().is_terminal() {
                 Some(
                     dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("🔐 BECOME password")
+                        .with_prompt("🔒 BECOME password")
                         .interact()?,
                 )
             } else {

--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -358,7 +358,7 @@ fn get_password(password_file: Option<&PathBuf>, ctx: &CommandContext) -> Result
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 Vault password")
+        .with_prompt("🔒 Vault password")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -376,8 +376,8 @@ fn get_password_with_confirm(
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 New Vault password")
-        .with_confirmation("🔐 Confirm Vault password", "Passwords do not match")
+        .with_prompt("🔒 New Vault password")
+        .with_confirmation("🔒 Confirm Vault password", "Passwords do not match")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -634,8 +634,8 @@ impl VaultArgs {
                     s.as_bytes().to_vec()
                 } else if std::io::stdin().is_terminal() {
                     let input = dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("📝 Enter text to encrypt (hidden)")
-                        .with_confirmation("🔐 Confirm text to encrypt", "Inputs do not match")
+                        .with_prompt("🔒 Enter text to encrypt (hidden)")
+                        .with_confirmation("🔒 Confirm text to encrypt", "Inputs do not match")
                         .interact()?;
                     input.as_bytes().to_vec()
                 } else {

--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -65,7 +65,7 @@ impl InteractiveSession {
         println!();
         let _ = self.term.write_line(&format!(
             "  {}",
-            "Tip: Use arrow keys to navigate menus, Space to select multiple items, Enter to confirm"
+            "Tip: Use arrow keys to navigate menus, Enter to confirm"
                 .cyan()
                 .dimmed()
         ));
@@ -87,7 +87,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("What would you like to do?")
+            .with_prompt("🎯 What would you like to do?")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;


### PR DESCRIPTION
### 💡 What
- Fixed the interactive CLI banner hint to accurately reflect the functionality of single-choice `Select` menus by removing the misleading instruction to use "Space".
- Standardized the visual language of all secure inputs (Vault passwords, text encryption, and BECOME passwords) across `src/cli/commands/vault.rs` and `src/cli/commands/run.rs` to consistently use the 🔒 (lock) emoji.
- Added a 🎯 (target) emoji to the main menu prompt for visual polish.

### 🎯 Why
- **Clarity:** The main menu is a single-select component, but the hint told users they could select multiple items with Space. This corrects the guidance.
- **Consistency:** Secure prompts previously mixed 🔐 (closed lock with key) and 📝 (memo) emojis, which was confusing and visually inconsistent. Standardizing on 🔒 provides a clear, unified visual indicator that input is hidden/secure.

### 📸 Before/After
**Before:**
- Banner Hint: `Tip: Use arrow keys to navigate menus, Space to select multiple items, Enter to confirm`
- Main Menu Prompt: `What would you like to do?`
- Vault Password: `🔐 Vault password`
- Encrypt Text: `📝 Enter text to encrypt (hidden)`

**After:**
- Banner Hint: `Tip: Use arrow keys to navigate menus, Enter to confirm`
- Main Menu Prompt: `🎯 What would you like to do?`
- Vault Password: `🔒 Vault password`
- Encrypt Text: `🔒 Enter text to encrypt (hidden)`

### ♿ Accessibility
- Improves cognitive accessibility by providing accurate, component-specific navigation instructions and consistent semantic iconography for secure input states.

---
*PR created automatically by Jules for task [57565261103536422](https://jules.google.com/task/57565261103536422) started by @dolagoartur*