### PR TITLE
⚡ Bolt: Statically cache regex patterns in audit logs

### DIFF
--- a/src/security/audit.rs
+++ b/src/security/audit.rs
@@ -250,20 +250,38 @@ fn sanitize_command(command: &str) -> String {
 
     // Remove potential passwords and secrets
     // This is a heuristic - we look for common patterns
-    let patterns = [
-        (r"(-p\s*)\S+", "$1[REDACTED]"),
-        (r"(--password[=\s]*)\S+", "$1[REDACTED]"),
-        (r"(PASSWORD[=:])\S+", "$1[REDACTED]"),
-        (r"(SECRET[=:])\S+", "$1[REDACTED]"),
-        (r"(TOKEN[=:])\S+", "$1[REDACTED]"),
-        (r"(API_KEY[=:])\S+", "$1[REDACTED]"),
-    ];
+    // Optimize: Use OnceLock to statically cache the compiled regexes for sanitization patterns to prevent recompiling them for every logged command.
+    static SANITIZATION_PATTERNS: std::sync::OnceLock<Vec<(regex::Regex, &'static str)>> =
+        std::sync::OnceLock::new();
+    let patterns = SANITIZATION_PATTERNS.get_or_init(|| {
+        vec![
+            (regex::Regex::new(r"(-p\s*)\S+").unwrap(), "$1[REDACTED]"),
+            (
+                regex::Regex::new(r"(--password[=\s]*)\S+").unwrap(),
+                "$1[REDACTED]",
+            ),
+            (
+                regex::Regex::new(r"(PASSWORD[=:])\S+").unwrap(),
+                "$1[REDACTED]",
+            ),
+            (
+                regex::Regex::new(r"(SECRET[=:])\S+").unwrap(),
+                "$1[REDACTED]",
+            ),
+            (
+                regex::Regex::new(r"(TOKEN[=:])\S+").unwrap(),
+                "$1[REDACTED]",
+            ),
+            (
+                regex::Regex::new(r"(API_KEY[=:])\S+").unwrap(),
+                "$1[REDACTED]",
+            ),
+        ]
+    });
 
     let mut result = cmd;
-    for (pattern, replacement) in patterns {
-        if let Ok(re) = regex::Regex::new(pattern) {
-            result = re.replace_all(&result, replacement).to_string();
-        }
+    for (re, replacement) in patterns {
+        result = re.replace_all(&result, *replacement).into_owned();
     }
 
     result


### PR DESCRIPTION
### 💡 What
Statically caches the regex patterns used in `src/security/audit.rs` inside `sanitize_command` using `std::sync::OnceLock`. Also replaces `.to_string()` with `.into_owned()` when handling the result of `.replace_all()`.

### 🎯 Why
`sanitize_command` is called for every audited command to remove potentially sensitive data. Previously, it repeatedly created `regex::Regex::new(...)` in a loop inside this function. Regex compilation is notoriously slow in Rust. By statically compiling and caching the regexes, we avoid this massive overhead on the hot path for audit logging. Further, `.replace_all` returns a `Cow<'_, str>`. Calling `.to_string()` unconditionally forced a string allocation even when no redaction happened. `.into_owned()` efficiently returns the original string if no substitutions occurred, preventing unnecessary allocations.

### 📊 Impact
Eliminates six regex compilations per audited command, drastically reducing CPU overhead. Avoids unnecessary heap allocations when commands do not contain secrets.

### 🔬 Measurement
Run `cargo test --lib -- tests` to verify `test_command_sanitization` still works and properly redacts without regressions.

---
*PR created automatically by Jules for task [18268134074689342180](https://jules.google.com/task/18268134074689342180) started by @dolagoartur*