### PR TITLE
🎨 Palette: Add semantic emoji to Main Menu prompt

### DIFF
--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -87,7 +87,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("What would you like to do?")
+            .with_prompt("🎯 What would you like to do?")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;


### PR DESCRIPTION
💡 What: Add the '🎯' emoji prefix to the main menu prompt.
🎯 Why: To maintain visual consistency and scannability across interactive CLI prompts, as other prompts already use semantic emoji prefixes.
📸 Before/After: Before: 'What would you like to do?', After: '🎯 What would you like to do?'.
♿ Accessibility: Improves visual scannability for users.

---
*PR created automatically by Jules for task [4688236025686511631](https://jules.google.com/task/4688236025686511631) started by @dolagoartur*