### PR TITLE
🎨 Palette: Standardize emojis for secure input fields

### DIFF
--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -726,7 +726,7 @@ impl RunArgs {
             if std::io::stdin().is_terminal() {
                 Some(
                     dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("🔐 BECOME password")
+                        .with_prompt("🔒 BECOME password")
                         .interact()?,
                 )
             } else {

--- a/src/cli/commands/vault.rs
+++ b/src/cli/commands/vault.rs
@@ -358,7 +358,7 @@ fn get_password(password_file: Option<&PathBuf>, ctx: &CommandContext) -> Result
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 Vault password")
+        .with_prompt("🔒 Vault password")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -376,8 +376,8 @@ fn get_password_with_confirm(
     ctx.output.flush();
 
     let password = dialoguer::Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("🔐 New Vault password")
-        .with_confirmation("🔐 Confirm Vault password", "Passwords do not match")
+        .with_prompt("🔒 New Vault password")
+        .with_confirmation("🔒 Confirm Vault password", "Passwords do not match")
         .interact()?;
 
     Ok(SecretString::new(password))
@@ -634,8 +634,8 @@ impl VaultArgs {
                     s.as_bytes().to_vec()
                 } else if std::io::stdin().is_terminal() {
                     let input = dialoguer::Password::with_theme(&ColorfulTheme::default())
-                        .with_prompt("📝 Enter text to encrypt (hidden)")
-                        .with_confirmation("🔐 Confirm text to encrypt", "Inputs do not match")
+                        .with_prompt("🔒 Enter text to encrypt (hidden)")
+                        .with_confirmation("🔒 Confirm text to encrypt", "Inputs do not match")
                         .interact()?;
                     input.as_bytes().to_vec()
                 } else {

--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -79,7 +79,7 @@ impl InteractiveSession {
             "🔍 Check playbook (dry-run)",
             "📋 List hosts",
             "📝 List tasks",
-            "🔐 Vault operations",
+            "🔒 Vault operations",
             "✨ Initialize project",
             "✅ Validate playbook",
             "⚙️ Settings",
@@ -382,7 +382,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("🔐 Vault operation")
+            .with_prompt("🔒 Vault operation")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;


### PR DESCRIPTION
### 💡 What
Unified the emojis used for hidden/password prompts across the CLI application, updating them to use the standard lock emoji (🔒) instead of a mix of closed-lock-with-key (🔐) and memo (📝).

### 🎯 Why
To improve visual consistency and user recognition. Previously, some password prompts used 🔐 while others used 📝 (e.g., "Enter text to encrypt" used a memo, but its confirmation used a lock). Standardizing on 🔒 creates a clearer, more predictable visual language for secure inputs.

### 📸 Before/After
**Before:**
`🔐 BECOME password`
`🔐 Vault password`
`📝 Enter text to encrypt (hidden)`

**After:**
`🔒 BECOME password`
`🔒 Vault password`
`🔒 Enter text to encrypt (hidden)`

### ♿ Accessibility
Improves scannability and cognitive accessibility by ensuring the same visual cue is consistently applied to all semantically similar input fields (passwords/encrypted text).

---
*PR created automatically by Jules for task [2763411164704522920](https://jules.google.com/task/2763411164704522920) started by @dolagoartur*