### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in Podman connection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -103,3 +103,8 @@
 **Vulnerability:** A refactoring error in `validate_command_args` introduced a logic flaw where input containing any unsafe character would bypass the dangerous pattern check and incorrectly be considered valid, enabling potential command injection.
 **Learning:** Security validation functions must be thoroughly tested, especially when refactoring for performance optimizations (like adding fast-paths). Boolean logic errors in early returns can completely neutralize subsequent security checks.
 **Prevention:** Always maintain comprehensive unit tests covering both positive (safe) and negative (malicious) inputs for security validation routines. Ensure fast-path logic correctly falls through to more exhaustive checks when necessary.
+
+## 2025-07-05 - Command Injection in Podman Connection Module
+**Vulnerability:** The `PodmanConnection` module constructed shell commands (like `mkdir`, `chmod`, `chown`, `cat`, `test`, and `stat`) by interpolating unescaped file paths and ownership strings directly into the command string. If a malicious path (e.g., containing `;` or `&`) was provided, it could result in arbitrary command execution on the host where `podman exec` is running.
+**Learning:** File paths and user-provided configuration values must always be treated as untrusted input when constructing shell commands, even in contextually "safe" modules like file transfer or connection handlers.
+**Prevention:** Always use `crate::utils::shell_escape` for any variable interpolated into a string that will be executed as a shell command.

--- a/src/connection/podman.rs
+++ b/src/connection/podman.rs
@@ -5,6 +5,7 @@
 //! and copying files to/from containers. The API mirrors the Docker
 //! connection module since Podman provides a Docker-compatible CLI.
 
+use crate::utils::shell_escape;
 use async_trait::async_trait;
 use std::path::Path;
 use std::process::Stdio;
@@ -185,7 +186,7 @@ impl Connection for PodmanConnection {
 
         if options.create_dirs {
             if let Some(parent) = remote_path.parent() {
-                let mkdir_cmd = format!("mkdir -p {}", parent.display());
+                let mkdir_cmd = format!("mkdir -p {}", shell_escape(&parent.display().to_string()));
                 self.execute(&mkdir_cmd, None).await?;
             }
         }
@@ -210,7 +211,11 @@ impl Connection for PodmanConnection {
         }
 
         if let Some(mode) = options.mode {
-            let chmod_cmd = format!("chmod {:o} {}", mode, remote_path.display());
+            let chmod_cmd = format!(
+                "chmod {:o} {}",
+                mode,
+                shell_escape(&remote_path.display().to_string())
+            );
             self.execute(&chmod_cmd, None).await?;
         }
 
@@ -221,7 +226,11 @@ impl Connection for PodmanConnection {
                 (None, Some(g)) => format!(":{}", g),
                 (None, None) => return Ok(()),
             };
-            let chown_cmd = format!("chown {} {}", ownership, remote_path.display());
+            let chown_cmd = format!(
+                "chown {} {}",
+                shell_escape(&ownership),
+                shell_escape(&remote_path.display().to_string())
+            );
             self.execute(&chown_cmd, None).await?;
         }
 
@@ -295,7 +304,7 @@ impl Connection for PodmanConnection {
             "Downloading content from Podman container"
         );
 
-        let command = format!("cat {}", remote_path.display());
+        let command = format!("cat {}", shell_escape(&remote_path.display().to_string()));
         let result = self.execute(&command, None).await?;
 
         if !result.success {
@@ -309,19 +318,28 @@ impl Connection for PodmanConnection {
     }
 
     async fn path_exists(&self, path: &Path) -> ConnectionResult<bool> {
-        let command = format!("test -e {} && echo yes || echo no", path.display());
+        let command = format!(
+            "test -e {} && echo yes || echo no",
+            shell_escape(&path.display().to_string())
+        );
         let result = self.execute(&command, None).await?;
         Ok(result.stdout.trim() == "yes")
     }
 
     async fn is_directory(&self, path: &Path) -> ConnectionResult<bool> {
-        let command = format!("test -d {} && echo yes || echo no", path.display());
+        let command = format!(
+            "test -d {} && echo yes || echo no",
+            shell_escape(&path.display().to_string())
+        );
         let result = self.execute(&command, None).await?;
         Ok(result.stdout.trim() == "yes")
     }
 
     async fn stat(&self, path: &Path) -> ConnectionResult<FileStat> {
-        let command = format!("stat -c '%s|%a|%u|%g|%X|%Y|%F' {}", path.display());
+        let command = format!(
+            "stat -c '%s|%a|%u|%g|%X|%Y|%F' {}",
+            shell_escape(&path.display().to_string())
+        );
         let result = self.execute(&command, None).await?;
 
         if !result.success {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command injection via unescaped file paths in Podman shell commands
🎯 Impact: Arbitrary command execution on the host where `podman exec` is running
🔧 Fix: Apply shell_escape to all paths and ownership strings before interpolating them into shell commands
✅ Verification: Ran cargo check and cargo test

---
*PR created automatically by Jules for task [11949491250750933281](https://jules.google.com/task/11949491250750933281) started by @dolagoartur*