### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in temporary private key creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -103,3 +103,8 @@
 **Vulnerability:** A refactoring error in `validate_command_args` introduced a logic flaw where input containing any unsafe character would bypass the dangerous pattern check and incorrectly be considered valid, enabling potential command injection.
 **Learning:** Security validation functions must be thoroughly tested, especially when refactoring for performance optimizations (like adding fast-paths). Boolean logic errors in early returns can completely neutralize subsequent security checks.
 **Prevention:** Always maintain comprehensive unit tests covering both positive (safe) and negative (malicious) inputs for security validation routines. Ensure fast-path logic correctly falls through to more exhaustive checks when necessary.
+
+## 2026-06-27 - Insecure File Creation (TOCTOU) for Temporary Private Key
+**Vulnerability:** In `src/api/kernel.rs`, a temporary private key file was created using `std::fs::write` followed by `std::fs::set_permissions`. This allowed for a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where the file was temporarily written to disk with default (potentially world-readable) permissions before being restricted.
+**Learning:** Convenience functions like `fs::write` combined with subsequent permission changes are not atomic and introduce a race condition.
+**Prevention:** Use `crate::utils::fs::secure_write_file` (or `std::fs::OpenOptionsExt::mode`) to set permissions *at creation time* atomically.

--- a/src/api/kernel.rs
+++ b/src/api/kernel.rs
@@ -1078,23 +1078,14 @@ async fn build_connection_for_host(
             ))
         })?;
         let key_path = key_dir.path().join("id_key");
-        std::fs::write(&key_path, private_key).map_err(|err| {
-            crate::connection::ConnectionError::InvalidConfig(format!(
-                "failed to write temporary private key: {}",
-                err
-            ))
-        })?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let perms = std::fs::Permissions::from_mode(0o600);
-            std::fs::set_permissions(&key_path, perms).map_err(|err| {
+        crate::utils::fs::secure_write_file(&key_path, private_key, true, Some(0o600)).map_err(
+            |err| {
                 crate::connection::ConnectionError::InvalidConfig(format!(
-                    "failed to secure temporary private key: {}",
+                    "failed to write temporary private key securely: {}",
                     err
                 ))
-            })?;
-        }
+            },
+        )?;
         builder = builder.private_key(key_path.to_string_lossy().to_string());
         _key_dir = Some(key_dir);
     } else {


### PR DESCRIPTION
**🚨 Severity:** CRITICAL
**💡 Vulnerability:** A temporary private key file in `src/api/kernel.rs` was created using `std::fs::write` and then restricted using `std::fs::set_permissions`. This introduces a Time-of-Check to Time-of-Use (TOCTOU) race condition where the private key exists on disk with default (potentially world-readable) permissions before being locked down.
**🎯 Impact:** Local privilege escalation or information disclosure. Another process on the system could quickly read the temporary private key before its permissions are restricted, allowing unauthorized access to the target host during a kernel deployment job.
**🔧 Fix:** Replaced the two-step insecure write-then-chmod pattern with the project's built-in `crate::utils::fs::secure_write_file` utility. This leverages `OpenOptionsExt::mode` (on Unix) to create the file atomically with `0o600` permissions from the start, closing the race condition window entirely.
**✅ Verification:**
1. Ran `cargo fmt && cargo clippy`.
2. Verified the code compiles successfully with `cargo check`.
3. Validated unit tests pass with `cargo test --lib -- tests`.
4. Logged learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [6036886244697987155](https://jules.google.com/task/6036886244697987155) started by @dolagoartur*