### PR TITLE
🎨 Palette: Standardize semantic emojis in interactive CLI prompts

### DIFF
--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -726,7 +726,7 @@ impl RunArgs {
             if std::io::stdin().is_terminal() {
                 Some(
                     dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("🔐 BECOME password")
+                        .with_prompt("🔒 BECOME password")
                         .interact()?,
                 )
             } else {

--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -358,7 +358,7 @@ fn get_password(password_file: Option<&PathBuf>, ctx: &CommandContext) -> Result
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 Vault password")
+        .with_prompt("🔒 Vault password")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -376,8 +376,8 @@ fn get_password_with_confirm(
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 New Vault password")
-        .with_confirmation("🔐 Confirm Vault password", "Passwords do not match")
+        .with_prompt("🔒 New Vault password")
+        .with_confirmation("🔒 Confirm Vault password", "Passwords do not match")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -634,8 +634,8 @@ impl VaultArgs {
                     s.as_bytes().to_vec()
                 } else if std::io::stdin().is_terminal() {
                     let input = dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("📝 Enter text to encrypt (hidden)")
-                        .with_confirmation("🔐 Confirm text to encrypt", "Inputs do not match")
+                        .with_prompt("🔒 Enter text to encrypt (hidden)")
+                        .with_confirmation("🔒 Confirm text to encrypt", "Inputs do not match")
                         .interact()?;
                     input.as_bytes().to_vec()
                 } else {

--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -87,7 +87,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("What would you like to do?")
+            .with_prompt("🎯 Main Menu")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;
@@ -382,7 +382,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("🔐 Vault operation")
+            .with_prompt("🔒 Vault operation")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;


### PR DESCRIPTION
### 💡 What
Standardized the emojis used for hidden/password input prompts across the CLI application. The existing prompts used a mix of `🔐` (Closed Lock with Key) and `📝` (Memo), which have been updated to consistently use `🔒` (Locked). Additionally, updated the generic main menu prompt ("What would you like to do?") to the more semantic and visually appealing `🎯 Main Menu`.

### 🎯 Why
Consistency in UI elements is a core principle of good UX design. By standardizing the emojis for sensitive input fields (passwords, vault keys, encrypted strings), we provide clearer, more predictable visual cues to the user, enhancing scannability. Updating the main menu prompt provides a better structural header for the top-level interaction. 

### 📸 Before/After
**Before:**
*   `🔐 BECOME password`
*   `🔐 Vault password`
*   `🔐 New Vault password` / `🔐 Confirm Vault password`
*   `📝 Enter text to encrypt (hidden)` / `🔐 Confirm text to encrypt`
*   `What would you like to do?`
*   `🔐 Vault operation`

**After:**
*   `🔒 BECOME password`
*   `🔒 Vault password`
*   `🔒 New Vault password` / `🔒 Confirm Vault password`
*   `🔒 Enter text to encrypt (hidden)` / `🔒 Confirm text to encrypt`
*   `🎯 Main Menu`
*   `🔒 Vault operation`

### ♿ Accessibility
While emojis are inherently visual, using consistent symbols for specific types of interactions (e.g., `🔒` for all secure/hidden inputs) helps users build cognitive associations, reducing friction and confusion. This particularly aids scannability in dense CLI environments.

---
*PR created automatically by Jules for task [1195590955809670911](https://jules.google.com/task/1195590955809670911) started by @dolagoartur*