### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix OOM vulnerability in file checksum verification

### DIFF
--- a/src/galaxy/integrity.rs
+++ b/src/galaxy/integrity.rs
@@ -80,8 +80,49 @@ impl IntegrityVerifier {
         path: &Path,
         algorithm: ChecksumAlgorithm,
     ) -> GalaxyResult<String> {
-        let data = tokio::fs::read(path).await?;
-        Ok(Self::compute_checksum(&data, algorithm))
+        // Sentinel: Prevent OOM by streaming file contents instead of reading the whole file into memory
+        let mut file = tokio::fs::File::open(path).await?;
+        use tokio::io::AsyncReadExt;
+
+        match algorithm {
+            ChecksumAlgorithm::Sha256 => {
+                let mut hasher = Sha256::new();
+                let mut buffer = [0; 8192];
+                loop {
+                    let n = file.read(&mut buffer).await?;
+                    if n == 0 {
+                        break;
+                    }
+                    hasher.update(&buffer[..n]);
+                }
+                Ok(format!("{:x}", hasher.finalize()))
+            }
+            ChecksumAlgorithm::Sha512 => {
+                use sha2::Sha512;
+                let mut hasher = Sha512::new();
+                let mut buffer = [0; 8192];
+                loop {
+                    let n = file.read(&mut buffer).await?;
+                    if n == 0 {
+                        break;
+                    }
+                    hasher.update(&buffer[..n]);
+                }
+                Ok(format!("{:x}", hasher.finalize()))
+            }
+            ChecksumAlgorithm::Md5 => {
+                let mut context = md5::Context::new();
+                let mut buffer = [0; 8192];
+                loop {
+                    let n = file.read(&mut buffer).await?;
+                    if n == 0 {
+                        break;
+                    }
+                    context.consume(&buffer[..n]);
+                }
+                Ok(format!("{:x}", context.compute()))
+            }
+        }
     }
 
     /// Verify checksum matches expected value


### PR DESCRIPTION
* 🚨 **Severity**: CRITICAL
* 💡 **Vulnerability**: Reading entire large files into memory when verifying checksums can cause Out-Of-Memory (OOM) crashes.
* 🎯 **Impact**: An attacker could provide a very large dummy file, which when processed, consumes all available memory resulting in Denial of Service (DoS).
* 🔧 **Fix**: Modified `compute_file_checksum` to use a loop and `AsyncReadExt::read` to stream the file contents in 8KB chunks.
* ✅ **Verification**: Ran `cargo test --lib galaxy::integrity` to ensure the algorithms still correctly compute checksums without breaking functionality.

---
*PR created automatically by Jules for task [3528636070181147721](https://jules.google.com/task/3528636070181147721) started by @dolagoartur*