### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in kernel private key creation

### DIFF
--- a/src/api/kernel.rs
+++ b/src/api/kernel.rs
@@ -1078,23 +1078,14 @@ async fn build_connection_for_host(
             ))
         })?;
         let key_path = key_dir.path().join("id_key");
-        std::fs::write(&key_path, private_key).map_err(|err| {
-            crate::connection::ConnectionError::InvalidConfig(format!(
-                "failed to write temporary private key: {}",
-                err
-            ))
-        })?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let perms = std::fs::Permissions::from_mode(0o600);
-            std::fs::set_permissions(&key_path, perms).map_err(|err| {
+        crate::utils::secure_write_file(&key_path, private_key, true, Some(0o600)).map_err(
+            |err| {
                 crate::connection::ConnectionError::InvalidConfig(format!(
-                    "failed to secure temporary private key: {}",
+                    "failed to securely write temporary private key: {}",
                     err
                 ))
-            })?;
-        }
+            },
+        )?;
         builder = builder.private_key(key_path.to_string_lossy().to_string());
         _key_dir = Some(key_dir);
     } else {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Insecure File Creation (TOCTOU) via fs::write followed by fs::set_permissions.
🎯 Impact: The created private key file exists with default permissions before being restricted, potentially leaking sensitive credentials.
🔧 Fix: Replaced fs::write + fs::set_permissions with crate::utils::secure_write_file to atomically create files with restricted permissions.
✅ Verification: Run cargo test --lib -- tests to verify the logic.

---
*PR created automatically by Jules for task [10540310690373727797](https://jules.google.com/task/10540310690373727797) started by @dolagoartur*