### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix predictable temp file and insecure permissions in vault commands

### DIFF
--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -489,9 +489,11 @@ impl VaultArgs {
                     content.into_bytes()
                 };
 
-                // Create temporary file
-                let temp_dir = std::env::temp_dir();
-                let temp_file = temp_dir.join(format!(".rustible_vault_{}", std::process::id()));
+                // Create temporary file securely
+                let temp_file = tempfile::Builder::new()
+                    .prefix(".rustible_vault_")
+                    .tempfile()?
+                    .into_temp_path();
 
                 fs::write(&temp_file, &plaintext)?;
 
@@ -502,13 +504,11 @@ impl VaultArgs {
                     .with_context(|| format!("Failed to open editor: {}", args.editor))?;
 
                 if !status.success() {
-                    fs::remove_file(&temp_file).ok();
                     bail!("Editor exited with error");
                 }
 
                 // Read edited content
                 let edited = fs::read(&temp_file)?;
-                fs::remove_file(&temp_file)?;
 
                 // Re-encrypt if it was encrypted
                 if was_encrypted {
@@ -536,9 +536,11 @@ impl VaultArgs {
                 let password = get_password_with_confirm(args.vault_password_file.as_ref(), ctx)?;
                 let engine = VaultEngine::new(password);
 
-                // Create temporary file
-                let temp_dir = std::env::temp_dir();
-                let temp_file = temp_dir.join(format!(".rustible_vault_{}", std::process::id()));
+                // Create temporary file securely
+                let temp_file = tempfile::Builder::new()
+                    .prefix(".rustible_vault_")
+                    .tempfile()?
+                    .into_temp_path();
 
                 fs::write(&temp_file, "")?;
 
@@ -549,13 +551,11 @@ impl VaultArgs {
                     .with_context(|| format!("Failed to open editor: {}", args.editor))?;
 
                 if !status.success() {
-                    fs::remove_file(&temp_file).ok();
                     bail!("Editor exited with error");
                 }
 
                 // Read content
                 let content = fs::read(&temp_file)?;
-                fs::remove_file(&temp_file)?;
 
                 if content.is_empty() {
                     ctx.output.warning("No content entered, file not created");


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `vault edit` and `vault create` commands were creating temporary files in `std::env::temp_dir()` (`/tmp` on Unix) using a predictable naming convention (`.rustible_vault_<pid>`). They used `fs::write` to populate the decrypted data and then opened it in the user's editor. This pattern is vulnerable to Time-of-Check to Time-of-Use (TOCTOU) and symlink attacks. It also leaked the unencrypted data if the process panicked or returned an error before the manual `fs::remove_file` calls.
🎯 Impact: An attacker with local access could predict the temporary file name and read sensitive vault data, or perform symlink attacks to overwrite arbitrary files. In the event of a crash, sensitive data was left on disk.
🔧 Fix: Replaced the manual temporary file creation logic with the `tempfile` crate (`tempfile::Builder::new().tempfile()?.into_temp_path()`). This atomically creates a file with a randomized name and strict permissions (`0600`). The `TempPath` ensures the file is safely deleted automatically when it goes out of scope, preventing data leaks on early exits.
✅ Verification: Ran `cargo test --lib -- tests`, `cargo check`, and `cargo clippy`. No regressions found.

---
*PR created automatically by Jules for task [4352282540073680448](https://jules.google.com/task/4352282540073680448) started by @dolagoartur*