### PR TITLE
⚡ Bolt: Replace Regex::new with cached get_regex implementation in proxmox plugin and compliance checks

### DIFF
--- a/src/compliance/checks.rs
+++ b/src/compliance/checks.rs
@@ -4,7 +4,6 @@
 //! that can be used across different compliance frameworks.
 
 use super::{CheckStatus, ComplianceContext, ComplianceError, ComplianceResult, Severity};
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -364,7 +363,8 @@ impl ComplianceCheck for FileCheck {
                 .map_err(|e| ComplianceError::CheckFailed(e.to_string()))?;
 
             if content_result.success {
-                let re = Regex::new(pattern).map_err(|e| {
+                // Optimize: Use cached get_regex instead of recompiling Regex::new for potentially repeated checks.
+                let re = crate::utils::regex_cache::get_regex(pattern).map_err(|e| {
                     ComplianceError::InvalidConfig(format!("Invalid regex pattern: {}", e))
                 })?;
                 if !re.is_match(&content_result.stdout) {
@@ -863,7 +863,8 @@ impl ComplianceCheck for CommandCheck {
 
         // Check expected pattern
         if let Some(ref pattern) = self.expected_pattern {
-            let re = Regex::new(pattern)
+            // Optimize: Use cached get_regex instead of recompiling Regex::new for potentially repeated checks.
+            let re = crate::utils::regex_cache::get_regex(pattern)
                 .map_err(|e| ComplianceError::InvalidConfig(format!("Invalid regex: {}", e)))?;
             if !re.is_match(&output) {
                 issues.push(format!("output does not match pattern: {}", pattern));
@@ -872,7 +873,8 @@ impl ComplianceCheck for CommandCheck {
 
         // Check not-expected pattern
         if let Some(ref pattern) = self.not_expected_pattern {
-            let re = Regex::new(pattern)
+            // Optimize: Use cached get_regex instead of recompiling Regex::new for potentially repeated checks.
+            let re = crate::utils::regex_cache::get_regex(pattern)
                 .map_err(|e| ComplianceError::InvalidConfig(format!("Invalid regex: {}", e)))?;
             if re.is_match(&output) {
                 issues.push(format!("output matches forbidden pattern: {}", pattern));

--- a/src/inventory/plugins/proxmox.rs
+++ b/src/inventory/plugins/proxmox.rs
@@ -824,7 +824,8 @@ fn value_matches_operator(operator: FilterOperator, value: &str, filter_value: &
         FilterOperator::Contains => value.contains(filter_value),
         FilterOperator::StartsWith => value.starts_with(filter_value),
         FilterOperator::EndsWith => value.ends_with(filter_value),
-        FilterOperator::Regex => regex::Regex::new(filter_value)
+        // Optimize: Use cached get_regex implementation instead of compiling on every filter check.
+        FilterOperator::Regex => crate::utils::regex_cache::get_regex(filter_value)
             .map(|re| re.is_match(value))
             .unwrap_or(false),
     }


### PR DESCRIPTION
💡 **What:** Replaced inline `regex::Regex::new()` calls with the statically cached `crate::utils::regex_cache::get_regex()` in `src/inventory/plugins/proxmox.rs` and `src/compliance/checks.rs`.

🎯 **Why:** Recompiling regular expressions on every filter match or compliance check is a significant performance bottleneck in Rust. Using the thread-safe global regex cache avoids redundant compilation overhead, especially in loops and hot paths.

📊 **Impact:** Reduces regex compilation overhead to near-zero for repeated dynamic patterns during inventory building and policy checks, resulting in faster execution on large infrastructures. 

🔬 **Measurement:** Verify tests run successfully using `cargo test --lib -- tests`. Profile playbook runs containing large dynamically filtered proxmox inventories or numerous compliance regex checks to observe CPU cycle reduction.

---
*PR created automatically by Jules for task [13692271054089450248](https://jules.google.com/task/13692271054089450248) started by @dolagoartur*