### PR TITLE
🎨 Palette: Add semantic emoji to main menu prompt

### DIFF
--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -87,7 +87,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("What would you like to do?")
+            .with_prompt("🎯 What would you like to do?")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;


### PR DESCRIPTION
💡 What: Added a target emoji (🎯) to the "What would you like to do?" prompt in the interactive main menu (`src/cli/interactive.rs`).
🎯 Why: To improve visual scanability and maintain consistent UX styling with the other interactive prompts (like 📖, 📋, 🏷️) across the CLI tool. This provides a small touch of delight and visual anchoring.
📸 Before/After: Before: `What would you like to do?`. After: `🎯 What would you like to do?`.
♿ Accessibility: The target emoji serves as a visual anchor that helps users quickly identify the primary question in the terminal output without negatively impacting screen readers (placed at the start of the prompt).

---
*PR created automatically by Jules for task [10962142326208014253](https://jules.google.com/task/10962142326208014253) started by @dolagoartur*