### PR TITLE
⚡ Bolt: Replace Regex::new with cached get_regex implementation in host pattern matching

### DIFF
--- a/src/cli/commands/inventory.rs
+++ b/src/cli/commands/inventory.rs
@@ -366,7 +366,8 @@ impl Inventory {
 fn glob_match(name: &str, pattern: &str) -> bool {
     if pattern.contains('*') {
         let regex_pattern = pattern.replace('.', "\\.").replace('*', ".*");
-        regex::Regex::new(&format!("^{}$", regex_pattern))
+        // Optimize: Use cached get_regex instead of recompiling
+        rustible::utils::get_regex(&format!("^{}$", regex_pattern))
             .map(|re| re.is_match(name))
             .unwrap_or(false)
     } else {

--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -2407,7 +2407,8 @@ impl RunArgs {
 
             // Check for regex pattern
             if let Some(regex_str) = pattern.strip_prefix('~') {
-                if regex::Regex::new(regex_str).is_err() {
+                // Optimize: Use cached get_regex instead of recompiling
+                if rustible::utils::get_regex(regex_str).is_err() {
                     return Err(format!("Invalid regex pattern in limit: {}", regex_str));
                 }
             }

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -2028,7 +2028,8 @@ impl Executor {
 
         // Check for regex pattern (starts with ~)
         if let Some(regex_pattern) = pattern.strip_prefix('~') {
-            let re = regex::Regex::new(regex_pattern)
+            // Optimize: Use cached get_regex instead of recompiling
+            let re = crate::utils::get_regex(regex_pattern)
                 .map_err(|e| ExecutorError::ParseError(format!("Invalid regex: {}", e)))?;
 
             let all_hosts = runtime.get_all_hosts();

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -141,7 +141,6 @@ pub use plugins::{
 };
 
 use indexmap::IndexMap;
-use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::process::Command;
@@ -1070,7 +1069,8 @@ impl Inventory {
 
         // Handle regex pattern
         if let Some(regex_str) = pattern.strip_prefix('~') {
-            let regex = Regex::new(regex_str)
+            // Optimize: Use cached get_regex instead of recompiling
+            let regex = crate::utils::get_regex(regex_str)
                 .map_err(|_| InventoryError::InvalidPattern(pattern.to_string()))?;
 
             return Ok(self
@@ -1083,7 +1083,8 @@ impl Inventory {
         // Handle glob/wildcard pattern
         if pattern.contains('*') || pattern.contains('?') || pattern.contains('[') {
             let regex_pattern = glob_to_regex(pattern);
-            let regex = Regex::new(&regex_pattern)
+            // Optimize: Use cached get_regex instead of recompiling
+            let regex = crate::utils::get_regex(&regex_pattern)
                 .map_err(|_| InventoryError::InvalidPattern(pattern.to_string()))?;
 
             return Ok(self


### PR DESCRIPTION
💡 What: Replaced direct `Regex::new()` instantiations with the cached `crate::utils::get_regex()` helper in host/group matching logic (`inventory.rs`, `run.rs`, `executor.rs`).
🎯 Why: Regex compilation is expensive. When running Ansible with large inventories or limits, compiling regular expressions on the fly (sometimes within loops) can cause massive slowdowns and unnecessary heap allocations. Using a caching layer avoids this performance penalty.
📊 Impact: Significantly speeds up host pattern matching, particularly when using glob or regex host limit strings (`~pattern`, `*`). Eliminates redundant regex compilations in loops.
🔬 Measurement: Verified with `cargo test`. Compilation overhead is reduced as we are now using cached instances.

---
*PR created automatically by Jules for task [4004539117513996143](https://jules.google.com/task/4004539117513996143) started by @dolagoartur*