### PR TITLE
⚡ Bolt: Optimize Proxmox inventory regex filtering with cache

### DIFF
--- a/src/inventory/plugins/proxmox.rs
+++ b/src/inventory/plugins/proxmox.rs
@@ -824,7 +824,8 @@ fn value_matches_operator(operator: FilterOperator, value: &str, filter_value: &
         FilterOperator::Contains => value.contains(filter_value),
         FilterOperator::StartsWith => value.starts_with(filter_value),
         FilterOperator::EndsWith => value.ends_with(filter_value),
-        FilterOperator::Regex => regex::Regex::new(filter_value)
+        // Optimize: Use cached get_regex to avoid recompiling the regex pattern during filtering loop operations
+        FilterOperator::Regex => crate::utils::get_regex(filter_value)
             .map(|re| re.is_match(value))
             .unwrap_or(false),
     }


### PR DESCRIPTION
💡 What: Replaced `regex::Regex::new` with `crate::utils::get_regex` in the proxmox inventory plugin's `FilterOperator::Regex` matching arm.
🎯 Why: Instantiating a new `Regex` object requires parsing and compiling the pattern, which is computationally expensive. Doing this inside a loop or mapping function (like `value_matches_operator`) creates a significant performance bottleneck.
📊 Impact: Considerably faster execution times when filtering large amounts of Proxmox VMs or containers based on complex Regex patterns, as the compiled expression is retrieved from a thread-safe cache rather than being compiled on every match check.
🔬 Measurement: Run a `cargo test --lib -- tests` to verify existing functionality is intact. Performance can be profiled by executing a playbook with intensive Proxmox Regex filtering and comparing execution durations before and after the change.

---
*PR created automatically by Jules for task [6597655516682391507](https://jules.google.com/task/6597655516682391507) started by @dolagoartur*