### PR TITLE
⚡ Bolt: Replace Regex::new with get_regex in diagnostics inspector

### DIFF
--- a/src/diagnostics/inspector.rs
+++ b/src/diagnostics/inspector.rs
@@ -317,7 +317,11 @@ impl WatchCondition {
                 value.as_str().map(|s| s.contains(substr)).unwrap_or(false)
             }
             WatchCondition::Matches(pattern) => {
-                if let (Some(s), Ok(re)) = (value.as_str(), regex::Regex::new(pattern)) {
+                // Optimize: Use get_regex to fetch a cached compiled regex, avoiding recompilation on every evaluation
+                if let (Some(s), Ok(re)) = (
+                    value.as_str(),
+                    crate::utils::regex_cache::get_regex(pattern),
+                ) {
                     re.is_match(s)
                 } else {
                     false
@@ -556,7 +560,8 @@ impl VariableInspector {
         pattern: &str,
         vars: &HashMap<String, JsonValue>,
     ) -> Vec<InspectionResult> {
-        let regex = match regex::Regex::new(pattern) {
+        // Optimize: Use get_regex to fetch a cached compiled regex, avoiding recompilation during variable searches
+        let regex = match crate::utils::regex_cache::get_regex(pattern) {
             Ok(r) => r,
             Err(_) => return Vec::new(),
         };


### PR DESCRIPTION
💡 What: Replacing `Regex::new` with `crate::utils::regex_cache::get_regex` in `src/diagnostics/inspector.rs`.
🎯 Why: To avoid recompiling the same regular expression pattern every time a `WatchCondition::Matches` is evaluated or a variable `search` is performed.
📊 Impact: Significantly improves performance during variable inspection and debugging by eliminating repeated regex compilation overhead.
🔬 Measurement: Observe reduction in CPU time when running playbooks with watches or debug inspections.

---
*PR created automatically by Jules for task [18113664023175135875](https://jules.google.com/task/18113664023175135875) started by @dolagoartur*