### PR TITLE
🎨 Palette: Add keyboard navigation hints to prompts and fix vault emojis

### DIFF
--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -726,7 +726,7 @@ impl RunArgs {
             if std::io::stdin().is_terminal() {
                 Some(
                     dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("🔐 BECOME password")
+                        .with_prompt("🔒 BECOME password")
                         .interact()?,
                 )
             } else {

--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -358,7 +358,7 @@ fn get_password(password_file: Option<&PathBuf>, ctx: &CommandContext) -> Result
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 Vault password")
+        .with_prompt("🔒 Vault password")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -376,8 +376,8 @@ fn get_password_with_confirm(
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 New Vault password")
-        .with_confirmation("🔐 Confirm Vault password", "Passwords do not match")
+        .with_prompt("🔒 New Vault password")
+        .with_confirmation("🔒 Confirm Vault password", "Passwords do not match")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -634,8 +634,8 @@ impl VaultArgs {
                     s.as_bytes().to_vec()
                 } else if std::io::stdin().is_terminal() {
                     let input = dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("📝 Enter text to encrypt (hidden)")
-                        .with_confirmation("🔐 Confirm text to encrypt", "Inputs do not match")
+                        .with_prompt("🔒 Enter text to encrypt (hidden)")
+                        .with_confirmation("🔒 Confirm text to encrypt", "Inputs do not match")
                         .interact()?;
                     input.as_bytes().to_vec()
                 } else {

--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -63,13 +63,6 @@ impl InteractiveSession {
                 .bold()
         );
         println!();
-        let _ = self.term.write_line(&format!(
-            "  {}",
-            "Tip: Use arrow keys to navigate menus, Space to select multiple items, Enter to confirm"
-                .cyan()
-                .dimmed()
-        ));
-        println!();
     }
 
     /// Prompt for main menu action
@@ -79,7 +72,7 @@ impl InteractiveSession {
             "🔍 Check playbook (dry-run)",
             "📋 List hosts",
             "📝 List tasks",
-            "🔐 Vault operations",
+            "🔒 Vault operations",
             "✨ Initialize project",
             "✅ Validate playbook",
             "⚙️ Settings",
@@ -87,7 +80,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("What would you like to do?")
+            .with_prompt("What would you like to do? (use arrow keys, enter to confirm)")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;
@@ -137,7 +130,7 @@ impl InteractiveSession {
         items.push("✏️ Enter custom path...".to_string());
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("📖 Select a playbook")
+            .with_prompt("📖 Select a playbook (use arrow keys, enter to confirm)")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;
@@ -199,7 +192,7 @@ impl InteractiveSession {
         items.push("🏠 Use localhost (no inventory)".to_string());
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("📋 Select inventory")
+            .with_prompt("📋 Select inventory (use arrow keys, enter to confirm)")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;
@@ -350,7 +343,7 @@ impl InteractiveSession {
         ];
 
         let verbosity = Select::with_theme(&self.theme)
-            .with_prompt("🔊 Verbose level")
+            .with_prompt("🔊 Verbose level (use arrow keys, enter to confirm)")
             .items(&verbosity_items)
             .default(0)
             .interact_on(&self.term)? as u8;
@@ -382,7 +375,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("🔐 Vault operation")
+            .with_prompt("🔒 Vault operation (use arrow keys, enter to confirm)")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;


### PR DESCRIPTION
💡 What: Moved the global keyboard navigation hint from the top banner to specific component prompts (`Select`), providing contextual instructions for each type of input. Also updated vault and password prompts to consistently use the 🔒 emoji instead of 🔐.
🎯 Why: The global tip in the banner incorrectly implied 'Space to select multiple items' was available for all menus, confusing users on single-select menus. Placing specific instructions (e.g., 'use arrow keys, enter to confirm') directly on the prompts makes the UI more intuitive. Fixing the emoji ensures visual consistency across secure inputs.
📸 Before/After: Before, a generic tip was displayed that confused users for single selects. After, each prompt tells the user exactly how to interact with it.
♿ Accessibility: Improves usability by offering immediate context on how to navigate and interact with the CLI menus, assisting users who rely on keyboard navigation.

---
*PR created automatically by Jules for task [18077537935788352684](https://jules.google.com/task/18077537935788352684) started by @dolagoartur*