### PR TITLE
🎨 Palette: Add emoji prefix to main menu prompt

### DIFF
--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -87,7 +87,7 @@ impl InteractiveSession {
         ];
 
         let selection = Select::with_theme(&self.theme)
-            .with_prompt("What would you like to do?")
+            .with_prompt("🎯 What would you like to do?")
             .items(&items)
             .default(0)
             .interact_on(&self.term)?;


### PR DESCRIPTION
### 💡 What
Added a 🎯 emoji to the main menu prompt ("What would you like to do?") in the interactive CLI module (`src/cli/interactive.rs`).

### 🎯 Why
This brings the main menu prompt into visual consistency with other selection prompts in the application (like `🎯 Limit to hosts`), making it more scannable and visually engaging.

### 📸 Before/After
**Before:**
`What would you like to do?`

**After:**
`🎯 What would you like to do?`

### ♿ Accessibility
Makes the primary action prompt easier to identify and parse quickly through visual cues.

---
*PR created automatically by Jules for task [6290958537609846272](https://jules.google.com/task/6290958537609846272) started by @dolagoartur*