### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in file creation

### DIFF
--- a/src/api/kernel.rs
+++ b/src/api/kernel.rs
@@ -1078,23 +1078,14 @@ async fn build_connection_for_host(
             ))
         })?;
         let key_path = key_dir.path().join("id_key");
-        std::fs::write(&key_path, private_key).map_err(|err| {
-            crate::connection::ConnectionError::InvalidConfig(format!(
-                "failed to write temporary private key: {}",
-                err
-            ))
-        })?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let perms = std::fs::Permissions::from_mode(0o600);
-            std::fs::set_permissions(&key_path, perms).map_err(|err| {
+        crate::utils::secure_write_file(&key_path, private_key, true, Some(0o600)).map_err(
+            |err| {
                 crate::connection::ConnectionError::InvalidConfig(format!(
-                    "failed to secure temporary private key: {}",
+                    "failed to securely write temporary private key: {}",
                     err
                 ))
-            })?;
-        }
+            },
+        )?;
         builder = builder.private_key(key_path.to_string_lossy().to_string());
         _key_dir = Some(key_dir);
     } else {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Time-of-Check to Time-of-Use (TOCTOU) vulnerability when writing a temporary private key to disk in `src/api/kernel.rs`. The code used `std::fs::write` to create the file (which writes with default, potentially overly permissive permissions) and subsequently used `std::fs::set_permissions` to restrict access. This created a brief window where an attacker could potentially read the private key.
🎯 Impact: High risk of local sensitive data exposure.
🔧 Fix: Replaced the separated `write` and `set_permissions` calls with the project's atomic `crate::utils::secure_write_file` function, which creates the file with the intended restrictive permissions (`0o600`) from the outset, eliminating the race condition.
✅ Verification: Ran `cargo fmt`, `cargo clippy`, `cargo check --lib`, and `cargo test --lib -- tests` to ensure correctness and that no regressions were introduced. Tests pass and linter shows no new warnings.

---
*PR created automatically by Jules for task [9795548173527524387](https://jules.google.com/task/9795548173527524387) started by @dolagoartur*