### PR TITLE
⚡ Bolt: Cache regex in array access parser to improve resolution performance

### DIFF
--- a/src/provisioning/resolver.rs
+++ b/src/provisioning/resolver.rs
@@ -589,9 +589,12 @@ impl ProvisionerContext {
 
 /// Parse array access pattern: "type.name[index].attr" -> (type, name, index, attr)
 fn parse_array_access(path: &str) -> Option<(String, String, usize, String)> {
-    let array_re =
+    // Optimize: Use OnceLock to statically cache the array access regex to avoid recompiling it on every call.
+    static ARRAY_RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    let array_re = ARRAY_RE.get_or_init(|| {
         Regex::new(r"^([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_][a-zA-Z0-9_-]*)\[(\d+)\](?:\.(.+))?$")
-            .ok()?;
+            .unwrap()
+    });
 
     let caps = array_re.captures(path)?;
     let resource_type = caps.get(1)?.as_str().to_string();


### PR DESCRIPTION
💡 What: Replaced dynamic `Regex::new` inside `parse_array_access` in `src/provisioning/resolver.rs` with a statically cached regex using `std::sync::OnceLock`.
🎯 Why: `parse_array_access` is called frequently when resolving nested resource attributes. Recompiling a complex regex on every call is highly inefficient.
📊 Impact: Eliminates redundant regex compilations in a hot path, reducing CPU overhead during template evaluation and speeding up overall execution.
🔬 Measurement: Verify tests pass with `cargo test --lib -- tests`, showing no behavior changes while eliminating the compilation cost.

---
*PR created automatically by Jules for task [11686190979956467827](https://jules.google.com/task/11686190979956467827) started by @dolagoartur*