### PR TITLE
⚡ Bolt: Replace Regex::new with cached get_regex implementation in inventory matching

### DIFF
--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -141,7 +141,6 @@ pub use plugins::{
 };
 
 use indexmap::IndexMap;
-use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::process::Command;
@@ -1070,7 +1069,8 @@ impl Inventory {
 
         // Handle regex pattern
         if let Some(regex_str) = pattern.strip_prefix('~') {
-            let regex = Regex::new(regex_str)
+            // Optimize: Use cached get_regex implementation to avoid recompiling patterns repeatedly
+            let regex = crate::utils::get_regex(regex_str)
                 .map_err(|_| InventoryError::InvalidPattern(pattern.to_string()))?;
 
             return Ok(self
@@ -1083,7 +1083,8 @@ impl Inventory {
         // Handle glob/wildcard pattern
         if pattern.contains('*') || pattern.contains('?') || pattern.contains('[') {
             let regex_pattern = glob_to_regex(pattern);
-            let regex = Regex::new(&regex_pattern)
+            // Optimize: Use cached get_regex implementation to avoid recompiling patterns repeatedly
+            let regex = crate::utils::get_regex(&regex_pattern)
                 .map_err(|_| InventoryError::InvalidPattern(pattern.to_string()))?;
 
             return Ok(self


### PR DESCRIPTION
**💡 What:** Replaced `Regex::new` with the cached `crate::utils::get_regex` implementation in `src/inventory/mod.rs` for matching host regexes and glob patterns. Also removed an unused `use regex::Regex;` import.

**🎯 Why:** `Regex::new` recompiles the regex pattern every time it's called. When filtering hosts using a pattern, this occurs inside the evaluation path which is a performance bottleneck if there are many hosts or patterns. The `get_regex` function caches compiled expressions to avoid this penalty.

**📊 Impact:** Reduces the CPU time spent compiling the same regex structures during inventory host matching.

**🔬 Measurement:** Verified by running `cargo check`, `cargo clippy`, and `cargo test --lib -- tests`, which ensure that the optimization did not change the functional correctness of pattern filtering.

---
*PR created automatically by Jules for task [8999756183176846440](https://jules.google.com/task/8999756183176846440) started by @dolagoartur*