### PR TITLE
🎨 Palette: Fix inconsistent emojis in CLI prompts

### DIFF
--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -726,7 +726,7 @@ impl RunArgs {
             if std::io::stdin().is_terminal() {
                 Some(
                     dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("🔐 BECOME password")
+                        .with_prompt("🔒 BECOME password")
                         .interact()?,
                 )
             } else {

--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -358,7 +358,7 @@ fn get_password(password_file: Option<&PathBuf>, ctx: &CommandContext) -> Result
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 Vault password")
+        .with_prompt("🔒 Vault password")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -376,8 +376,8 @@ fn get_password_with_confirm(
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 New Vault password")
-        .with_confirmation("🔐 Confirm Vault password", "Passwords do not match")
+        .with_prompt("🔒 New Vault password")
+        .with_confirmation("🔒 Confirm Vault password", "Passwords do not match")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -634,8 +634,8 @@ impl VaultArgs {
                     s.as_bytes().to_vec()
                 } else if std::io::stdin().is_terminal() {
                     let input = dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("📝 Enter text to encrypt (hidden)")
-                        .with_confirmation("🔐 Confirm text to encrypt", "Inputs do not match")
+                        .with_prompt("🔒 Enter text to encrypt (hidden)")
+                        .with_confirmation("🔒 Confirm text to encrypt", "Inputs do not match")
                         .interact()?;
                     input.as_bytes().to_vec()
                 } else {

--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -87,7 +87,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("What would you like to do?")
+            .with_prompt("🎯 What would you like to do?")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;
@@ -382,7 +382,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("🔐 Vault operation")
+            .with_prompt("🔒 Vault operation")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;


### PR DESCRIPTION
💡 **What:**
- Changed the emoji in `src/cli/commands/vault.rs` from `🔐` and `📝` to `🔒` for all secure inputs (vault passwords, new vault passwords, encrypt string text).
- Changed the BECOME password prompt emoji in `src/cli/commands/run.rs` from `🔐` to `🔒`.
- Standardized `Select` prompts in `src/cli/interactive.rs` to use `🎯 Main Menu` (for What would you like to do?) and `🔒 Vault operation`.

🎯 **Why:**
- Emojis help visually distinguish password inputs from regular text, but using multiple variations for the same context (passwords) reduces scannability.
- `🔒` is globally understood as a symbol for secure input and matches our interactive menu conventions.

📸 **Before/After:**
*(Text Representation)*
**Before:**
`🔐 Vault password:`
`📝 Enter text to encrypt (hidden):`

**After:**
`🔒 Vault password:`
`🔒 Enter text to encrypt (hidden):`

♿ **Accessibility:**
- Consistent emojis make the terminal output easier to quickly scan.
- Semantic prefixes enhance the readability of the terminal for standard-sighted users, while keeping the interface standard and accessible.

---
*PR created automatically by Jules for task [12265847999192925392](https://jules.google.com/task/12265847999192925392) started by @dolagoartur*