### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in kernel API

### DIFF
--- a/src/api/kernel.rs
+++ b/src/api/kernel.rs
@@ -1078,23 +1078,14 @@ async fn build_connection_for_host(
             ))
         })?;
         let key_path = key_dir.path().join("id_key");
-        std::fs::write(&key_path, private_key).map_err(|err| {
-            crate::connection::ConnectionError::InvalidConfig(format!(
-                "failed to write temporary private key: {}",
-                err
-            ))
-        })?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let perms = std::fs::Permissions::from_mode(0o600);
-            std::fs::set_permissions(&key_path, perms).map_err(|err| {
+        crate::utils::secure_write_file(&key_path, private_key, true, Some(0o600)).map_err(
+            |err| {
                 crate::connection::ConnectionError::InvalidConfig(format!(
                     "failed to secure temporary private key: {}",
                     err
                 ))
-            })?;
-        }
+            },
+        )?;
         builder = builder.private_key(key_path.to_string_lossy().to_string());
         _key_dir = Some(key_dir);
     } else {


### PR DESCRIPTION
**🚨 Severity**: CRITICAL

**💡 Vulnerability**: A Time-of-Check to Time-of-Use (TOCTOU) race condition existed in `src/api/kernel.rs`. The code wrote a temporary SSH private key to disk using `std::fs::write` (which creates the file with default permissions), and then subsequently used `std::fs::set_permissions` to lock the file down to `0o600`.

**🎯 Impact**: Between the time the file is written and the permissions are changed, there is a brief window where the file exists with default permissions (potentially world-readable depending on umask). A malicious local process could potentially read the sensitive private key during this race condition window.

**🔧 Fix**: Replaced the sequential `std::fs::write` and `set_permissions` calls with the project's existing atomic `crate::utils::secure_write_file` utility. This leverages `OpenOptionsExt::mode(0o600)` on Unix systems to atomically create the file with the strict permissions from the very beginning, eliminating the race condition.

**✅ Verification**: 
- Verified `cargo test --lib -- tests` passes locally.
- Verified `cargo clippy` passes cleanly.

---
*PR created automatically by Jules for task [12210055116014387923](https://jules.google.com/task/12210055116014387923) started by @dolagoartur*