### PR TITLE
⚡ Bolt: Use regex cache and avoid allocation in string replacement

### DIFF
--- a/src/diagnostics/forensics/redaction.rs
+++ b/src/diagnostics/forensics/redaction.rs
@@ -52,10 +52,11 @@ impl Redactor {
         for rule in rules {
             match &rule.pattern {
                 RedactionPattern::Regex(pattern) => {
-                    if let Ok(re) = regex::Regex::new(pattern) {
+                    // Optimize: Use cached get_regex and into_owned to avoid unnecessary allocations and regex recompilation
+                    if let Ok(re) = crate::utils::get_regex(pattern) {
                         result = re
                             .replace_all(&result, rule.replacement.as_str())
-                            .to_string();
+                            .into_owned();
                     }
                 }
                 RedactionPattern::Literal(literal) => {

--- a/src/diagnostics/inspector.rs
+++ b/src/diagnostics/inspector.rs
@@ -317,7 +317,8 @@ impl WatchCondition {
                 value.as_str().map(|s| s.contains(substr)).unwrap_or(false)
             }
             WatchCondition::Matches(pattern) => {
-                if let (Some(s), Ok(re)) = (value.as_str(), regex::Regex::new(pattern)) {
+                // Optimize: Use get_regex to avoid recompiling regexes in inspector
+                if let (Some(s), Ok(re)) = (value.as_str(), crate::utils::get_regex(pattern)) {
                     re.is_match(s)
                 } else {
                     false
@@ -556,7 +557,8 @@ impl VariableInspector {
         pattern: &str,
         vars: &HashMap<String, JsonValue>,
     ) -> Vec<InspectionResult> {
-        let regex = match regex::Regex::new(pattern) {
+        // Optimize: Use get_regex to avoid recompiling regexes in inspector search
+        let regex = match crate::utils::get_regex(pattern) {
             Ok(r) => r,
             Err(_) => return Vec::new(),
         };


### PR DESCRIPTION
💡 What: Replaced `Regex::new` with the cached `get_regex` implementation in redaction and inspector modules. Also, replaced `.to_string()` with `.into_owned()` when using `Regex::replace_all` in `Redactor::redact`. Added comments to explain these optimizations.
🎯 Why: `Regex::new` is computationally expensive and recompiling patterns in tight loops (like iterating over redaction rules or evaluating watch conditions) drastically hurts performance. Additionally, `.to_string()` on `replace_all` forces a string allocation even when no replacement occurs, whereas `.into_owned()` avoids it since `replace_all` returns a `Cow`.
📊 Impact: Eliminates redundant regex compilations and unnecessary memory allocations during redaction and inspection, significantly reducing CPU overhead and memory pressure.
🔬 Measurement: Run `cargo test --lib -- tests` to verify no regressions in functionality. Profiling `Redactor::redact` with large inputs will show a reduction in allocations and CPU time.

---
*PR created automatically by Jules for task [16088132628159538530](https://jules.google.com/task/16088132628159538530) started by @dolagoartur*