### PR TITLE
🎨 Palette: Standardize emojis for interactive CLI prompts

### DIFF
--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -726,7 +726,7 @@ impl RunArgs {
             if std::io::stdin().is_terminal() {
                 Some(
                     dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("🔐 BECOME password")
+                        .with_prompt("🔒 BECOME password")
                         .interact()?,
                 )
             } else {

--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -358,7 +358,7 @@ fn get_password(password_file: Option<&PathBuf>, ctx: &CommandContext) -> Result
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 Vault password")
+        .with_prompt("🔒 Vault password")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -376,8 +376,8 @@ fn get_password_with_confirm(
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 New Vault password")
-        .with_confirmation("🔐 Confirm Vault password", "Passwords do not match")
+        .with_prompt("🔒 New Vault password")
+        .with_confirmation("🔒 Confirm Vault password", "Passwords do not match")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -634,8 +634,8 @@ impl VaultArgs {
                     s.as_bytes().to_vec()
                 } else if std::io::stdin().is_terminal() {
                     let input = dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("📝 Enter text to encrypt (hidden)")
-                        .with_confirmation("🔐 Confirm text to encrypt", "Inputs do not match")
+                        .with_prompt("🔒 Enter text to encrypt (hidden)")
+                        .with_confirmation("🔒 Confirm text to encrypt", "Inputs do not match")
                         .interact()?;
                     input.as_bytes().to_vec()
                 } else {

--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -79,7 +79,7 @@ impl InteractiveSession {
             "🔍 Check playbook (dry-run)",
             "📋 List hosts",
             "📝 List tasks",
-            "🔐 Vault operations",
+            "🔒 Vault operations",
             "✨ Initialize project",
             "✅ Validate playbook",
             "⚙️ Settings",
@@ -87,7 +87,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("What would you like to do?")
+            .with_prompt("🎯 Main Menu")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;
@@ -382,7 +382,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("🔐 Vault operation")
+            .with_prompt("🔒 Vault operation")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;


### PR DESCRIPTION
**💡 What:**
Standardized the emojis used in the interactive CLI prompts across the `run.rs`, `vault.rs`, and `interactive.rs` files. Specifically, it updates the varying lock emojis (like `🔐`) used for sensitive data prompts to a consistent `🔒` (locked) emoji. It also adds a `🎯` emoji to the main menu prompt.

**🎯 Why:**
To improve visual consistency and cognitive ease. Users should immediately recognize a prompt as a secure, hidden input field by associating it with a single, consistent symbol (`🔒`). Providing a clear "🎯 Main Menu" prompt instead of a generic question helps orient the user within the CLI navigation structure. 

**📸 Before/After:**
*Before:*
- `What would you like to do?`
- `🔐 BECOME password`
- `🔐 Vault operation`
- `🔐 Confirm text to encrypt`

*After:*
- `🎯 Main Menu`
- `🔒 BECOME password`
- `🔒 Vault operation`
- `🔒 Confirm text to encrypt`

**♿ Accessibility:**
This is a micro-UX improvement that aids cognitive accessibility by providing consistent visual cues for different types of interactions (e.g., locking a vault vs. general menu navigation), reducing the cognitive load required to parse the CLI's requests.

---
*PR created automatically by Jules for task [12670738474150929178](https://jules.google.com/task/12670738474150929178) started by @dolagoartur*